### PR TITLE
Restrict viewsettings to single array item for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -564,6 +564,7 @@
 				"cosmosDB.graph.viewSettings": {
 					"type": "array",
 					"description": "Settings for CosmosDB graph visualization.",
+					"maxItems": 1,
 					"items": {
 						"type": "object",
 						"description": "A group of view settings",


### PR DESCRIPTION
The current multi-group behavior probably isn't correct, and multiple settings don't make sense until we have filters anyway.