### PR TITLE
Use timeout on account name validation, fixes #494

### DIFF
--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
@@ -6,6 +6,7 @@
 import CosmosDBManagementClient = require("azure-arm-cosmosdb");
 import { IAzureUserInput, AzureNameStep, ResourceGroupStep, resourceGroupNamingRules } from 'vscode-azureextensionui';
 import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
+import { validOnTimeout } from "../../utils/inputValidation";
 
 export class CosmosDBAccountNameStep extends AzureNameStep<ICosmosDBWizardContext> {
     protected async isRelatedNameAvailable(wizardContext: ICosmosDBWizardContext, name: string): Promise<boolean> {
@@ -17,7 +18,7 @@ export class CosmosDBAccountNameStep extends AzureNameStep<ICosmosDBWizardContex
         wizardContext.accountName = (await ui.showInputBox({
             placeHolder: "Account name",
             prompt: "Provide a Cosmos DB account name",
-            validateInput: (name: string) => validateCosmosDBAccountName(name, client)
+            validateInput: (name: string) => validOnTimeout(() => validateCosmosDBAccountName(name, client))
         })).trim();
 
         wizardContext.relatedNameTask = this.generateRelatedName(wizardContext, wizardContext.accountName, resourceGroupNamingRules);
@@ -35,6 +36,7 @@ async function validateCosmosDBAccountName(name: string, client: CosmosDBManagem
 
     const min = 3;
     const max = 31;
+
     if (name.length < min || name.length > max) {
         return `The name must be between ${min} and ${max} characters.`;
     } else if (name.match(/[^a-z0-9-]/)) {

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
@@ -6,7 +6,7 @@
 import CosmosDBManagementClient = require("azure-arm-cosmosdb");
 import { IAzureUserInput, AzureNameStep, ResourceGroupStep, resourceGroupNamingRules } from 'vscode-azureextensionui';
 import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
-import { validOnTimeout } from "../../utils/inputValidation";
+import { validOnTimeoutOrException } from "../../utils/inputValidation";
 
 export class CosmosDBAccountNameStep extends AzureNameStep<ICosmosDBWizardContext> {
     protected async isRelatedNameAvailable(wizardContext: ICosmosDBWizardContext, name: string): Promise<boolean> {
@@ -18,7 +18,7 @@ export class CosmosDBAccountNameStep extends AzureNameStep<ICosmosDBWizardContex
         wizardContext.accountName = (await ui.showInputBox({
             placeHolder: "Account name",
             prompt: "Provide a Cosmos DB account name",
-            validateInput: (name: string) => validOnTimeout(() => validateCosmosDBAccountName(name, client))
+            validateInput: (name: string) => validOnTimeoutOrException(() => validateCosmosDBAccountName(name, client))
         })).trim();
 
         wizardContext.relatedNameTask = this.generateRelatedName(wizardContext, wizardContext.accountName, resourceGroupNamingRules);

--- a/src/utils/inputValidation.ts
+++ b/src/utils/inputValidation.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { valueOnTimeout } from "./timeout";
+
+export const inputValidationTimeoutMs = 2000;
+
+export function validOnTimeout(inputValidation: () => Promise<string | undefined>) {
+    return valueOnTimeout(inputValidationTimeoutMs, undefined, inputValidation);
+}

--- a/src/utils/inputValidation.ts
+++ b/src/utils/inputValidation.ts
@@ -5,8 +5,17 @@
 
 import { valueOnTimeout } from "./timeout";
 
-export const inputValidationTimeoutMs = 2000;
+const inputValidationTimeoutMs = 2000;
 
-export function validOnTimeout(inputValidation: () => Promise<string | undefined>) {
-    return valueOnTimeout(inputValidationTimeoutMs, undefined, inputValidation);
+/**
+ * Intended to be used for VS Code validateInput to protect against long-running validations. If a time-out occurs or the action throws,
+ * returns undefined (indicating a valid input). Use for optional validations.
+ */
+export function validOnTimeoutOrException(inputValidation: () => Promise<string | undefined>, timeoutMs?: number): Promise<string | undefined> {
+    try {
+        timeoutMs = timeoutMs || inputValidationTimeoutMs;
+        return valueOnTimeout(timeoutMs, undefined, inputValidation);
+    } catch (error) {
+        return undefined;
+    }
 }

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -12,22 +12,17 @@ export async function valueOnTimeout<T>(timeoutMs: number, timeoutValue: T, acti
 }
 
 export function throwOnTimeout<T>(timeoutMs: number, action: () => Promise<T>) {
-    let hasTimedOut = false;
-    let hasValue = false;
-
     return new Promise<T>(async (resolve, reject) => {
-        setTimeout(
+        let timer: NodeJS.Timer = setTimeout(
             () => {
-                if (!hasValue) {
-                    hasTimedOut = true;
-                    reject("Execution timed out");
-                }
+                timer = null;
+                reject("Execution timed out");
             },
             timeoutMs);
 
         let value = await action();
-        if (!hasTimedOut) {
-            hasValue = true;
+        if (timer) {
+            clearTimeout(timer);
             resolve(value);
         }
     });

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export async function valueOnTimeout<T>(timeoutMs: number, timeoutValue: T, action: () => Promise<T>) {
+    try {
+        return await throwOnTimeout(timeoutMs, action);
+    } catch (error) {
+        return timeoutValue;
+    }
+}
+
+export function throwOnTimeout<T>(timeoutMs: number, action: () => Promise<T>) {
+    let hasTimedOut = false;
+    let hasValue = false;
+
+    return new Promise<T>(async (resolve, reject) => {
+        setTimeout(
+            () => {
+                if (!hasValue) {
+                    hasTimedOut = true;
+                    reject("Execution timed out");
+                }
+            },
+            timeoutMs);
+
+        let value = await action();
+        if (!hasTimedOut) {
+            hasValue = true;
+            resolve(value);
+        }
+    });
+}

--- a/test/inputValidation.test.ts
+++ b/test/inputValidation.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+import { validOnTimeoutOrException } from '../src/utils/inputValidation';
+
+suite("inputValidation Tests", () => {
+
+    suite("validOnTimeoutOrException", () => {
+
+        test("executed", async () => {
+            let value = await validOnTimeoutOrException(async () => {
+                return await new Promise<string | undefined>((resolve, reject) => {
+                    setTimeout(() => { resolve("invalid input"); }, 1);
+                });
+            });
+
+            assert.equal(value, "invalid input");
+        });
+
+        test("timed out",
+            async () => {
+                let value = await validOnTimeoutOrException(async () => {
+                    return await new Promise<string | undefined>((resolve, reject) => {
+                        setTimeout(() => { resolve("invalid input"); }, 1000);
+                    });
+                },
+                    1);
+
+                assert.equal(value, undefined);
+            });
+
+        test("exception", async () => {
+            let value = await validOnTimeoutOrException(async () => {
+                return await new Promise<string | undefined>((resolve, reject) => {
+                    setTimeout(() => { reject("Oh, boy"); }, 1);
+                });
+            });
+
+            assert.equal(value, undefined);
+        });
+
+    });
+
+});
+

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+import { rejectOnTimeout, valueOnTimeout } from '../src/utils/timeout';
+
+suite("timeout Tests", () => {
+    suite("rejectOnTimeout", () => {
+
+        test("executes synchronously", async () => {
+            let executed: boolean;
+
+            await rejectOnTimeout(1, () => {
+                executed = true;
+            });
+
+            assert.equal(executed, true);
+        });
+
+        test("executes synchronously in promise", async () => {
+            let executed = false;
+
+            await rejectOnTimeout(1, () => {
+                return new Promise((resolve, reject) => {
+                    executed = true;
+                    resolve();
+                });
+            })
+
+            assert.equal(executed, true);
+        });
+
+        test("executes before time-out", async () => {
+            let executed = false;
+
+            await rejectOnTimeout(1, () => {
+                return new Promise((resolve, reject) => {
+                    executed = true;
+                    resolve();
+                });
+            })
+            assert.equal(executed, true);
+        });
+
+        test("timed out", async () => {
+            let executed = false;
+
+            try {
+                await rejectOnTimeout(1, async () => {
+                    await new Promise((resolve, reject) => {
+                        setTimeout(() => {
+                            executed = true;
+                            resolve();
+                        }, 1000);
+                    });
+                });
+
+                assert.fail(null, null, "Expected exception");
+            } catch (error) {
+            }
+
+            assert.equal(executed, false);
+        });
+
+        test("throws before time-out", async () => {
+            let executed = false;
+            let error: Error;
+
+            try {
+                await rejectOnTimeout(1000, async () => {
+                    await new Promise((resolve, reject) => {
+                        throw new Error("I threw up");
+                    });
+                })
+            } catch (err) {
+                error = err;
+            }
+
+            assert.equal(executed, false);
+            assert.equal(error.message, "I threw up");
+        });
+    });
+
+    suite("valueOnTimeout", () => {
+
+        test("executed", async () => {
+            let value = await valueOnTimeout(1000, 123, async () => {
+                return await new Promise<number>((resolve, reject) => {
+                    setTimeout(() => { resolve(-123); }, 1);
+                });
+            });
+
+            assert.equal(value, -123);
+        });
+
+        test("timed out", async () => {
+            let value = await valueOnTimeout(1, 123, async () => {
+                return await new Promise<number>((resolve, reject) => {
+                    setTimeout(() => { resolve(-123); }, 1000);
+                });
+            });
+
+            assert.equal(value, 123);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Azure is currently giving Server Error 500 when checking for account name availability, if the name is available (after about a minute delay).

Also, VS Code doesn't handle this situation well.

So, after 2 seconds we'll assume the name is available.