### PR TITLE
Default throughput to cheapest option

### DIFF
--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -132,7 +132,7 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
         try {
             const value = Number(input);
             if (value < minThroughput || value > maxThroughput) {
-                return `Value needs to lie between ${minThroughput} and ${maxThroughput}`
+                return `Value must be between ${minThroughput} and ${maxThroughput}`
             }
         } catch (err) {
             return "Input must be a number"

--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -11,6 +11,9 @@ import * as vscode from 'vscode';
 import { DocumentBase } from 'documentdb/lib';
 import { DialogBoxResponses } from '../../constants';
 
+const minThroughput: number = 1000;
+const maxThroughput: number = 100000;
+
 /**
  * This class provides common logic for DocumentDB, Graph, and Table databases
  * (DocumentDB is the base type for all Cosmos DB accounts)
@@ -81,9 +84,9 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
                     partitionKey = '/' + partitionKey;
                 }
                 const throughput: number = Number(await vscode.window.showInputBox({
-                    value: '10000',
+                    value: minThroughput.toString(),
                     ignoreFocusOut: true,
-                    prompt: 'Initial throughput capacity, between 2500 and 100,000',
+                    prompt: `Initial throughput capacity, between ${minThroughput} and ${maxThroughput}`,
                     validateInput: DocDBDatabaseTreeItemBase.validateThroughput
                 }));
 
@@ -128,8 +131,8 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
     private static validateThroughput(input: string): string | undefined | null {
         try {
             const value = Number(input);
-            if (value < 2500 || value > 100000) {
-                return "Value needs to lie between 2500 and 100,000"
+            if (value < minThroughput || value > maxThroughput) {
+                return `Value needs to lie between ${minThroughput} and ${maxThroughput}`
             }
         } catch (err) {
             return "Input must be a number"


### PR DESCRIPTION
The portal lists 1,000 as the lower limit (not 2,500)
![screen shot 2017-12-15 at 11 16 00 am](https://user-images.githubusercontent.com/11282622/34056806-5ebd32bc-e189-11e7-9b6c-4126025a7ab0.png)

This fixes it for graph and docdb (the graph tree item inherits from the docdbbase class). It does not fix it for mongo since that goes directly though the mongo api (aka not the cosmos api)