### PR TITLE
Show error when copying connection string on linux without xclip

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import * as copypaste from 'copy-paste';
 import * as opn from 'opn';
 import * as util from "./util";
+import * as cpUtil from './utils/cp';
 
 import { AzureAccount } from './azure-account.api';
 import { CosmosDBCommands } from './commands';
@@ -228,8 +229,12 @@ function openInPortal(node: CosmosDBAccountNode) {
 
 async function copyConnectionString(node: IMongoServer) {
 	if (node) {
-		const connectionString = await node.getConnectionString();
-		copypaste.copy(connectionString);
+		if (process.platform !== 'linux' || (await cpUtil.commandSucceeds('xclip', '-version'))) {
+			const connectionString = await node.getConnectionString();
+			copypaste.copy(connectionString);
+		} else {
+			vscode.window.showErrorMessage('You must have xclip installed to copy the connection string.');
+		}
 	}
 }
 

--- a/src/utils/cp.ts
+++ b/src/utils/cp.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as cp from 'child_process';
+
+export async function commandSucceeds(command: string, ...args: string[]): Promise<boolean> {
+    return await new Promise<boolean>(resolve => {
+        cp.spawn(command, args)
+            .on('error', err => resolve(false))
+            .on('exit', code => resolve(code === 0));
+    });
+}


### PR DESCRIPTION
We could potentially output the connection string to the output window so the user can manually copy it, but I would prefer not to do that with a sensitive string.

Plus, it's easy to install xclip

Fixes #64 