### PR TITLE
Fix commands failing with error 'getConnectionString is not a function'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ function initCommand(context: vscode.ExtensionContext, commandId: string, callba
 }
 
 function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, callback: (...args: any[]) => Promise<any>) {
-	context.subscriptions.push(vscode.commands.registerCommand(commandId, async (...args: any[]) => {
+	context.subscriptions.push(vscode.commands.registerCommand(commandId, async (args: any) => {
 		let result = "Succeeded";
 		let error = "";
 		const startTime = Date.now();


### PR DESCRIPTION
I broke a few commands when I added telemetry in #47. Apparently the typing of the async function was too specific