### PR TITLE
DocumentDB creation/deletion errors - show full message in output window

### DIFF
--- a/src/ErrorData.ts
+++ b/src/ErrorData.ts
@@ -1,0 +1,32 @@
+import { error } from "util";
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export class ErrorData {
+    public readonly message: string;
+    public readonly errorType: string;
+
+    constructor(error: any) {
+        if (error instanceof Error) {
+            try {
+                const parsed = JSON.parse(error.message);
+                this.errorType = parsed.Code || parsed.code;
+                this.message = parsed.Message || parsed.message;
+            } catch (err) {
+                this.errorType = error.constructor.name;
+                this.message = error.message;
+            }
+        } else if (typeof (error) === 'object' && error !== null) {
+            this.errorType = (<object>error).constructor.name;
+            this.message = JSON.stringify(error);
+        } else if (error !== undefined && error !== null && error.toString && error.toString().trim() !== '') {
+            this.errorType = typeof (error);
+            this.message = error.toString();
+        } else {
+            this.errorType = typeof (error);
+            this.message = 'Unknown Error';
+        }
+    }
+}

--- a/src/ErrorData.ts
+++ b/src/ErrorData.ts
@@ -1,5 +1,3 @@
-import { error } from "util";
-
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/docdb/commands.ts
+++ b/src/docdb/commands.ts
@@ -26,7 +26,7 @@ export class DocDBCommands {
             await new Promise((resolve, reject) => {
                 client.createDatabase({ id: databaseName }, (err, result) => {
                     if (err) {
-                        reject(err.body);
+                        reject(new Error(err.body));
                     }
                     else {
                         resolve(result);
@@ -50,7 +50,7 @@ export class DocDBCommands {
         await new Promise((resolve, reject) => {
             client.createDocument(coll.getCollLink(), { 'id': docid }, (err, result) => {
                 if (err) {
-                    reject(err.body);
+                    reject(new Error(err.body));
                 }
                 else {
                     resolve(result);
@@ -97,7 +97,7 @@ export class DocDBCommands {
                     await new Promise((resolve, reject) => {
                         client.createCollection(db.getDbLink(), collectionDef, options, (err, result) => {
                             if (err) {
-                                reject(err.body);
+                                reject(new Error(err.body));
                             }
                             else {
                                 resolve(result);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,7 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
 		const start = Date.now();
 		let result = 'Succeeded';
 		let errorData: string = '';
+		const output = util.getOutputChannel();
 
 		try {
 			await callback(...args);
@@ -122,9 +123,17 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
 				result = 'Canceled';
 			}
 			else if (err instanceof Error) {
-				vscode.window.showErrorMessage(err.message);
+				output.appendLine(err.message);
+				if (JSON.parse(err.message).message.includes("\n") || JSON.parse(err.message).message.includes("\r")) {
+					output.show();
+					vscode.window.showErrorMessage('An error has occured. See output window for more details.');
+				}
+				else {
+					vscode.window.showErrorMessage(err.message);
+				}
 			}
 			else if (typeof err === "string") {
+				output.appendLine(err);
 				vscode.window.showErrorMessage(err);
 			}
 		} finally {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,14 +131,12 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
 					output.show();
 					vscode.window.showErrorMessage('An error has occured. See output window for more details.');
 				}
+				else if (typeof err === "string") {
+					vscode.window.showErrorMessage(err);
+				}
 				else {
 					vscode.window.showErrorMessage(errorData.message);
 				}
-			}
-			else if (typeof err === "string") {
-				errorData = new ErrorData(err);
-				output.appendLine(errorData.message);
-				vscode.window.showErrorMessage(err);
 			}
 		} finally {
 			if (errorData) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,9 +131,6 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
 					output.show();
 					vscode.window.showErrorMessage('An error has occured. See output window for more details.');
 				}
-				else if (typeof err === "string") {
-					vscode.window.showErrorMessage(err);
-				}
 				else {
 					vscode.window.showErrorMessage(errorData.message);
 				}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,11 +120,11 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
 		try {
 			await callback(...args);
 		} catch (err) {
-			properties.result = 'Failed';
 			if (err instanceof UserCancelledError) {
 				properties.result = 'Canceled';
 			}
 			else {
+				properties.result = 'Failed';
 				errorData = new ErrorData(err);
 				output.appendLine(errorData.message);
 				if (errorData.message.includes("\n")) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,6 @@ import { Reporter } from './telemetry';
 import { UserCancelledError } from './errors';
 import { DocDBCommands } from './docdb/commands';
 import { DialogBoxResponses } from './constants';
-import { error } from 'util';
 
 let connectedDb: MongoDatabaseNode = null;
 let languageClient: MongoDBLanguageClient = null;
@@ -125,9 +124,8 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
 			if (err instanceof UserCancelledError) {
 				properties.result = 'Canceled';
 			}
-			else if (err instanceof Error) {
+			else {
 				errorData = new ErrorData(err);
-				output.appendLine(errorData.errorType);
 				output.appendLine(errorData.message);
 				if (errorData.message.includes("\n")) {
 					output.show();

--- a/src/util.ts
+++ b/src/util.ts
@@ -49,6 +49,12 @@ export function errToString(error: any): string {
 	return error.toString();
 }
 
+const outputChannel = vscode.window.createOutputChannel("Azure CosmosDB");
+
+export function getOutputChannel(): vscode.OutputChannel {
+	return outputChannel;
+}
+
 export function showResult(result: string, filename: string, column?: vscode.ViewColumn): Thenable<void> {
 	let uri: vscode.Uri = null;
 	if (vscode.workspace.rootPath) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,27 +28,6 @@ export function sendTelemetry(eventName: string, properties?: { [key: string]: s
 	}
 }
 
-export function errToString(error: any): string {
-	if (error === null || error === undefined) {
-		return '';
-	}
-
-	if (error instanceof Error) {
-		return JSON.stringify({
-			'Error': error.constructor.name,
-			'Message': error.message
-		});
-	}
-
-	if (typeof (error) === 'object') {
-		return JSON.stringify({
-			'object': error.constructor.name
-		});
-	}
-
-	return error.toString();
-}
-
 const outputChannel = vscode.window.createOutputChannel("Azure CosmosDB");
 
 export function getOutputChannel(): vscode.OutputChannel {


### PR DESCRIPTION
Fixes #96 
The activity ID is useful too, hence we are showing the whole error message in the output window.
