### PR TITLE
Allow mongo.shell.path to be a workspace setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -616,8 +616,7 @@
 						"null"
 					],
 					"description": "Path to the Mongo shell executable",
-					"default": null,
-					"isExecutable": true
+					"default": null
 				},
 				"cosmosDB.showExplorer": {
 					"type": "boolean",


### PR DESCRIPTION
Fixes #311 

Removed the isExecutable flag because:
1) It keeps the settings from being allowed as a workspace setting (change in scope is not needed)
2) At least one customer is using this setting in a way that it's an executable (with no path) plus arguments
3) This flag is currently used in vscode only to keep it from being a workspace setting. Perhaps in the future they might add intellisense to it, but if people aren't using it as a full path anyway...
#