### PR TITLE
Add right-click menu commands to graph nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
 		"onCommand:cosmosDB.createDocDBDatabase",
 		"onCommand:cosmosDB.createDocDBCollection",
 		"onCommand:cosmosDB.createDocDBDocument",
+		"onCommand:cosmosDB.createGraphDatabase",
+		"onCommand:cosmosDB.createGraph",
 		"onCommand:cosmosDB.connectMongoDB",
 		"onCommand:cosmosDB.deleteMongoDB",
 		"onCommand:cosmosDB.deleteMongoCollection",
@@ -46,6 +48,8 @@
 		"onCommand:cosmosDB.deleteDocDBDatabase",
 		"onCommand:cosmosDB.deleteDocDBCollection",
 		"onCommand:cosmosDB.deleteDocDBDocument",
+		"onCommand:cosmosDB.deleteGraphDatabase",
+		"onCommand:cosmosDB.deleteGraph",
 		"onCommand:cosmosDB.newMongoScrapbook",
 		"onCommand:cosmosDB.update",
 		"onCommand:cosmosDB.openDocument",
@@ -146,6 +150,16 @@
 				"title": "Create Document"
 			},
 			{
+				"category": "Graph",
+				"command": "cosmosDB.createGraphDatabase",
+				"title": "Create Database"
+			},
+			{
+				"category": "Graph",
+				"command": "cosmosDB.createGraph",
+				"title": "Create Graph"
+			},
+			{
 				"category": "MongoDB",
 				"command": "cosmosDB.removeMongoServer",
 				"title": "Remove Server"
@@ -179,6 +193,16 @@
 				"category": "DocumentDB",
 				"command": "cosmosDB.deleteDocDBCollection",
 				"title": "Delete Collection"
+			},
+			{
+				"category": "Graph",
+				"command": "cosmosDB.deleteGraphDatabase",
+				"title": "Delete Database"
+			},
+			{
+				"category": "Graph",
+				"command": "cosmosDB.deleteGraph",
+				"title": "Delete Graph"
 			},
 			{
 				"category": "DocumentDB",
@@ -303,6 +327,14 @@
 					"when": "view == cosmosDBExplorer && viewItem == cosmosDBDocumentServer"
 				},
 				{
+					"command": "cosmosDB.createGraphDatabase",
+					"when": "view == cosmosDBExplorer && viewItem == cosmosDBGraphAccount"
+				},
+				{
+					"command": "cosmosDB.createGraph",
+					"when": "view == cosmosDBExplorer && viewItem == cosmosDBGraphDatabase"
+				},
+				{
 					"command": "cosmosDB.removeMongoServer",
 					"when": "view == cosmosDBExplorer && viewItem == mongoServer"
 				},
@@ -335,6 +367,14 @@
 					"when": "view == cosmosDBExplorer && viewItem == cosmosDBDocumentDatabase"
 				},
 				{
+					"command": "cosmosDB.deleteGraphDatabase",
+					"when": "view == cosmosDBExplorer && viewItem == cosmosDBGraphDatabase"
+				},
+				{
+					"command": "cosmosDB.deleteGraph",
+					"when": "view == cosmosDBExplorer && viewItem == cosmosDBGraph"
+				},
+				{
 					"command": "cosmosDB.attachMongoServer",
 					"when": "view == cosmosDBExplorer && viewItem == cosmosDBAttachedServers"
 				},
@@ -349,6 +389,10 @@
 				{
 					"command": "cosmosDB.openInPortal",
 					"when": "view == cosmosDBExplorer && viewItem == cosmosDBDocumentServer"
+				},
+				{
+					"command": "cosmosDB.openInPortal",
+					"when": "view == cosmosDBExplorer && viewItem == cosmosDBGraphAccount"
 				},
 				{
 					"command": "cosmosDB.copyConnectionString",
@@ -373,6 +417,14 @@
 				{
 					"command": "cosmosDB.refresh",
 					"when": "view == cosmosDBExplorer && viewItem == cosmosDBDocumentServer"
+				},
+				{
+					"command": "cosmosDB.refresh",
+					"when": "view == cosmosDBExplorer && viewItem == cosmosDBGraphAccount"
+				},
+				{
+					"command": "cosmosDB.refresh",
+					"when": "view == cosmosDBExplorer && viewItem == cosmosDBGraphDatabase"
 				},
 				{
 					"command": "cosmosDB.refresh",

--- a/src/docdb/commands.ts
+++ b/src/docdb/commands.ts
@@ -11,9 +11,10 @@ import { DocumentClient } from 'documentdb';
 import { DocumentBase } from 'documentdb/lib';
 import { CosmosDBExplorer } from './../explorer';
 import { DialogBoxResponses } from '../constants'
+import { GraphDatabaseNode, GraphNode } from '../graph/graphNodes';
 
 export class DocDBCommands {
-    public static async createDocDBDatabase(server: CosmosDBAccountNode, explorer: CosmosDBExplorer) {
+    public static async createDatabase(server: CosmosDBAccountNode, explorer: CosmosDBExplorer) {
         const databaseName = await vscode.window.showInputBox({
             placeHolder: 'Database Name',
             validateInput: DocDBCommands.validateDatabaseName,
@@ -35,13 +36,13 @@ export class DocDBCommands {
             });
             const databaseNode = new DocDBDatabaseNode(databaseName, await server.getPrimaryMasterKey(), server.documentEndpoint, server);
             explorer.refresh(server);
-            DocDBCommands.createDocDBCollection(databaseNode, explorer);
+            DocDBCommands.createCollection(databaseNode, explorer);
         }
     }
 
     public static async createDocDBDocument(coll: DocDBCollectionNode, explorer: CosmosDBExplorer) {
-        const masterKey = coll.db.getPrimaryMasterKey();
-        const endpoint = coll.db.getEndpoint();
+        const masterKey = coll.dbNode.masterKey;
+        const endpoint = coll.dbNode.documentEndpoint;
         const client = new DocumentClient(endpoint, { masterKey: masterKey });
         let docID = await vscode.window.showInputBox({
             placeHolder: "Enter a unique id",
@@ -65,14 +66,20 @@ export class DocDBCommands {
     }
 
 
-    public static async createDocDBCollection(db: DocDBDatabaseNode, explorer: CosmosDBExplorer) {
+    public static async createCollection(db: DocDBDatabaseNode | GraphDatabaseNode, explorer: CosmosDBExplorer) {
+        let placeHolder: string;
+        if (db instanceof GraphDatabaseNode) {
+            placeHolder = 'Enter name of collection';
+        } else {
+            placeHolder = 'Enter name of graph';
+        }
         const collectionName = await vscode.window.showInputBox({
-            placeHolder: 'Enter name of collection',
+            placeHolder: placeHolder,
             ignoreFocusOut: true
         });
         if (collectionName) {
-            const masterKey = await db.getPrimaryMasterKey();
-            const endpoint = await db.getEndpoint();
+            const masterKey = await db.masterKey;
+            const endpoint = await db.documentEndpoint;
             let partitionKey: string = await vscode.window.showInputBox({
                 prompt: 'Partition Key',
                 ignoreFocusOut: true,
@@ -99,7 +106,7 @@ export class DocDBCommands {
                         }
                     };
                     await new Promise((resolve, reject) => {
-                        client.createCollection(db.getDbLink(), collectionDef, options, (err, result) => {
+                        client.createCollection(db.getDBLink(), collectionDef, options, (err, result) => {
                             if (err) {
                                 reject(new Error(err.body));
                             }
@@ -140,16 +147,16 @@ export class DocDBCommands {
         return null;
     }
 
-    public static async deleteDocDBDatabase(db: DocDBDatabaseNode, explorer: CosmosDBExplorer): Promise<void> {
+    public static async deleteDatabase(db: DocDBDatabaseNode | GraphDatabaseNode, explorer: CosmosDBExplorer): Promise<void> {
         if (db) {
-            const confirmed = await vscode.window.showWarningMessage(`Are you sure you want to delete database '${db.label}' and its collections?`,
+            const confirmed = await vscode.window.showWarningMessage(`Are you sure you want to delete database '${db.label}' and its contents?`,
                 DialogBoxResponses.Yes, DialogBoxResponses.No);
             if (confirmed === DialogBoxResponses.Yes) {
-                const masterKey = await db.getPrimaryMasterKey();
-                const endpoint = await db.getEndpoint();
+                const masterKey = await db.masterKey;
+                const endpoint = await db.documentEndpoint;
                 const client = new DocumentClient(endpoint, { masterKey: masterKey });
                 await new Promise((resolve, reject) => {
-                    client.deleteDatabase(db.getDbLink(), function (err) {
+                    client.deleteDatabase(db.getDBLink(), function (err) {
                         err ? reject(new Error(err.body)) : resolve();
                     });
                 });
@@ -157,12 +164,18 @@ export class DocDBCommands {
             }
         }
     }
-    public static async deleteDocDBCollection(coll: DocDBCollectionNode, explorer: CosmosDBExplorer): Promise<void> {
+    public static async deleteCollection(coll: DocDBCollectionNode | GraphNode, explorer: CosmosDBExplorer): Promise<void> {
         if (coll) {
-            const confirmed = await vscode.window.showWarningMessage(`Are you sure you want to delete collection '${coll.label}'?`, DialogBoxResponses.Yes, DialogBoxResponses.No);
+            let message: string;
+            if (coll instanceof GraphNode) {
+                message = `Are you sure you want to delete graph '${coll.label}'?`;
+            } else {
+                message = `Are you sure you want to delete collection '${coll.label}'?`;
+            }
+            const confirmed = await vscode.window.showWarningMessage(message, DialogBoxResponses.Yes, DialogBoxResponses.No);
             if (confirmed === DialogBoxResponses.Yes) {
-                const masterKey = await coll.db.getPrimaryMasterKey();
-                const endpoint = await coll.db.getEndpoint();
+                const masterKey = await coll.dbNode.masterKey;
+                const endpoint = await coll.dbNode.documentEndpoint;
                 const client = new DocumentClient(endpoint, { masterKey: masterKey });
                 const collLink = coll.getCollLink();
                 await new Promise((resolve, reject) => {
@@ -170,7 +183,7 @@ export class DocDBCommands {
                         err ? reject(new Error(err.body)) : resolve();
                     });
                 });
-                explorer.refresh(coll.db);
+                explorer.refresh(coll.dbNode);
             }
         }
     }
@@ -179,8 +192,8 @@ export class DocDBCommands {
         if (doc) {
             const confirmed = await vscode.window.showWarningMessage(`Are you sure you want to delete document '${doc.label}'?`, DialogBoxResponses.Yes, DialogBoxResponses.No);
             if (confirmed === DialogBoxResponses.Yes) {
-                const masterKey = await doc.collection.db.getPrimaryMasterKey();
-                const endpoint = await doc.collection.db.getEndpoint();
+                const masterKey = await doc.collection.dbNode.masterKey;
+                const endpoint = await doc.collection.dbNode.documentEndpoint;
                 const client: DocumentClient = new DocumentClient(endpoint, { masterKey: masterKey });
                 const docLink = doc.getDocLink();
                 const options = { partitionKey: doc.partitionKeyValue || Object() }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import { IMongoServer, MongoDatabaseNode, MongoCommand, MongoCollectionNode, Mon
 import { DocDBDatabaseNode, DocDBCollectionNode, DocDBDocumentNode } from './docdb/nodes';
 import { CosmosDBAccountNode, INode, IDocumentNode, LoadMoreNode } from './nodes';
 import { DocumentClient } from 'documentdb';
-import { GraphNode } from './graph/graphNodes';
+import { GraphNode, GraphDatabaseNode } from './graph/graphNodes';
 import MongoDBLanguageClient from './mongo/languageClient';
 import { Reporter } from './telemetry';
 import { UserCancelledError } from './errors';
@@ -83,9 +83,11 @@ export function activate(context: vscode.ExtensionContext) {
 		MongoCommands.createMongoCollection(node, explorer);
 		connectToDatabase(node);
 	});
-	initAsyncCommand(context, 'cosmosDB.createDocDBDatabase', (node: CosmosDBAccountNode) => DocDBCommands.createDocDBDatabase(node, explorer));
+	initAsyncCommand(context, 'cosmosDB.createDocDBDatabase', (node: CosmosDBAccountNode) => DocDBCommands.createDatabase(node, explorer));
+	initAsyncCommand(context, 'cosmosDB.createGraphDatabase', (node: CosmosDBAccountNode) => DocDBCommands.createDatabase(node, explorer));
 	initAsyncCommand(context, 'cosmosDB.createMongoDocument', (node: MongoCollectionNode) => MongoCommands.createMongoDocument(node, explorer));
-	initAsyncCommand(context, 'cosmosDB.createDocDBCollection', (node: DocDBDatabaseNode) => DocDBCommands.createDocDBCollection(node, explorer));
+	initAsyncCommand(context, 'cosmosDB.createDocDBCollection', (node: DocDBDatabaseNode) => DocDBCommands.createCollection(node, explorer));
+	initAsyncCommand(context, 'cosmosDB.createGraph', (node: GraphDatabaseNode) => DocDBCommands.createCollection(node, explorer));
 	initAsyncCommand(context, 'cosmosDB.createDocDBDocument', (node: DocDBCollectionNode) => DocDBCommands.createDocDBDocument(node, explorer));
 	initCommand(context, 'cosmosDB.openInPortal', (node: CosmosDBAccountNode) => openInPortal(node));
 	initAsyncCommand(context, 'cosmosDB.copyConnectionString', (node: CosmosDBAccountNode) => copyConnectionString(node));
@@ -95,9 +97,11 @@ export function activate(context: vscode.ExtensionContext) {
 	initAsyncCommand(context, 'cosmosDB.deleteMongoDB', (element: MongoDatabaseNode) => deleteDatabase(element));
 	initAsyncCommand(context, 'cosmosDB.deleteMongoCollection', (element: MongoCollectionNode) => MongoCommands.deleteMongoCollection(element, explorer));
 	initAsyncCommand(context, 'cosmosDB.deleteMongoDocument', (element: MongoDocumentNode) => MongoCommands.deleteMongoDocument(element, explorer));
-	initAsyncCommand(context, 'cosmosDB.deleteDocDBDatabase', (element: DocDBDatabaseNode) => DocDBCommands.deleteDocDBDatabase(element, explorer));
-	initAsyncCommand(context, 'cosmosDB.deleteDocDBCollection', (element: DocDBCollectionNode) => DocDBCommands.deleteDocDBCollection(element, explorer));
+	initAsyncCommand(context, 'cosmosDB.deleteDocDBDatabase', (element: DocDBDatabaseNode) => DocDBCommands.deleteDatabase(element, explorer));
+	initAsyncCommand(context, 'cosmosDB.deleteDocDBCollection', (element: DocDBCollectionNode) => DocDBCommands.deleteCollection(element, explorer));
 	initAsyncCommand(context, 'cosmosDB.deleteDocDBDocument', (element: DocDBDocumentNode) => DocDBCommands.deleteDocDBDocument(element, explorer));
+	initAsyncCommand(context, 'cosmosDB.deleteGraphDatabase', (element: GraphDatabaseNode) => DocDBCommands.deleteDatabase(element, explorer));
+	initAsyncCommand(context, 'cosmosDB.deleteGraph', (element: GraphNode) => DocDBCommands.deleteCollection(element, explorer));
 	initAsyncCommand(context, 'cosmosDB.newMongoScrapbook', async () => await util.showNewFile('', context.extensionPath, 'Scrapbook', '.mongo'));
 	initAsyncCommand(context, 'cosmosDB.executeMongoCommand', async () => await MongoCommands.executeCommandFromActiveEditor(connectedDb, context.extensionPath));
 	initAsyncCommand(context, 'cosmosDB.update', () => documentEditor.updateLastDocument());

--- a/src/graph/graphNodes.ts
+++ b/src/graph/graphNodes.ts
@@ -13,7 +13,7 @@ import { GraphConfiguration } from './GraphConfiguration';
 import { GraphViewServer } from './GraphViewServer';
 
 export class GraphDatabaseNode implements INode {
-	public readonly contextValue: string = "cosmosGraphDatabase";
+	public readonly contextValue: string = "cosmosDBGraphDatabase";
 
 	private _graphEndpoint: string;
 	private _graphPort: number;
@@ -61,12 +61,12 @@ export class GraphDatabaseNode implements INode {
 
 	readonly collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
 
-	public getGraphLink(): string {
+	public getDBLink(): string {
 		return 'dbs/' + this.id;
 	}
 
 	async getChildren(): Promise<INode[]> {
-		const dbLink: string = this.getGraphLink();
+		const dbLink: string = this.getDBLink();
 		const parentNode = this;
 		const client = new DocumentClient(this.documentEndpoint, { masterKey: this.masterKey });
 		let collections = await this.listCollections(dbLink, client);
@@ -86,10 +86,10 @@ export class GraphNode implements INode {
 
 	readonly collapsibleState = vscode.TreeItemCollapsibleState.None;
 
-	constructor(readonly id: string, readonly graphDBNode: GraphDatabaseNode) {
+	constructor(readonly id: string, readonly dbNode: GraphDatabaseNode) {
 	}
 
-	readonly contextValue: string = "cosmosGraph";
+	readonly contextValue: string = "cosmosDBGraph";
 
 	get label(): string {
 		return this.id;
@@ -103,16 +103,16 @@ export class GraphNode implements INode {
 	}
 
 	getCollLink(): string {
-		return this.graphDBNode.getGraphLink() + '/colls/' + this.id;
+		return this.dbNode.getDBLink() + '/colls/' + this.id;
 	}
 
 	public async showExplorer(graphViewsManager: GraphViewsManager): Promise<void> {
 		await graphViewsManager.showGraphViewer(this.id, <GraphConfiguration>{
-			endpoint: this.graphDBNode.graphEndpoint,
-			endpointPort: this.graphDBNode.graphPort,
-			databaseName: this.graphDBNode.id,
+			endpoint: this.dbNode.graphEndpoint,
+			endpointPort: this.dbNode.graphPort,
+			databaseName: this.dbNode.id,
 			graphName: this.id,
-			key: this.graphDBNode.masterKey
+			key: this.dbNode.masterKey
 		});
 	}
 

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -103,7 +103,7 @@ export class CosmosDBAccountNode implements IMongoServer {
 				this.contextValue = "cosmosDBDocumentServer"
 				break;
 			case "Graph":
-				this.contextValue = "cosmosGraphDatabaseServer"
+				this.contextValue = "cosmosDBGraphAccount"
 				break;
 			default:
 				this.contextValue = "cosmosDBGenericResource";
@@ -159,7 +159,7 @@ export class CosmosDBAccountNode implements IMongoServer {
 				return MongoServerNode.getMongoDatabaseNodes(connectionString, this);
 
 			case "cosmosDBDocumentServer":
-			case "cosmosGraphDatabaseServer":
+			case "cosmosDBGraphAccount":
 				return await this.getDocumentDatabaseNodesByExperience();
 		}
 	}


### PR DESCRIPTION
This brings it up to parity with DocumentDB nodes:
1. Open in Portal
1. Refresh
1. Create/Delete database
1. Create/Delete graph

I think there's more code clean-up/organization that we could do, but I'll save that until after the release