### PR TITLE
Update the banner color to improve icon contrast.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"vscode": "^1.20.0"
 	},
 	"galleryBanner": {
-		"color": "#0072c6",
+		"color": "#3c3c3c",
 		"theme": "dark"
 	},
 	"icon": "resources/cosmos.png",


### PR DESCRIPTION
Changed to dark grey to match the theme and better show off the icon.

![image](https://user-images.githubusercontent.com/1186948/37841877-f36d6c6a-2e7d-11e8-87bc-f579beee1856.png)

Closes #359