### PR TITLE
Changes to DocumentEditor dispose to improve VSCode restarting experience

### DIFF
--- a/src/DocumentEditor.ts
+++ b/src/DocumentEditor.ts
@@ -51,7 +51,10 @@ export class DocumentEditor implements vscode.Disposable {
     }
 
     public async dispose(): Promise<void> {
-        Object.keys(this.fileMap).forEach(async (key) => await fse.remove(path.dirname(key)));
+        Object.keys(this.fileMap).forEach((key) => {
+            fse.copySync(key, "backup-" + key);
+            fse.writeFileSync(key, "");
+        });
     }
 
     private async updateToCloud(node: IEditableNode, doc: vscode.TextDocument): Promise<void> {

--- a/src/DocumentEditor.ts
+++ b/src/DocumentEditor.ts
@@ -53,7 +53,7 @@ export class DocumentEditor implements vscode.Disposable {
     public async dispose(): Promise<void> {
         Object.keys(this.fileMap).forEach((key) => {
             const backupFileName = key.substring(0, key.lastIndexOf('.')) + "-backup.json";
-            fse.ensureFileSync(backupFileName)
+            fse.ensureFileSync(backupFileName);
             fse.copySync(key, backupFileName);
             fse.writeFileSync(key, "We do not support editing entities across sessions. Please open an entity from the tree on the left to continue. The previous changes you made here are in the corresponding back-up file.");
         });

--- a/src/DocumentEditor.ts
+++ b/src/DocumentEditor.ts
@@ -55,7 +55,7 @@ export class DocumentEditor implements vscode.Disposable {
             const backupFileName = key.substring(0, key.lastIndexOf('.')) + "-backup.json";
             fse.ensureFileSync(backupFileName);
             fse.copySync(key, backupFileName);
-            fse.writeFileSync(key, "We do not support editing entities across sessions. Please open an entity from the tree on the left to continue. The previous changes you made here are in the corresponding back-up file.");
+            fse.writeFileSync(key, `Reopen the entity or view your previous changes here: ${backupFileName}`);
         });
     }
 

--- a/src/DocumentEditor.ts
+++ b/src/DocumentEditor.ts
@@ -55,7 +55,7 @@ export class DocumentEditor implements vscode.Disposable {
             const backupFileName = key.substring(0, key.lastIndexOf('.')) + "-backup.json";
             fse.ensureFileSync(backupFileName);
             fse.copySync(key, backupFileName);
-            fse.writeFileSync(key, `Reopen the entity or view your previous changes here: ${backupFileName}`);
+            fse.writeFileSync(key, `We do not support editing entities across sessions. Reopen the entity or view your previous changes here: ${backupFileName}`);
         });
     }
 

--- a/src/DocumentEditor.ts
+++ b/src/DocumentEditor.ts
@@ -52,8 +52,10 @@ export class DocumentEditor implements vscode.Disposable {
 
     public async dispose(): Promise<void> {
         Object.keys(this.fileMap).forEach((key) => {
-            fse.copySync(key, "backup-" + key);
-            fse.writeFileSync(key, "");
+            const backupFileName = key.substring(0, key.lastIndexOf('.')) + "-backup.json";
+            fse.ensureFileSync(backupFileName)
+            fse.copySync(key, backupFileName);
+            fse.writeFileSync(key, "We do not support editing entities across sessions. Please open an entity from the tree on the left to continue. The previous changes you made here are in the corresponding back-up file.");
         });
     }
 


### PR DESCRIPTION
Create a backup of the file before clearing it. 