### PR TITLE
Let Mongo auto-generate _id on new document

### DIFF
--- a/src/mongo/commands.ts
+++ b/src/mongo/commands.ts
@@ -94,8 +94,11 @@ export class MongoCommands {
 			placeHolder: "Enter a unique id for the document.",
 			ignoreFocusOut: true
 		});
-		await collectionNode.collection.insertOne({ "_id": docId });
-		explorer.refresh(collectionNode);
+
+		if (docId !== undefined) {
+			await collectionNode.collection.insertOne(docId === '' ? {} : { "id": docId });
+			explorer.refresh(collectionNode);
+		}
 	}
 	public static async deleteMongoDocument(documentNode: MongoDocumentNode, explorer: CosmosDBExplorer) {
 		const confirmed = await vscode.window.showWarningMessage(`Are you sure you want to delete collection '${documentNode.label}'?`, DialogBoxResponses.Yes);


### PR DESCRIPTION
There's no need to ask the user for id. Mongo will generate the it for us.

Fixes #124 