### PR TITLE
List Azure Resources in Mongo Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,10 @@
 					"when": "view == mongoExplorer && viewItem == mongoServer"
 				},
 				{
+					"command": "mongo.createDatabase",
+					"when": "view == mongoExplorer && viewItem == azureMongoServer"
+				},
+				{
 					"command": "mongo.removeServer",
 					"when": "view == mongoExplorer && viewItem == mongoServer"
 				},
@@ -236,12 +240,18 @@
 	},
 	"dependencies": {
 		"antlr4ts": "^0.4.0-alpha.4",
+		"azure-arm-documentdb": "^1.0.0-preview",
+		"azure-arm-resource": "^2.0.0-preview",
 		"mongodb": "^2.2.25",
+		"ms-rest": "^2.2.1",
 		"request-light": "^0.2.0",
 		"vscode-languageclient": "^3.1.0-alpha.1",
 		"vscode-languageserver": "^3.1.0-alpha.1",
 		"vscode-nls": "^2.0.2",
 		"vscode-uri": "^1.0.0",
 		"vscode-json-languageservice": "^2.0.9"
-	}
+	},
+	"extensionDependencies": [
+		"vscode.azure-account"
+	]
 }

--- a/src/azure-account.api.d.ts
+++ b/src/azure-account.api.d.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from 'vscode';
+import { ServiceClientCredentials } from 'ms-rest';
+import { AzureEnvironment } from 'ms-rest-azure';
+import { SubscriptionModels, ResourceModels } from 'azure-arm-resource';
+
+export type AzureLoginStatus = 'Initializing' | 'LoggingIn' | 'LoggedIn' | 'LoggedOut';
+
+export interface AzureAccount {
+	readonly status: AzureLoginStatus;
+	readonly onStatusChanged: Event<AzureLoginStatus>;
+	readonly sessions: AzureSession[];
+	readonly onSessionsChanged: Event<void>;
+	readonly filters: AzureResourceFilter[];
+	readonly onFiltersChanged: Event<void>;
+	readonly credentials: Credentials;
+}
+
+export interface AzureSession {
+	readonly environment: AzureEnvironment;
+	readonly userId: string;
+	readonly tenantId: string;
+	readonly credentials: ServiceClientCredentials;
+}
+
+export interface AzureResourceFilter {
+	readonly session: AzureSession;
+	readonly subscription: SubscriptionModels.Subscription;
+	readonly allResourceGroups: boolean;
+	readonly resourceGroups: ResourceModels.ResourceGroup[];
+}
+
+export interface Credentials {
+	readSecret(service: string, account: string): Thenable<string | undefined>;
+	writeSecret(service: string, account: string, secret: string): Thenable<void>;
+	deleteSecret(service: string, account: string): Thenable<boolean>;
+}

--- a/src/mongo/explorer.ts
+++ b/src/mongo/explorer.ts
@@ -12,7 +12,7 @@ export class MongoExplorer implements TreeDataProvider<IMongoResource> {
 	private _onDidChangeTreeData: EventEmitter<IMongoResource> = new EventEmitter<IMongoResource>();
 	readonly onDidChangeTreeData: Event<IMongoResource> = this._onDidChangeTreeData.event;
 
-	constructor(private model: Model, private extensionContext: ExtensionContext) {
+	constructor(private model: Model) {
 		this.model.onChange(() => this._onDidChangeTreeData.fire());
 	}
 

--- a/src/mongo/mongo.ts
+++ b/src/mongo/mongo.ts
@@ -120,7 +120,10 @@ export class Model implements IMongoResource {
 			servers = servers.concat(...serverResult);
 		}));
 
-		return servers;
+		return servers.sort((a, b) => {
+			const n = a.resourceGroupName.localeCompare(b.resourceGroupName);
+			return n !== 0 ? n : a.name.localeCompare(b.name);
+		});
 	}
 }
 
@@ -157,13 +160,12 @@ export class Server implements IMongoResource {
 	private _databases: Database[] = [];
 	private _onChange: EventEmitter<void> = new EventEmitter<void>();
 	readonly onChange: Event<void> = this._onChange.event;
-	
 
 	constructor(
 		public readonly connectionString: string,
 		private readonly mongoServer: MongoServer,
 		private readonly azureServer?: docDBModels.DatabaseAccount,
-		private readonly resourceGroupName?: string) {
+		public readonly resourceGroupName?: string) {
 			this.contextValue = azureServer ? 'azureMongoServer' : 'mongoServer';
 	}
 
@@ -210,6 +212,10 @@ export class Server implements IMongoResource {
 
 	get label(): string {
 		return this.azureServer ? `${this.azureServer.name} (${this.resourceGroupName})` : this.id;
+	}
+
+	get name(): string {
+		return this.azureServer ? this.azureServer.name : null;
 	}
 
 	readonly collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;


### PR DESCRIPTION
For now, this _only_ lists Mongo resources, and no other CosmosDB resources. I also removed the persistence of manually added connection strings because they were not using secure storage. I will add that support back in a future commit using secure storage.

Related issues: #10 #15