### PR TITLE
Fix 'Save' doesn't 'Update to Azure' on windows

### DIFF
--- a/src/DocumentEditor.ts
+++ b/src/DocumentEditor.ts
@@ -152,8 +152,6 @@ export class DocumentEditor implements vscode.Disposable {
     }
 
     private isLocalDocPath(doc: vscode.TextDocument): boolean {
-        // VSCode can return a uri with various schemes, resulting in an fsPath like 'cosmos-document.json.git'
-        // Since the local doc is saved in our extension's directory, we can just use 'startsWith' to check if this is the right file
-        return path.resolve(doc.uri.fsPath).startsWith(this.localDocPath);
+        return path.relative(doc.uri.fsPath, this.localDocPath) == '';
     }
 }


### PR DESCRIPTION
On windows, one path started with 'C:\' and another started with 'c:\', so isLocalDocPath was returning false

However, I don't want to just make the check case-insensitive, because not all OS's are case-insensitive. Instead I use path.relative, which worked for me on mac, linux, and windows.