### PR TITLE
Fix invalid partitionKey for cheap Cosmos collections

### DIFF
--- a/src/docdb/tree/DocDBDocumentTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentTreeItem.ts
@@ -56,7 +56,7 @@ export class DocDBDocumentTreeItem implements IAzureTreeItem {
         const result = await vscode.window.showWarningMessage(message, DialogBoxResponses.Yes, DialogBoxResponses.Cancel);
         if (result === DialogBoxResponses.Yes) {
             const client = this._collection.getDocumentClient();
-            const options = { partitionKey: this.partitionKeyValue || Object() }
+            const options = { partitionKey: this.partitionKeyValue }
             await new Promise((resolve, reject) => {
                 client.deleteDocument(this.link, options, function (err) {
                     err ? reject(new Error(err.body)) : resolve();
@@ -72,7 +72,7 @@ export class DocDBDocumentTreeItem implements IAzureTreeItem {
         const _self: string = this.document._self;
         this._document = await new Promise<RetrievedDocument>((resolve, reject) => {
             client.replaceDocument(_self, newData,
-                { accessCondition: { type: 'IfMatch', condition: newData._etag }, partitionKey: this.partitionKeyValue || Object() },
+                { accessCondition: { type: 'IfMatch', condition: newData._etag }, partitionKey: this.partitionKeyValue },
                 (err, updated: RetrievedDocument) => {
                     if (err) {
                         reject(new Error(err.body));


### PR DESCRIPTION
When you create the cheaper collection option in the portal, it doesn't let you specify a partition key.  These collections fail when the user tries to upload or delete a document. (I believe @StephenWeatherford ran into this issue when he attached his 'graph' account as a 'docdb' account and tried to update a document)
> Partition key provided either doesn't correspond to definition in the collection or doesn't match partition key field values specified in the document.
ActivityId: 164c2bd0-8118-46df-aafa-26eb376bf4f0, Microsoft.Azure.Documents.Common/1.19.121.4

Here's the docs for partition key:
http://azure.github.io/azure-documentdb-node/global.html#RequestOptions 

partitionKey | string | \<optional\> | Specifies a partition key definition for a particular path in the Azure DocumentDB database service.
-- | -- | -- | --

(It's an optional string, not an object)

Fixes #300