### PR TITLE
Ensure isEmulator is always passed to child resources

### DIFF
--- a/src/docdb/tree/DocDBAccountTreeItem.ts
+++ b/src/docdb/tree/DocDBAccountTreeItem.ts
@@ -15,7 +15,7 @@ export class DocDBAccountTreeItem extends DocDBAccountTreeItemBase {
     public contextValue: string = DocDBAccountTreeItem.contextValue;
 
     public initChild(database: DatabaseMeta): IAzureTreeItem {
-        return new DocDBDatabaseTreeItem(this.documentEndpoint, this.masterKey, database, this.id);
+        return new DocDBDatabaseTreeItem(this.documentEndpoint, this.masterKey, database, this.id, this.isEmulator);
     }
 
     public isAncestorOf(contextValue: string): boolean {

--- a/src/docdb/tree/DocDBAccountTreeItemBase.ts
+++ b/src/docdb/tree/DocDBAccountTreeItemBase.ts
@@ -18,7 +18,7 @@ export abstract class DocDBAccountTreeItemBase extends DocDBTreeItemBase<Databas
     public readonly label: string;
     public readonly childTypeLabel: string = "Database";
 
-    constructor(id: string, label: string, documentEndpoint: string, masterKey: string, isEmulator?: boolean) {
+    constructor(id: string, label: string, documentEndpoint: string, masterKey: string, isEmulator: boolean) {
         super(documentEndpoint, masterKey, isEmulator);
         this.id = id;
         this.label = label;

--- a/src/docdb/tree/DocDBCollectionTreeItemBase.ts
+++ b/src/docdb/tree/DocDBCollectionTreeItemBase.ts
@@ -18,8 +18,8 @@ export abstract class DocDBCollectionTreeItemBase extends DocDBTreeItemBase<Retr
     private readonly _collection: CollectionMeta;
     private readonly _parentId: string;
 
-    constructor(documentEndpoint: string, masterKey: string, collection: CollectionMeta, parentId: string) {
-        super(documentEndpoint, masterKey);
+    constructor(documentEndpoint: string, masterKey: string, collection: CollectionMeta, parentId: string, isEmulator: boolean) {
+        super(documentEndpoint, masterKey, isEmulator);
         this._collection = collection;
         this._parentId = parentId;
     }

--- a/src/docdb/tree/DocDBDatabaseTreeItem.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItem.ts
@@ -14,6 +14,6 @@ export class DocDBDatabaseTreeItem extends DocDBDatabaseTreeItemBase {
     public readonly childTypeLabel: string = 'Collection';
 
     public initChild(collection: CollectionMeta): IAzureTreeItem {
-        return new DocDBCollectionTreeItem(this.documentEndpoint, this.masterKey, collection, this.id);
+        return new DocDBCollectionTreeItem(this.documentEndpoint, this.masterKey, collection, this.id, this.isEmulator);
     }
 }

--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -23,8 +23,8 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
     private readonly _database: DatabaseMeta;
     private readonly _parentId: string;
 
-    constructor(documentEndpoint: string, masterKey: string, database: DatabaseMeta, parentId: string) {
-        super(documentEndpoint, masterKey);
+    constructor(documentEndpoint: string, masterKey: string, database: DatabaseMeta, parentId: string, isEmulator: boolean) {
+        super(documentEndpoint, masterKey, isEmulator);
         this._database = database;
         this._parentId = parentId;
     }

--- a/src/docdb/tree/DocDBTreeItemBase.ts
+++ b/src/docdb/tree/DocDBTreeItemBase.ts
@@ -27,7 +27,7 @@ export abstract class DocDBTreeItemBase<T> implements IAzureParentTreeItem {
     private _iterator: QueryIterator<T> | undefined;
     private _batchSize: number = DefaultBatchSize;
 
-    constructor(documentEndpoint: string, masterKey: string, isEmulator?: boolean) {
+    constructor(documentEndpoint: string, masterKey: string, isEmulator: boolean) {
         this.documentEndpoint = documentEndpoint;
         this.masterKey = masterKey;
         this.isEmulator = isEmulator;
@@ -75,13 +75,6 @@ export abstract class DocDBTreeItemBase<T> implements IAzureParentTreeItem {
         }
         this._batchSize *= 2;
 
-        return resources.map((resource: T) => {
-            const child = this.initChild(resource);
-            if (child instanceof DocDBTreeItemBase) {
-                child.isEmulator = this.isEmulator;
-            }
-            return child;
-        }
-        );
+        return resources.map((resource: T) => this.initChild(resource));
     }
 }

--- a/src/graph/tree/GraphAccountTreeItem.ts
+++ b/src/graph/tree/GraphAccountTreeItem.ts
@@ -14,12 +14,12 @@ export class GraphAccountTreeItem extends DocDBAccountTreeItemBase {
     public static contextValue: string = "cosmosDBGraphAccount";
     public contextValue: string = GraphAccountTreeItem.contextValue;
 
-    constructor(id: string, label: string, documentEndpoint: string, private _gremlinEndpoint: IGremlinEndpoint | undefined, masterKey: string, isEmulator?: boolean) {
+    constructor(id: string, label: string, documentEndpoint: string, private _gremlinEndpoint: IGremlinEndpoint | undefined, masterKey: string, isEmulator: boolean) {
         super(id, label, documentEndpoint, masterKey, isEmulator);
     }
 
     public initChild(database: DatabaseMeta): IAzureTreeItem {
-        return new GraphDatabaseTreeItem(this.documentEndpoint, this._gremlinEndpoint, this.masterKey, database, this.id);
+        return new GraphDatabaseTreeItem(this.documentEndpoint, this._gremlinEndpoint, this.masterKey, database, this.id, this.isEmulator);
     }
 
     public isAncestorOf(contextValue: string): boolean {

--- a/src/graph/tree/GraphDatabaseTreeItem.ts
+++ b/src/graph/tree/GraphDatabaseTreeItem.ts
@@ -14,8 +14,8 @@ export class GraphDatabaseTreeItem extends DocDBDatabaseTreeItemBase {
     public readonly contextValue: string = GraphDatabaseTreeItem.contextValue;
     public readonly childTypeLabel: string = 'Graph';
 
-    constructor(documentEndpoint: string, private _gremlinEndpoint: IGremlinEndpoint | undefined, masterKey: string, database: DatabaseMeta, parentId: string) {
-        super(documentEndpoint, masterKey, database, parentId);
+    constructor(documentEndpoint: string, private _gremlinEndpoint: IGremlinEndpoint | undefined, masterKey: string, database: DatabaseMeta, parentId: string, isEmulator: boolean) {
+        super(documentEndpoint, masterKey, database, parentId, isEmulator);
     }
 
     public initChild(collection: CollectionMeta): IAzureTreeItem {

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -21,7 +21,7 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
 
     public isEmulator: boolean;
 
-    constructor(id: string, label: string, connectionString: string, isEmulator?: boolean) {
+    constructor(id: string, label: string, connectionString: string, isEmulator: boolean) {
         this.id = id;
         this.label = label;
         this.connectionString = connectionString;

--- a/src/tree/CosmosDBAccountProvider.ts
+++ b/src/tree/CosmosDBAccountProvider.ts
@@ -41,23 +41,24 @@ export class CosmosDBAccountProvider implements IChildProvider {
         const defaultExperience = <Experience>databaseAccount.tags.defaultExperience;
         const resourceGroup: string = azureUtils.getResourceGroupFromId(databaseAccount.id);
         const label: string = `${databaseAccount.name} (${resourceGroup})`;
+        const isEmulator: boolean = false;
         if (defaultExperience === "MongoDB") {
             const result = await client.databaseAccounts.listConnectionStrings(resourceGroup, databaseAccount.name);
             // Use the default connection string
-            return new MongoAccountTreeItem(databaseAccount.id, label, result.connectionStrings[0].connectionString);
+            return new MongoAccountTreeItem(databaseAccount.id, label, result.connectionStrings[0].connectionString, isEmulator);
         } else {
             const keyResult: DatabaseAccountListKeysResult = await client.databaseAccounts.listKeys(resourceGroup, databaseAccount.name);
             switch (defaultExperience) {
                 case "Table":
-                    return new TableAccountTreeItem(databaseAccount.id, label, databaseAccount.documentEndpoint, keyResult.primaryMasterKey);
+                    return new TableAccountTreeItem(databaseAccount.id, label, databaseAccount.documentEndpoint, keyResult.primaryMasterKey, isEmulator);
                 case "Graph": {
                     const gremlinEndpoint = await TryGetGremlinEndpointFromAzure(client, resourceGroup, databaseAccount.name);
-                    return new GraphAccountTreeItem(databaseAccount.id, label, databaseAccount.documentEndpoint, gremlinEndpoint, keyResult.primaryMasterKey);
+                    return new GraphAccountTreeItem(databaseAccount.id, label, databaseAccount.documentEndpoint, gremlinEndpoint, keyResult.primaryMasterKey, isEmulator);
                 }
                 case "DocumentDB":
                 default:
                     // Default to DocumentDB, the base type for all Cosmos DB Accounts
-                    return new DocDBAccountTreeItem(databaseAccount.id, label, databaseAccount.documentEndpoint, keyResult.primaryMasterKey);
+                    return new DocDBAccountTreeItem(databaseAccount.id, label, databaseAccount.documentEndpoint, keyResult.primaryMasterKey, isEmulator);
             }
         }
     }


### PR DESCRIPTION
We weren't passing isEmulator in all cases, leading to bug #344. I made it a required parameter in the constructor to fix the issue

Fixes #344 