### PR TITLE
Persist attached mongo connection strings to secure storage

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TreeDataProvider, Event, EventEmitter, TreeItem } from 'vscode';
+import { TreeDataProvider, Event, EventEmitter, Memento, TreeItem } from 'vscode';
 import { AttachedServersNode, LoadingNode, NoSubscriptionsNode, SignInToAzureNode, SubscriptionNode, INode } from './nodes';
 import { AzureAccount } from './azure-account.api';
 
@@ -11,9 +11,10 @@ export class CosmosDBExplorer implements TreeDataProvider<INode> {
 	private _onDidChangeTreeData: EventEmitter<INode> = new EventEmitter<INode>();
 	readonly onDidChangeTreeData: Event<INode> = this._onDidChangeTreeData.event;
 
-	readonly attachedServersNode: AttachedServersNode = new AttachedServersNode();
+	readonly attachedServersNode: AttachedServersNode;
 
-	constructor(private azureAccount: AzureAccount) {
+	constructor(private azureAccount: AzureAccount, globalState: Memento) {
+		this.attachedServersNode = new AttachedServersNode(azureAccount, globalState);
 	}
 
 	getTreeItem(node: INode): TreeItem {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	languageClient = new MongoDBLanguageClient(context);
 
-	explorer = new CosmosDBExplorer(azureAccount);
+	explorer = new CosmosDBExplorer(azureAccount, context.globalState);
 	context.subscriptions.push(azureAccount.onFiltersChanged(() => explorer.refresh()));
 	context.subscriptions.push(azureAccount.onStatusChanged(() => explorer.refresh()));
 	context.subscriptions.push(azureAccount.onSessionsChanged(() => explorer.refresh()));
@@ -125,8 +125,8 @@ async function copyConnectionString(node: IMongoServer) {
 	}
 }
 
-function removeMongoServer(node: INode) {
-	const deletedNodes = explorer.attachedServersNode.remove(node);
+async function removeMongoServer(node: INode) {
+	const deletedNodes = await explorer.attachedServersNode.remove(node);
 	if (deletedNodes) {
 		explorer.refresh(explorer.attachedServersNode);
 	}


### PR DESCRIPTION
The location of the secure storage api might be moving around a little bit going forward, but the API itself shouldn't change much.

NOTE: We will not persist connection strings for resources from Azure. Those will be loaded on the fly each time. 

Related to #5 