### PR TITLE
Refactor persistence of connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-# MongoDB NoSQL Support for VS Code
+# Cosmos DB NoSQL Support for VS Code
 
-The MongoDB extension makes it easy to work with MongoDB NoSQL databases, collections, and documents. With this extension, you can:
+The Cosmos DB extension makes it easy to work with MongoDB NoSQL databases, collections, and documents. With this extension, you can:
 
 * Connect to local or hosted (e.g. Azure CosmosDB) servers
 * Create and view MongoDB databases and collections with the MongoDB Explorer
@@ -12,6 +12,7 @@ The MongoDB extension makes it easy to work with MongoDB NoSQL databases, collec
 # Prerequisites
 
 - Install [Mongo DB and Mongo shell](https://docs.mongodb.com/manual/installation/).
+- Install the [insiders build of Visual Studio Code](https://code.visualstudio.com/insiders)
 
 # Features
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"displayName": "MongoDB",
 	"description": "Create, browse, and update MongoDB NoSQL collections and documents.",
 	"engines": {
-		"vscode": "^1.13.0"
+		"vscode": "^1.15.0"
 	},
 	"galleryBanner": {
 		"color": "#3E8E3A",
@@ -25,6 +25,7 @@
 		"url": "https://github.com/microsoft/vscode-mongodb"
 	},
 	"main": "./out/src/extension",
+	"enableProposedApi": true,
 	"activationEvents": [
 		"onView:mongoExplorer",
 		"onCommand:mongo.execute",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,44 +13,38 @@ import { MongoCommands } from './mongo/commands';
 import { Model, Database, Server, IMongoResource, MongoCommand, Collection } from './mongo/mongo';
 import MongoDBLanguageClient from './mongo/languageClient';
 
-let connectedDb: Database = null;
 let languageClient: MongoDBLanguageClient = null;
 let model: Model;
 let lastCommand: MongoCommand;
 
 export function activate(context: vscode.ExtensionContext) {
-	// Create the storage folder
-	if (context.storagePath) {
-		createStorageFolder(context).then(() => {
-			languageClient = new MongoDBLanguageClient(context);
-			model = new Model(context.storagePath);
+	languageClient = new MongoDBLanguageClient(context);
+	model = new Model(context.globalState);
 
-			// Mongo Tree View
-			const explorer = new MongoExplorer(model, context);
-			vscode.window.registerTreeDataProvider('mongoExplorer', explorer);
+	// Mongo Tree View
+	const explorer = new MongoExplorer(model, context);
+	vscode.window.registerTreeDataProvider('mongoExplorer', explorer);
 
-			// Commands
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.addServer', () => addServer()));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.refreshExplorer', () => explorer.refresh()));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.removeServer', (element: IMongoResource) => model.remove(element)));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.createDatabase', (server: Server) => createDatabase(server)));
+	// Commands
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.addServer', () => addServer()));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.refreshExplorer', () => explorer.refresh()));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.removeServer', (element: IMongoResource) => model.remove(element)));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.createDatabase', (server: Server) => createDatabase(server)));
 
-			vscode.window.setStatusBarMessage('Mongo: Not connected');
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.connect', (element: Database) => connectToDatabase(element)));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.dropDb', (element: Database) => dropDatabase(element)));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.connectDb', () => {
-				vscode.window.showQuickPick(getDatabaseQuickPicks()).then(pick => connectToDatabase(pick.database));
-			}));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.newScrapbook', () => createScrapbook()));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.executeCommand', () => lastCommand = MongoCommands.executeCommandFromActiveEditor(connectedDb)));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.updateDocuments', () => MongoCommands.updateDocuments(connectedDb, lastCommand)));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.openCollection', (collection: Collection) => {
-				connectToDatabase(collection.db);
-				lastCommand = MongoCommands.getCommand(`db.${collection.label}.find()`);
-				MongoCommands.executeCommand(lastCommand, connectedDb).then(result => MongoCommands.showResult(result));
-			}));
-		});
-	}
+	vscode.window.setStatusBarMessage('Mongo: Not connected');
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.connect', (element: Database) => connectToDatabase(element)));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.dropDb', (element: Database) => dropDatabase(element)));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.connectDb', () => {
+		vscode.window.showQuickPick(getDatabaseQuickPicks()).then(pick => connectToDatabase(pick.database));
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.newScrapbook', () => createScrapbook()));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.executeCommand', () => lastCommand = MongoCommands.executeCommandFromActiveEditor(model.connectedDB)));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.updateDocuments', () => MongoCommands.updateDocuments(model.connectedDB, lastCommand)));
+	context.subscriptions.push(vscode.commands.registerCommand('mongo.openCollection', (collection: Collection) => {
+		connectToDatabase(collection.db);
+		lastCommand = MongoCommands.getCommand(`db.${collection.label}.find()`);
+		MongoCommands.executeCommand(lastCommand, model.connectedDB).then(result => MongoCommands.showResult(result));
+	}));
 }
 
 function createScrapbook(): Thenable<void> {
@@ -126,38 +120,20 @@ function getDatabaseQuickPicks(): Thenable<DatabaseQuickPick[]> {
 	});
 }
 
-function dropDatabase(database: Database): void {
-	vscode.window.showInformationMessage('Are you sure you want to drop the database \'' + database.id + '\' and its collections?', { modal: true }, 'Drop')
-		.then(result => {
-			if (result === 'Drop') {
-				if (connectedDb && connectedDb.server.id === database.server.id && connectedDb.id === database.id) {
-					connectedDb = null;
-					languageClient.disconnect();
-					vscode.window.setStatusBarMessage('Mongo: Not connected');
-				}
-				database.server.dropDb(database);
-			}
-		})
+async function dropDatabase(database: Database): Promise<void> {
+	const result = await vscode.window.showInformationMessage('Are you sure you want to drop the database \'' + database.id + '\' and its collections?', { modal: true }, 'Drop');
+	if (result === 'Drop') {
+		if (model.connectedDB && model.connectedDB.server.id === database.server.id && model.connectedDB.id === database.id) {
+			model.connectedDB = null;
+			languageClient.disconnect();
+		}
+		database.server.dropDb(database);
+	}
 }
 
 function connectToDatabase(database: Database): void {
-	connectedDb = database;
+	model.connectedDB = database;
 	languageClient.connect(database);
-	vscode.window.setStatusBarMessage('Mongo: ' + database.server.label + '/' + connectedDb.id);
-}
-
-async function createStorageFolder(context: vscode.ExtensionContext): Promise<void> {
-	return new Promise<void>((c, e) => {
-		fs.exists(context.storagePath, exists => {
-			if (exists) {
-				c(null);
-			} else {
-				fs.mkdir(context.storagePath, error => {
-					c(null);
-				})
-			}
-		});
-	})
 }
 
 // this method is called when your extension is deactivated

--- a/src/vscode.proposed.d.ts
+++ b/src/vscode.proposed.d.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// This is the place for API experiments and proposal.
+
+declare module 'vscode' {
+	/**
+	 * Namespace for handling credentials.
+	 */
+	export namespace credentials {
+
+		/**
+		 * Read a previously stored secret from the credential store.
+		 *
+		 * @param service The service of the credential.
+		 * @param account The account of the credential.
+		 * @return A promise for the secret of the credential.
+		 */
+		export function readSecret(service: string, account: string): Thenable<string | undefined>;
+
+		/**
+		 * Write a secret to the credential store.
+		 *
+		 * @param service The service of the credential.
+		 * @param account The account of the credential.
+		 * @param secret The secret of the credential to write to the credential store.
+		 * @return A promise indicating completion of the operation.
+		 */
+		export function writeSecret(service: string, account: string, secret: string): Thenable<void>;
+
+		/**
+		 * Delete a previously stored secret from the credential store.
+		 *
+		 * @param service The service of the credential.
+		 * @param account The account of the credential.
+		 * @return A promise resolving to true if there was a secret for that service and account.
+		 */
+		export function deleteSecret(service: string, account: string): Thenable<boolean>;
+	}
+}


### PR DESCRIPTION
Rather than persisting connection strings in normal storage on a per workspace basis, we will now persist strings in secure storage globally for VS Code.

We will also persist the latest connected DB and reconnect if possible when VS Code opens.

Fixes #2 #3 #5