### PR TITLE
Move to alpha version for next release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cosmosdb",
-	"version": "0.5.1",
+	"version": "0.5.2-alpha",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-azuretools",
 	"displayName": "Azure Cosmos DB",


### PR DESCRIPTION
Would like to start adding alpha to the versions until we're ready to release. Will especially help telemetry to distinguish between 1.0 when it's the released version 1.0 and 1.0 when it's one day before preparing for the 1.1 release.

The alpha should always be the next incremental update so we don't have to worry about going backwards in version if we decide to do 5.2 instead of 6.0. Thus assuming 5.2 for now. We can still always release as 6.0 if desired.