### PR TITLE
Remove osx from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: node_js
 
 sudo: false
 
-os:
-  - osx
-  - linux
-
 node_js:
   - 'stable'
 


### PR DESCRIPTION
The tests fail on osx most of the time and I think running tests on just linux is good enough for now