### PR TITLE
Fix can't open documents in explorer

### DIFF
--- a/src/docdb/nodes.ts
+++ b/src/docdb/nodes.ts
@@ -130,14 +130,14 @@ export class DocDBCollectionNode implements INode {
 }
 
 export class DocDBDocumentNode implements IDocumentNode {
+	public readonly partitionKeyValue: string;
 	private _data: IDocDBDocumentSpec;
 	constructor(readonly id: string, readonly collection: DocDBCollectionNode, payload: IDocDBDocumentSpec) {
 		this._data = payload;
+		this.partitionKeyValue = this.getPartitionKeyValue();
 	}
 
 	readonly contextValue: string = "cosmosDBDocument";
-
-	readonly partitionKeyValue = this.getPartitionKeyValue();
 
 	get data(): IDocDBDocumentSpec {
 		return this._data;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,6 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	initEvent(context, 'cosmosDB.documentEditor.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, (doc: vscode.TextDocument) => documentEditor.onDidSaveTextDocument(context.globalState, doc));
-	initEvent(context, 'cosmosDB.documentEditor.onDidCloseTextDocument', vscode.workspace.onDidCloseTextDocument, (doc: vscode.TextDocument) => documentEditor.onDidCloseTextDocument(doc));
 }
 
 function initCommand(context: vscode.ExtensionContext, commandId: string, callback: (...args: any[]) => any) {


### PR DESCRIPTION
Any time you expand a DocumentDB collection, you got an error like this:
<img width="476" alt="screen shot 2017-11-09 at 10 01 31 pm" src="https://user-images.githubusercontent.com/11282622/32644954-a6b393a6-c599-11e7-80d3-ddcf55822847.png">

It's because this.getPartitionKeyValue() relies on this.data, which wasn't set yet