### PR TITLE
Fixes #364: Adopt the usage of ASAR in VSCode

### DIFF
--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -35,11 +35,7 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
     private _keytar: typeof keytarType;
 
     constructor(private readonly _globalState: vscode.Memento) {
-        try {
-            this._keytar = require(`${vscode.env.appRoot}/node_modules/keytar`);
-        } catch (e) {
-            // unable to find keytar
-        }
+        this._keytar = getCoreNodeModule(`keytar`);
 
         this.loadPersistedServers();
     }
@@ -298,4 +294,19 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
         const id = vscode.Uri.parse(endpoint).authority;
         return [endpoint, masterKey, id];
     }
+}
+
+/**
+ * Returns a node module installed with VSCode, or null if it fails.
+ */
+function getCoreNodeModule(moduleName: string) {
+    try {
+        return require(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`);
+    } catch (err) { }
+
+    try {
+        return require(`${vscode.env.appRoot}/node_modules/${moduleName}`);
+    } catch (err) { }
+
+    return null;
 }


### PR DESCRIPTION
Starting with today's insiders, this extension is no longer functioning correctly!

This fixes #364 and adopts the usage of ASAR when loading node modules which are part of the VS Code installation.