### PR TITLE
Use context extensionpath if rootpath is null

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,7 @@ export function activate(context: vscode.ExtensionContext) {
 	initAsyncCommand(context, 'cosmosDB.deleteDocDBCollection', (element: DocDBCollectionNode) => DocDBCommands.deleteDocDBCollection(element, explorer));
 	initAsyncCommand(context, 'cosmosDB.deleteDocDBDocument', (element: DocDBDocumentNode) => DocDBCommands.deleteDocDBDocument(element, explorer));
 	initCommand(context, 'cosmosDB.newMongoScrapbook', () => createScrapbook());
-	initAsyncCommand(context, 'cosmosDB.executeMongoCommand', async () => await MongoCommands.executeCommandFromActiveEditor(connectedDb));
+	initAsyncCommand(context, 'cosmosDB.executeMongoCommand', async () => await MongoCommands.executeCommandFromActiveEditor(connectedDb, context.extensionPath));
 	initAsyncCommand(context, 'cosmosDB.update', () => documentEditor.updateLastDocument());
 	initAsyncCommand(context, 'cosmosDB.openDocument', async (docNode: IDocumentNode) => await documentEditor.showDocument(docNode));
 	initCommand(context, 'cosmosDB.launchMongoShell', () => launchMongoShell());

--- a/src/mongo/commands.ts
+++ b/src/mongo/commands.ts
@@ -18,7 +18,7 @@ import { DialogBoxResponses } from '../constants'
 
 export class MongoCommands {
 
-	public static async executeCommandFromActiveEditor(database: MongoDatabaseNode): Promise<MongoCommand> {
+	public static async executeCommandFromActiveEditor(database: MongoDatabaseNode, extensionPath): Promise<MongoCommand> {
 		const activeEditor = vscode.window.activeTextEditor;
 		if (activeEditor.document.languageId !== 'mongo') {
 			return;
@@ -27,7 +27,7 @@ export class MongoCommands {
 		const command = MongoCommands.getCommand(activeEditor.document.getText(), selection.start);
 		if (command) {
 			const result = await MongoCommands.executeCommand(command, database);
-			await util.showResult(result, 'result.json', activeEditor.viewColumn + 1);
+			await util.showResult(result, 'result.json', extensionPath, activeEditor.viewColumn + 1);
 		} else {
 			vscode.window.showErrorMessage('No executable command found.');
 		}

--- a/src/util.ts
+++ b/src/util.ts
@@ -34,18 +34,13 @@ export function getOutputChannel(): vscode.OutputChannel {
 	return outputChannel;
 }
 
-export async function showResult(result: string, filename: string, column?: vscode.ViewColumn): Promise<void> {
+export async function showResult(result: string, filename: string, extensionPath: string, column?: vscode.ViewColumn): Promise<void> {
 	let uri: vscode.Uri = null;
-	if (vscode.workspace.rootPath) {
-		uri = vscode.Uri.file(path.join(vscode.workspace.rootPath, filename));
-		if (!fs.existsSync(uri.fsPath)) {
-			uri = uri.with({ scheme: 'untitled' });
-		}
-	} else {
-		vscode.window.showErrorMessage(`No workspace present. Please create a workspace.`);
-		return;
+	const filepath: string = vscode.workspace.rootPath || extensionPath;
+	uri = vscode.Uri.file(path.join(filepath, filename));
+	if (!fs.existsSync(uri.fsPath)) {
+		uri = uri.with({ scheme: 'untitled' });
 	}
-
 	const textDocument = await vscode.workspace.openTextDocument(uri);
 	const editor = await vscode.window.showTextDocument(textDocument, column ? column > vscode.ViewColumn.Three ? vscode.ViewColumn.One : column : undefined, true)
 	await writeToEditor(editor, result);


### PR DESCRIPTION
Fixes #68.
Uses the extension's folder path as a stand-in if no workspace has been opened yet.

Abandoning the previous PR. 