### PR TITLE
Allow empty strings for docID

### DIFF
--- a/src/docdb/commands.ts
+++ b/src/docdb/commands.ts
@@ -43,21 +43,23 @@ export class DocDBCommands {
         const masterKey = coll.db.getPrimaryMasterKey();
         const endpoint = coll.db.getEndpoint();
         const client = new DocumentClient(endpoint, { masterKey: masterKey });
-        const docid = await vscode.window.showInputBox({
+        const docID = await vscode.window.showInputBox({
             placeHolder: "Enter a unique id",
             ignoreFocusOut: true
         });
-        const newDoc = await new Promise((resolve, reject) => {
-            client.createDocument(coll.getCollLink(), { 'id': docid }, (err, result) => {
-                if (err) {
-                    reject(new Error(err.body));
-                }
-                else {
-                    resolve(result);
-                }
+        if (docID) {
+            const newDoc = await new Promise((resolve, reject) => {
+                client.createDocument(coll.getCollLink(), { 'id': docID }, (err, result) => {
+                    if (err) {
+                        reject(new Error(err.body));
+                    }
+                    else {
+                        resolve(result);
+                    }
+                });
             });
-        });
-        coll.addNewDocToCache(newDoc);
+            coll.addNewDocToCache(newDoc);
+        }
         explorer.refresh(coll);
     }
 

--- a/src/docdb/commands.ts
+++ b/src/docdb/commands.ts
@@ -45,7 +45,6 @@ export class DocDBCommands {
         const client = new DocumentClient(endpoint, { masterKey: masterKey });
         let docID = await vscode.window.showInputBox({
             placeHolder: "Enter a unique id",
-            validateInput: DocDBCommands.validateDocumentName,
             ignoreFocusOut: true
         });
         if (docID || docID === "") {

--- a/src/docdb/commands.ts
+++ b/src/docdb/commands.ts
@@ -45,6 +45,7 @@ export class DocDBCommands {
         const client = new DocumentClient(endpoint, { masterKey: masterKey });
         const docID = await vscode.window.showInputBox({
             placeHolder: "Enter a unique id",
+            validateInput: DocDBCommands.validateDocumentName,
             ignoreFocusOut: true
         });
         if (docID) {
@@ -138,6 +139,14 @@ export class DocDBCommands {
         }
         return null;
     }
+
+    private static validateDocumentName(name: string): string | null | undefined {
+        if (name.trim().length === 0) {
+            return "Name cannot be empty or contain just spaces";
+        }
+        return;
+    }
+
     public static async deleteDocDBDatabase(db: DocDBDatabaseNode, explorer: CosmosDBExplorer): Promise<void> {
         if (db) {
             const confirmed = await vscode.window.showWarningMessage(`Are you sure you want to delete database '${db.label}' and its collections?`,

--- a/src/docdb/commands.ts
+++ b/src/docdb/commands.ts
@@ -43,16 +43,16 @@ export class DocDBCommands {
         const masterKey = coll.db.getPrimaryMasterKey();
         const endpoint = coll.db.getEndpoint();
         const client = new DocumentClient(endpoint, { masterKey: masterKey });
-        const docID = await vscode.window.showInputBox({
+        let docID = await vscode.window.showInputBox({
             placeHolder: "Enter a unique id",
-            validateInput: DocDBCommands.validateDocumentName,
             ignoreFocusOut: true
         });
-        if (docID) {
+        if (docID || docID === "") {
+            docID = docID.trim();
             const newDoc = await new Promise((resolve, reject) => {
                 client.createDocument(coll.getCollLink(), { 'id': docID }, (err, result) => {
                     if (err) {
-                        reject(new Error(err.body));
+                        reject(err);
                     }
                     else {
                         resolve(result);
@@ -138,13 +138,6 @@ export class DocDBCommands {
             return "Input must be a number"
         }
         return null;
-    }
-
-    private static validateDocumentName(name: string): string | null | undefined {
-        if (name.trim().length === 0) {
-            return "Name cannot be empty or contain just spaces";
-        }
-        return;
     }
 
     public static async deleteDocDBDatabase(db: DocDBDatabaseNode, explorer: CosmosDBExplorer): Promise<void> {

--- a/src/mongo/commands.ts
+++ b/src/mongo/commands.ts
@@ -86,6 +86,7 @@ export class MongoCommands {
 	public static async createMongoDocument(collectionNode: MongoCollectionNode, explorer: CosmosDBExplorer) {
 		const docId = await vscode.window.showInputBox({
 			placeHolder: "Enter a unique id for the document.",
+			validateInput: MongoCommands.validateDocumentName,
 			ignoreFocusOut: true
 		});
 
@@ -104,6 +105,13 @@ export class MongoCommands {
 			await coll.collection.deleteOne({ "_id": documentNode.id });
 			explorer.refresh(documentNode.collection);
 		}
+	}
+
+	private static validateDocumentName(name: string): string | null | undefined {
+		if (name.trim().length === 0) {
+			return "Name cannot be empty or contain just spaces";
+		}
+		return;
 	}
 }
 


### PR DESCRIPTION
Trim because ID's ending in space aren't allowed.