### PR TITLE
Fix attached accounts race condition

### DIFF
--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -11,7 +11,7 @@ const localize = nls.loadMessageBundle();
 
 export default class MongoDBLanguageClient {
 
-	private client: LanguageClient;
+	public client: LanguageClient;
 
 	constructor(context: ExtensionContext) {
 		// The server is implemented in node

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -22,7 +22,7 @@ const connectedDBKey: string = 'ms-azuretools.vscode-cosmosdb.connectedDB';
 export function registerMongoCommands(context: vscode.ExtensionContext, actionHandler: AzureActionHandler, tree: AzureTreeDataProvider, editorManager: CosmosEditorManager): void {
     let languageClient: MongoDBLanguageClient = new MongoDBLanguageClient(context);
 
-    const loadPersistedMongoDBTask: Promise<void> = loadPersistedMongoDB(context, tree);
+    const loadPersistedMongoDBTask: Promise<void> = loadPersistedMongoDB(context, tree, languageClient);
 
     actionHandler.registerCommand('cosmosDB.createMongoDatabase', async (node?: IAzureParentNode) => {
         if (!node) {
@@ -100,7 +100,7 @@ export function registerMongoCommands(context: vscode.ExtensionContext, actionHa
     });
 }
 
-async function loadPersistedMongoDB(context: vscode.ExtensionContext, tree: AzureTreeDataProvider): Promise<void> {
+async function loadPersistedMongoDB(context: vscode.ExtensionContext, tree: AzureTreeDataProvider, languageClient: MongoDBLanguageClient): Promise<void> {
     await callWithTelemetryAndErrorHandling('cosmosDB.loadPersistedMongoDB', reporter, undefined, async function (this: IActionContext): Promise<void> {
         this.suppressErrorDisplay = true;
         this.properties.isActivationEvent = 'true';
@@ -108,6 +108,7 @@ async function loadPersistedMongoDB(context: vscode.ExtensionContext, tree: Azur
         if (persistedNodeId) {
             const persistedNode: IAzureNode | undefined = await tree.findNode(persistedNodeId);
             if (persistedNode) {
+                await languageClient.client.onReady();
                 await vscode.commands.executeCommand('cosmosDB.connectMongoDB', persistedNode);
             }
         }


### PR DESCRIPTION
I saw issues where the connected mongo database didn't always persist for attached accounts. It's because there is a race condition related to loading the persisted accounts.

I suppose there was always a bit of a race condition here. For example, if the user expanded the 'Attached Accounts' node before we load the persisted accounts, they would not see their accounts.