### PR TITLE
EnableGremlin capability to create post-GA graphs, fixes #352

### DIFF
--- a/package.json
+++ b/package.json
@@ -711,7 +711,7 @@
 	},
 	"dependencies": {
 		"antlr4ts": "^0.4.0-alpha.4",
-		"azure-arm-cosmosdb": "^1.0.0-preview",
+		"azure-arm-cosmosdb": "^1.1.0-preview",
 		"azure-arm-resource": "^3.0.0-preview",
 		"azure-graph": "^2.2.0",
 		"copy-paste": "^1.3.0",


### PR DESCRIPTION
Unfortunately, this requires a new version of the cosmosdb SDK built using the current swagger, and it has lots of changes.  Not sure how high a risk it is to take this right now.