### PR TITLE
Restricting language services to local files

### DIFF
--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -2,50 +2,75 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as path from 'path';
-import * as nls from 'vscode-nls';
-import { ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+import * as path from "path";
+import * as nls from "vscode-nls";
+import { ExtensionContext } from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind
+} from "vscode-languageclient";
 
 const localize = nls.loadMessageBundle();
 
 export default class MongoDBLanguageClient {
+  public client: LanguageClient;
 
-	public client: LanguageClient;
+  constructor(context: ExtensionContext) {
+    // The server is implemented in node
+    let serverModule = context.asAbsolutePath(
+      path.join("out", "src", "mongo", "languageServer.js")
+    );
+    // The debug options for the server
+    let debugOptions = { execArgv: ["--nolazy", "--debug=6005", "--inspect"] };
 
-	constructor(context: ExtensionContext) {
-		// The server is implemented in node
-		let serverModule = context.asAbsolutePath(path.join('out', 'src', 'mongo', 'languageServer.js'));
-		// The debug options for the server
-		let debugOptions = { execArgv: ['--nolazy', '--debug=6005', '--inspect'] };
+    // If the extension is launch in debug mode the debug server options are use
+    // Otherwise the run options are used
+    let serverOptions: ServerOptions = {
+      run: {
+        module: serverModule,
+        transport: TransportKind.ipc,
+        options: debugOptions
+      },
+      debug: {
+        module: serverModule,
+        transport: TransportKind.ipc,
+        options: debugOptions
+      }
+    };
 
-		// If the extension is launch in debug mode the debug server options are use
-		// Otherwise the run options are used
-		let serverOptions: ServerOptions = {
-			run: { module: serverModule, transport: TransportKind.ipc, options: debugOptions },
-			debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
-		};
+    // Options to control the language client
+    let clientOptions: LanguageClientOptions = {
+      // Register the server for mongo javascript documents
+      documentSelector: [
+        { language: "mongo", scheme: "file" },
+        { language: "mongo", scheme: "untitled" }
+      ]
+    };
 
-		// Options to control the language client
-		let clientOptions: LanguageClientOptions = {
-			// Register the server for mongo javascript documents
-			documentSelector: ['mongo'],
-		};
+    // Create the language client and start the client.
+    this.client = new LanguageClient(
+      "mongo",
+      localize("mongo.server.name", "Mongo Language Server"),
+      serverOptions,
+      clientOptions
+    );
+    let disposable = this.client.start();
 
-		// Create the language client and start the client.
-		this.client = new LanguageClient('mongo', localize('mongo.server.name', 'Mongo Language Server'), serverOptions, clientOptions);
-		let disposable = this.client.start();
+    // Push the disposable to the context's subscriptions so that the
+    // client can be deactivated on extension deactivation
+    context.subscriptions.push(disposable);
+  }
 
-		// Push the disposable to the context's subscriptions so that the
-		// client can be deactivated on extension deactivation
-		context.subscriptions.push(disposable);
-	}
+  async connect(connectionString: string, databaseName: string) {
+    await this.client.sendRequest("connect", {
+      connectionString: connectionString,
+      databaseName: databaseName
+    });
+  }
 
-	async connect(connectionString: string, databaseName: string) {
-		await this.client.sendRequest('connect', { connectionString: connectionString, databaseName: databaseName });
-	}
-
-	disconnect(): void {
-		this.client.sendRequest('disconnect');
-	}
+  disconnect(): void {
+    this.client.sendRequest("disconnect");
+  }
 }

--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -2,75 +2,53 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as path from "path";
-import * as nls from "vscode-nls";
-import { ExtensionContext } from "vscode";
-import {
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-  TransportKind
-} from "vscode-languageclient";
+import * as path from 'path';
+import * as nls from 'vscode-nls';
+import { ExtensionContext } from 'vscode';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 
 const localize = nls.loadMessageBundle();
 
 export default class MongoDBLanguageClient {
-  public client: LanguageClient;
 
-  constructor(context: ExtensionContext) {
-    // The server is implemented in node
-    let serverModule = context.asAbsolutePath(
-      path.join("out", "src", "mongo", "languageServer.js")
-    );
-    // The debug options for the server
-    let debugOptions = { execArgv: ["--nolazy", "--debug=6005", "--inspect"] };
+	public client: LanguageClient;
 
-    // If the extension is launch in debug mode the debug server options are use
-    // Otherwise the run options are used
-    let serverOptions: ServerOptions = {
-      run: {
-        module: serverModule,
-        transport: TransportKind.ipc,
-        options: debugOptions
-      },
-      debug: {
-        module: serverModule,
-        transport: TransportKind.ipc,
-        options: debugOptions
-      }
-    };
+	constructor(context: ExtensionContext) {
+		// The server is implemented in node
+		let serverModule = context.asAbsolutePath(path.join('out', 'src', 'mongo', 'languageServer.js'));
+		// The debug options for the server
+		let debugOptions = { execArgv: ['--nolazy', '--debug=6005', '--inspect'] };
 
-    // Options to control the language client
-    let clientOptions: LanguageClientOptions = {
-      // Register the server for mongo javascript documents
-      documentSelector: [
-        { language: "mongo", scheme: "file" },
-        { language: "mongo", scheme: "untitled" }
-      ]
-    };
+		// If the extension is launch in debug mode the debug server options are use
+		// Otherwise the run options are used
+		let serverOptions: ServerOptions = {
+			run: { module: serverModule, transport: TransportKind.ipc, options: debugOptions },
+			debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
+		};
 
-    // Create the language client and start the client.
-    this.client = new LanguageClient(
-      "mongo",
-      localize("mongo.server.name", "Mongo Language Server"),
-      serverOptions,
-      clientOptions
-    );
-    let disposable = this.client.start();
+		// Options to control the language client
+		let clientOptions: LanguageClientOptions = {
+			// Register the server for mongo javascript documents
+			documentSelector: [
+				{ language: 'mongo', scheme: 'file' },
+				{ language: 'mongo', scheme: 'untitled' }
+			],
+		};
 
-    // Push the disposable to the context's subscriptions so that the
-    // client can be deactivated on extension deactivation
-    context.subscriptions.push(disposable);
-  }
+		// Create the language client and start the client.
+		this.client = new LanguageClient('mongo', localize('mongo.server.name', 'Mongo Language Server'), serverOptions, clientOptions);
+		let disposable = this.client.start();
 
-  async connect(connectionString: string, databaseName: string) {
-    await this.client.sendRequest("connect", {
-      connectionString: connectionString,
-      databaseName: databaseName
-    });
-  }
+		// Push the disposable to the context's subscriptions so that the
+		// client can be deactivated on extension deactivation
+		context.subscriptions.push(disposable);
+	}
 
-  disconnect(): void {
-    this.client.sendRequest("disconnect");
-  }
+	async connect(connectionString: string, databaseName: string) {
+		await this.client.sendRequest('connect', { connectionString: connectionString, databaseName: databaseName });
+	}
+
+	disconnect(): void {
+		this.client.sendRequest('disconnect');
+	}
 }


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](http://aka.ms/vsls) adding support for "guests" to receive remote language services for MongoDB, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with)