### PR TITLE
Make mongo connections simpler and more robust

### DIFF
--- a/src/mongo/editors/MongoFindResultEditor.ts
+++ b/src/mongo/editors/MongoFindResultEditor.ts
@@ -33,7 +33,7 @@ export class MongoFindResultEditor implements ICosmosEditor<IMongoDocument[]> {
         const collection: Collection = db.collection(this._command.collection);
         // NOTE: Intentionally creating a _new_ tree item rather than searching for a cached node in the tree because
         // the executed 'find' command could have a filter or projection that is not handled by a cached tree node
-        this._collectionTreeItem = new MongoCollectionTreeItem(dbTreeItem.connectionString, collection, dbTreeItem.id, this._command.arguments);
+        this._collectionTreeItem = new MongoCollectionTreeItem(collection, dbTreeItem.id, this._command.arguments);
         const documents: MongoDocumentTreeItem[] = <MongoDocumentTreeItem[]>await this._collectionTreeItem.loadMoreChildren(undefined, true);
         return documents.map((docTreeItem) => docTreeItem.document);
     }

--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -49,8 +49,8 @@ export default class MongoDBLanguageClient {
 		context.subscriptions.push(disposable);
 	}
 
-	async connect(databaseConnectionString: string) {
-		await this.client.sendRequest('connect', { connectionString: databaseConnectionString });
+	async connect(connectionString: string, databaseName: string) {
+		await this.client.sendRequest('connect', { connectionString: connectionString, databaseName: databaseName });
 	}
 
 	disconnect(): void {

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -48,7 +48,7 @@ export function registerMongoCommands(context: vscode.ExtensionContext, actionHa
             await connectedDb.refresh();
         }
         connectedDb = node;
-        await languageClient.connect(connectedDb.treeItem.connectionString);
+        await languageClient.connect(connectedDb.treeItem.connectionString, connectedDb.treeItem.databaseName);
         connectedDb.treeItem.isConnected = true;
         await node.refresh();
     });

--- a/src/mongo/services/languageService.ts
+++ b/src/mongo/services/languageService.ts
@@ -44,8 +44,8 @@ export class LanguageService {
 
 		connection.onRequest('connect', (connectionParams) => {
 			MongoClient.connect(connectionParams.connectionString)
-				.then(db => {
-					this.db = db;
+				.then(account => {
+					this.db = account.db(connectionParams.databaseName);
 					this.schemaService.registerSchemas(this.db)
 						.then(schemas => {
 							this.configureSchemas(schemas);

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -20,17 +20,15 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 
 	private readonly collection: Collection;
 	private readonly _query: string | undefined;
-	private readonly _databaseConnectionString: string;
 	private _cursor: Cursor | undefined;
 	private _hasMoreChildren: boolean = true;
 	private _parentId: string;
 	private _batchSize: number = DefaultBatchSize;
 
-	constructor(databaseConnectionString: string, collection: Collection, parentId: string, query?: string) {
+	constructor(collection: Collection, parentId: string, query?: string) {
 		this.collection = collection;
 		this._parentId = parentId;
 		this._query = query;
-		this._databaseConnectionString = databaseConnectionString;
 	}
 
 	public async update(documents: IMongoDocument[]): Promise<IMongoDocument[]> {
@@ -149,8 +147,7 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 	}
 
 	private async drop(): Promise<string> {
-		const db: Db = await MongoClient.connect(this._databaseConnectionString);
-		await db.dropCollection(this.collection.collectionName);
+		await this.collection.drop();
 		return `Dropped collection ${this.collection.collectionName}.`;
 	}
 


### PR DESCRIPTION
Rather than trying to parse the connection string, just use `.db(databaseName)` after calling `MongoClient.connect`

This also ensure that connection strings that already have a database name will work:
>mongodb://examplemongo:xxx==@examplemongo.documents.azure.com:10255/**_admin_**?ssl=true

Let me know if you think it's worth merging before the release. I think it is, but I'm somewhat on the fence.