### PR TITLE
Persist isEmulator for reload of VSCode, remove graph from quickpick

### DIFF
--- a/src/docdb/tree/DocDBAccountTreeItemBase.ts
+++ b/src/docdb/tree/DocDBAccountTreeItemBase.ts
@@ -18,8 +18,8 @@ export abstract class DocDBAccountTreeItemBase extends DocDBTreeItemBase<Databas
     public readonly label: string;
     public readonly childTypeLabel: string = "Database";
 
-    constructor(id: string, label: string, documentEndpoint: string, masterKey: string) {
-        super(documentEndpoint, masterKey);
+    constructor(id: string, label: string, documentEndpoint: string, masterKey: string, isEmulator?: boolean) {
+        super(documentEndpoint, masterKey, isEmulator);
         this.id = id;
         this.label = label;
     }

--- a/src/docdb/tree/DocDBTreeItemBase.ts
+++ b/src/docdb/tree/DocDBTreeItemBase.ts
@@ -27,9 +27,10 @@ export abstract class DocDBTreeItemBase<T> implements IAzureParentTreeItem {
     private _iterator: QueryIterator<T> | undefined;
     private _batchSize: number = DefaultBatchSize;
 
-    constructor(documentEndpoint: string, masterKey: string) {
+    constructor(documentEndpoint: string, masterKey: string, isEmulator?: boolean) {
         this.documentEndpoint = documentEndpoint;
         this.masterKey = masterKey;
+        this.isEmulator = isEmulator;
     }
 
     public hasMoreChildren(): boolean {

--- a/src/graph/tree/GraphAccountTreeItem.ts
+++ b/src/graph/tree/GraphAccountTreeItem.ts
@@ -14,8 +14,8 @@ export class GraphAccountTreeItem extends DocDBAccountTreeItemBase {
     public static contextValue: string = "cosmosDBGraphAccount";
     public contextValue: string = GraphAccountTreeItem.contextValue;
 
-    constructor(id: string, label: string, documentEndpoint: string, private _gremlinEndpoint: IGremlinEndpoint | undefined, masterKey: string) {
-        super(id, label, documentEndpoint, masterKey);
+    constructor(id: string, label: string, documentEndpoint: string, private _gremlinEndpoint: IGremlinEndpoint | undefined, masterKey: string, isEmulator?: boolean) {
+        super(id, label, documentEndpoint, masterKey, isEmulator);
     }
 
     public initChild(database: DatabaseMeta): IAzureTreeItem {

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -17,13 +17,15 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
     public readonly childTypeLabel: string = "Database";
     public readonly id: string;
     public readonly label: string;
-
     public readonly connectionString: string;
 
-    constructor(id: string, label: string, connectionString: string) {
+    public isEmulator: boolean;
+
+    constructor(id: string, label: string, connectionString: string, isEmulator?: boolean) {
         this.id = id;
         this.label = label;
         this.connectionString = connectionString;
+        this.isEmulator = isEmulator;
     }
 
     public get iconPath(): any {

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -35,7 +35,11 @@ export class MongoDatabaseTreeItem implements IAzureParentTreeItem {
 		if (path.endsWith('/')) {
 			path = path.slice(0, -1);
 		}
-		this.connectionString = `${uri.scheme}://${uri.authority}/${path}/${this._databaseName}?${uri.query}`;
+		if (path) {
+			this.connectionString = `${uri.scheme}://${uri.authority}/${path}/${this._databaseName}?${uri.query}`;
+		} else {
+			this.connectionString = `${uri.scheme}://${uri.authority}/${this._databaseName}?${uri.query}`;
+		}
 	}
 
 	public get label(): string {

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -111,7 +111,7 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
 
     public async attachEmulator(): Promise<void> {
         let connectionString: string;
-        const defaultExperience = <Experience>await vscode.window.showQuickPick(['MongoDB', 'DocumentDB', 'Graph'], { placeHolder: "Select a Database Account API...", ignoreFocusOut: true });
+        const defaultExperience = <Experience>await vscode.window.showQuickPick(['MongoDB', 'DocumentDB'], { placeHolder: "Select a Database Account API...", ignoreFocusOut: true });
         if (defaultExperience) {
             let port: number;
             if (defaultExperience === Experience.MongoDB) {

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -250,18 +250,17 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
         const value: IPersistedAccount[] = this._attachedAccounts.map((node: IAzureTreeItem) => {
             let experience: Experience;
             let isEmulator: boolean;
+            if (node instanceof MongoAccountTreeItem || node instanceof DocDBAccountTreeItem || node instanceof GraphAccountTreeItem || node instanceof TableAccountTreeItem) {
+                isEmulator = node.isEmulator;
+            }
             if (node instanceof MongoAccountTreeItem) {
                 experience = Experience.MongoDB;
-                isEmulator = node.isEmulator;
             } else if (node instanceof GraphAccountTreeItem) {
                 experience = Experience.Graph;
-                isEmulator = node.isEmulator;
             } else if (node instanceof TableAccountTreeItem) {
                 experience = Experience.Table;
-                isEmulator = node.isEmulator;
             } else if (node instanceof DocDBAccountTreeItem) {
                 experience = Experience.DocumentDB;
-                isEmulator = node.isEmulator;
             } else {
                 throw new Error(`Unexpected account node "${node.constructor.name}".`);
             }


### PR DESCRIPTION
Ensures that on reloading VSCode, the attached emulator does not forget its emulator-ness. 