### PR TITLE
Fix build to work with latest cosmosdb package

### DIFF
--- a/package.json
+++ b/package.json
@@ -762,7 +762,7 @@
 	},
 	"dependencies": {
 		"antlr4ts": "^0.4.0-alpha.4",
-		"azure-arm-cosmosdb": "1.1.0-preview",
+		"azure-arm-cosmosdb": "^1.1.2",
 		"azure-arm-resource": "^3.0.0-preview",
 		"azure-graph": "^2.2.0",
 		"copy-paste": "^1.3.0",

--- a/src/commands/deleteCosmosDBAccount.ts
+++ b/src/commands/deleteCosmosDBAccount.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import CosmosDBManagementClient = require("azure-arm-cosmosdb");
+import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { IAzureNode } from 'vscode-azureextensionui';
 import { DialogBoxResponses } from '../constants';
 import { azureUtils } from '../utils/azureUtils';

--- a/src/graph/gremlinEndpoints.ts
+++ b/src/graph/gremlinEndpoints.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import CosmosDBManagementClient = require("azure-arm-cosmosdb");
+import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 
 export interface IGremlinEndpoint {
     host: string;

--- a/src/tree/CosmosDBAccountProvider.ts
+++ b/src/tree/CosmosDBAccountProvider.ts
@@ -9,7 +9,7 @@ import { TableAccountTreeItem } from "../table/tree/TableAccountTreeItem";
 import { GraphAccountTreeItem } from "../graph/tree/GraphAccountTreeItem";
 import { DocDBAccountTreeItem } from "../docdb/tree/DocDBAccountTreeItem";
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
-import CosmosDBManagementClient = require("azure-arm-cosmosdb");
+import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { DatabaseAccountsListResult, DatabaseAccount, DatabaseAccountListKeysResult } from 'azure-arm-cosmosdb/lib/models';
 import { Experience } from '../constants';
 import { TryGetGremlinEndpointFromAzure } from '../graph/gremlinEndpoints';

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import CosmosDBManagementClient = require("azure-arm-cosmosdb");
+import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { IAzureUserInput, AzureNameStep, ResourceGroupStep, resourceGroupNamingRules } from 'vscode-azureextensionui';
 import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
 

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import CosmosDBManagementClient = require("azure-arm-cosmosdb");
+import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { Capability } from 'azure-arm-cosmosdb/lib/models';
 import { AzureWizardStep } from 'vscode-azureextensionui';
 import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';


### PR DESCRIPTION
A new version of the cosmosdb package was released a few days ago that broke our builds. To fix it, I hard-coded the version of the package in this PR: https://github.com/Microsoft/vscode-cosmosdb/pull/496/files

This PR implements the _proper_ fix so that we can stay up to date. I'm fine merging this now or holding off until after the release. Let me know what you think

For more info, they changed this:
```typescript
declare class CosmosDBManagementClient extends AzureServiceClient {
```
(in javascript):
```
class CosmosDBManagementClient extends ServiceClient {
...
module.exports = CosmosDBManagementClient;
```

to this:
```
export default class CosmosDBManagementClient extends AzureServiceClient {
```
(in javascript):
```
class CosmosDBManagementClient extends ServiceClient {
...
module.exports = CosmosDBManagementClient;
module.exports['default'] = CosmosDBManagementClient;
module.exports.CosmosDBManagementClient = CosmosDBManagementClient;
module.exports.CosmosDBManagementModels = models;
```