### PR TITLE
Fix Mongo Scrapbook intellisense

### DIFF
--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -51,7 +51,7 @@ export default class MongoDBLanguageClient {
 	}
 
 	connect(database: Database): void {
-		const uri = Uri.parse(database.server.id);
+		const uri = Uri.parse(database.server.connectionString);
 		const connectionString = `${uri.scheme}://${uri.authority}/${database.id}?${uri.query}`
 		this.client.sendRequest('connect', { connectionString });
 	}


### PR DESCRIPTION
Fix for #28 

In the Server class, `id` used to always be the connection string. However, when I added the Azure resources to the explorer, I refactored `id` and added a new `connectionString` field. Apparently I missed updating one of the fields. See here for the previous commit: https://github.com/Microsoft/vscode-cosmosdb/commit/3f5396480c5d2c06cc0ab2436ef8997dabdcceca#diff-566bee68995619b9ddea388ded5443caR162