### PR TITLE
Add MongoDB database name validation. Closes #140

### DIFF
--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -59,7 +59,8 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
     public async createChild(_node: IAzureNode, showCreatingNode: (label: string) => void): Promise<IAzureTreeItem> {
         const databaseName = await vscode.window.showInputBox({
             placeHolder: "Database Name",
-            prompt: "Enter the name of the database"
+            prompt: "Enter the name of the database",
+            validateInput: validateDatabaseName,
         });
         if (databaseName) {
             const collectionName = await vscode.window.showInputBox({
@@ -78,6 +79,20 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
 
         throw new UserCancelledError();
     }
+
+}
+
+function validateDatabaseName(database: string): string | undefined | null {
+    // https://docs.mongodb.com/manual/reference/limits/#naming-restrictions
+    const min = 1;
+    const max = 63;
+    if(!database || database.length < min || database.length > max) {
+        return `The name must be between ${min} and ${max} characters.`;
+    }
+    if (/[/\\. "$]/.test(database)) {
+        return "The name cannot contain these characters - `/\\. \"$`"
+    }
+    return null;
 }
 
 interface IDatabaseInfo {


### PR DESCRIPTION
This commit uses MongodB 3.6 docs specs to verify input when new
MongoDB is to be created:

https://docs.mongodb.com/manual/reference/limits/\#naming-restrictions

Thanks!