### PR TITLE
Remove Azure keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 		"Azure"
 	],
 	"keywords": [
-		"Azure",
 		"Cosmos DB",
 		"DocumentDB",
 		"Graph",


### PR DESCRIPTION
We're only allowed 5 keywords and Azure should be covered by our title/category