### PR TITLE
Stats shouldn't display while querying

### DIFF
--- a/resources/graphClient/graphClient.css
+++ b/resources/graphClient/graphClient.css
@@ -187,7 +187,7 @@ textarea {
     padding-top: 18%;
 }
 
-#stats {
+#statsBackground {
     box-sizing: border-box;
     padding: 12px 15px;
     color: #cccccc;
@@ -222,7 +222,7 @@ textarea {
     display: none;
 }
 
-#states:not(.state-graph-results) #stats span {
+#states:not(.state-graph-results) #stats {
     display: none;
 }
 

--- a/resources/graphClient/graphClient.html
+++ b/resources/graphClient/graphClient.html
@@ -77,8 +77,8 @@
             </div>
             <div id="queryStatus">Querying...</div>
         </div>
-        <div id="stats">
-            <span></span>
+        <div id="statsBackground">
+            <div id="stats"></div>
         </div>
 
 

--- a/src/graph/client/graphClient.ts
+++ b/src/graph/client/graphClient.ts
@@ -1,5 +1,3 @@
-import { error } from "util";
-
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
Code was setting text directly on #stats, thus erasing the span under it which is what the CSS keyed off of.  Be more explicit by adding another div.