### PR TITLE
Remove duplicate code in editor node labels

### DIFF
--- a/src/docdb/editors/DocDBDocumentNodeEditor.ts
+++ b/src/docdb/editors/DocDBDocumentNodeEditor.ts
@@ -7,7 +7,7 @@ import { IAzureNode } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { RetrievedDocument } from "documentdb";
 import { DocDBDocumentTreeItem } from "../tree/DocDBDocumentTreeItem";
-import { getLabel } from '../../utils/vscodeUtils';
+import { getNodeEditorLabel } from '../../utils/vscodeUtils';
 
 export class DocDBDocumentNodeEditor implements ICosmosEditor<RetrievedDocument> {
     private _documentNode: IAzureNode<DocDBDocumentTreeItem>;
@@ -16,7 +16,7 @@ export class DocDBDocumentNodeEditor implements ICosmosEditor<RetrievedDocument>
     }
 
     public get label(): string {
-        return getLabel(this._documentNode);
+        return getNodeEditorLabel(this._documentNode);
     }
 
     public async getData(): Promise<RetrievedDocument> {

--- a/src/docdb/editors/DocDBDocumentNodeEditor.ts
+++ b/src/docdb/editors/DocDBDocumentNodeEditor.ts
@@ -7,6 +7,7 @@ import { IAzureNode } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { RetrievedDocument } from "documentdb";
 import { DocDBDocumentTreeItem } from "../tree/DocDBDocumentTreeItem";
+import { getLabel } from '../../utils/vscodeUtils';
 
 export class DocDBDocumentNodeEditor implements ICosmosEditor<RetrievedDocument> {
     private _documentNode: IAzureNode<DocDBDocumentTreeItem>;
@@ -15,10 +16,7 @@ export class DocDBDocumentNodeEditor implements ICosmosEditor<RetrievedDocument>
     }
 
     public get label(): string {
-        const collectionNode = this._documentNode.parent;
-        const databaseNode = collectionNode.parent;
-        const accountNode = databaseNode.parent;
-        return `${accountNode.treeItem.label}/${databaseNode.treeItem.label}/${collectionNode.treeItem.label}/${this._documentNode.treeItem.label}`;
+        return getLabel(this._documentNode);
     }
 
     public async getData(): Promise<RetrievedDocument> {

--- a/src/mongo/editors/MongoCollectionNodeEditor.ts
+++ b/src/mongo/editors/MongoCollectionNodeEditor.ts
@@ -7,7 +7,7 @@ import { IAzureParentNode, IAzureNode } from "vscode-azureextensionui";
 import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
-import { getLabel } from '../../utils/vscodeUtils';
+import { getNodeEditorLabel } from '../../utils/vscodeUtils';
 
 export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]> {
     private _collectionNode: IAzureParentNode<MongoCollectionTreeItem>;
@@ -16,7 +16,7 @@ export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]
     }
 
     public get label(): string {
-        return getLabel(this._collectionNode);
+        return getNodeEditorLabel(this._collectionNode);
     }
 
     public async getData(): Promise<IMongoDocument[]> {

--- a/src/mongo/editors/MongoCollectionNodeEditor.ts
+++ b/src/mongo/editors/MongoCollectionNodeEditor.ts
@@ -7,6 +7,7 @@ import { IAzureParentNode, IAzureNode } from "vscode-azureextensionui";
 import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
+import { getLabel } from '../../utils/vscodeUtils';
 
 export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]> {
     private _collectionNode: IAzureParentNode<MongoCollectionTreeItem>;
@@ -15,9 +16,7 @@ export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]
     }
 
     public get label(): string {
-        const databaseNode = this._collectionNode.parent;
-        const accountNode = databaseNode.parent;
-        return `${accountNode.treeItem.label}/${databaseNode.treeItem.label}/${this._collectionNode.treeItem.label}`;
+        return getLabel(this._collectionNode);
     }
 
     public async getData(): Promise<IMongoDocument[]> {

--- a/src/mongo/editors/MongoDocumentNodeEditor.ts
+++ b/src/mongo/editors/MongoDocumentNodeEditor.ts
@@ -6,7 +6,7 @@
 import { IAzureNode } from "vscode-azureextensionui";
 import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { ICosmosEditor } from "../../CosmosEditorManager";
-import { getLabel } from '../../utils/vscodeUtils';
+import { getNodeEditorLabel } from '../../utils/vscodeUtils';
 
 export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     private _documentNode: IAzureNode<MongoDocumentTreeItem>;
@@ -15,7 +15,7 @@ export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     }
 
     public get label(): string {
-        return getLabel(this._documentNode);
+        return getNodeEditorLabel(this._documentNode);
     }
 
     public async getData(): Promise<IMongoDocument> {

--- a/src/mongo/editors/MongoDocumentNodeEditor.ts
+++ b/src/mongo/editors/MongoDocumentNodeEditor.ts
@@ -6,6 +6,7 @@
 import { IAzureNode } from "vscode-azureextensionui";
 import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { ICosmosEditor } from "../../CosmosEditorManager";
+import { getLabel } from '../../utils/vscodeUtils';
 
 export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     private _documentNode: IAzureNode<MongoDocumentTreeItem>;
@@ -14,10 +15,7 @@ export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     }
 
     public get label(): string {
-        const collectionNode = this._documentNode.parent;
-        const databaseNode = collectionNode.parent;
-        const accountNode = databaseNode.parent;
-        return `${accountNode.treeItem.label}/${databaseNode.treeItem.label}/${collectionNode.treeItem.label}/${this._documentNode.treeItem.label}`;
+        return getLabel(this._documentNode);
     }
 
     public async getData(): Promise<IMongoDocument> {

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -6,6 +6,10 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
+import { IAzureNode } from 'vscode-azureextensionui';
+import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
+import { DocDBAccountTreeItem } from '../docdb/tree/DocDBAccountTreeItem';
+import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
 
 const outputChannel = vscode.window.createOutputChannel("Azure CosmosDB");
 
@@ -77,4 +81,16 @@ export function fetchNodeModule(moduleName: string) {
         return require(`${vscode.env.appRoot}/node_modules/${moduleName}`);
     } catch (err) { }
     return null;
+}
+
+export function getLabel(node: IAzureNode): string {
+    let labels = [node.treeItem.label];
+    while (node.parent) {
+        node = node.parent;
+        labels.unshift(node.treeItem.label);
+        if ((node.treeItem instanceof MongoAccountTreeItem) || (node.treeItem instanceof DocDBAccountTreeItemBase)) {
+            break;
+        }
+    }
+    return labels.join('/');
 }

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -8,7 +8,6 @@ import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
 import { IAzureNode } from 'vscode-azureextensionui';
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
-import { DocDBAccountTreeItem } from '../docdb/tree/DocDBAccountTreeItem';
 import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
 
 const outputChannel = vscode.window.createOutputChannel("Azure CosmosDB");

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
-import { IAzureNode } from 'vscode-azureextensionui';
+import { IAzureNode, IAzureTreeItem } from 'vscode-azureextensionui';
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
 import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
 
@@ -82,14 +82,18 @@ export function fetchNodeModule(moduleName: string) {
     return null;
 }
 
-export function getLabel(node: IAzureNode): string {
+export function getNodeEditorLabel(node: IAzureNode): string {
     let labels = [node.treeItem.label];
     while (node.parent) {
         node = node.parent;
         labels.unshift(node.treeItem.label);
-        if ((node.treeItem instanceof MongoAccountTreeItem) || (node.treeItem instanceof DocDBAccountTreeItemBase)) {
+        if (isAccountTreeItem(node.treeItem)) {
             break;
         }
     }
     return labels.join('/');
+}
+
+function isAccountTreeItem(treeItem: IAzureTreeItem): boolean {
+    return (treeItem instanceof MongoAccountTreeItem) || (treeItem instanceof DocDBAccountTreeItemBase);
 }


### PR DESCRIPTION
Noticed that the previous implementation was guilty with the strictNullCheck flag. 
Remove almost-duplicate code in those files to reduce number of offending lines. In the process, this function is strictNullCheck compliant. :) 