### PR TITLE
Mongo Editors:Use Ext JSON (EJSON) instead of JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -821,6 +821,7 @@
 		"fs-extra": "^4.0.2",
 		"gremlin": "^2.6.0",
 		"mongodb": "^2.2.25",
+		"mongodb-extended-json": "^1.10.0",
 		"ms-rest": "^2.2.1",
 		"request-light": "^0.2.0",
 		"socket.io": "^1.7.3",

--- a/src/mongo/editors/MongoCollectionNodeEditor.ts
+++ b/src/mongo/editors/MongoCollectionNodeEditor.ts
@@ -11,8 +11,10 @@ import { getNodeEditorLabel } from '../../utils/vscodeUtils';
 
 export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]> {
     private _collectionNode: IAzureParentNode<MongoCollectionTreeItem>;
+    private EJSON;
     constructor(collectionNode: IAzureParentNode<MongoCollectionTreeItem>) {
         this._collectionNode = collectionNode;
+        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -45,11 +47,11 @@ export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]
     }
 
     public convertFromString(data: string): IMongoDocument[] {
-        return JSON.parse(data);
+        return this.EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument[]): string {
-        return JSON.stringify(data, null, 2);
+        return this.EJSON.stringify(data, null, 2);
     }
 
 }

--- a/src/mongo/editors/MongoCollectionNodeEditor.ts
+++ b/src/mongo/editors/MongoCollectionNodeEditor.ts
@@ -8,13 +8,13 @@ import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTree
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
 import { getNodeEditorLabel } from '../../utils/vscodeUtils';
+// tslint:disable:no-var-requires
+const EJSON = require("mongodb-extended-json");
 
 export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]> {
     private _collectionNode: IAzureParentNode<MongoCollectionTreeItem>;
-    private EJSON;
     constructor(collectionNode: IAzureParentNode<MongoCollectionTreeItem>) {
         this._collectionNode = collectionNode;
-        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -47,11 +47,11 @@ export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]
     }
 
     public convertFromString(data: string): IMongoDocument[] {
-        return this.EJSON.parse(data);
+        return EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument[]): string {
-        return this.EJSON.stringify(data, null, 2);
+        return EJSON.stringify(data, null, 2);
     }
 
 }

--- a/src/mongo/editors/MongoDocumentNodeEditor.ts
+++ b/src/mongo/editors/MongoDocumentNodeEditor.ts
@@ -7,13 +7,13 @@ import { IAzureNode } from "vscode-azureextensionui";
 import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { getNodeEditorLabel } from '../../utils/vscodeUtils';
+// tslint:disable:no-var-requires
+const EJSON = require("mongodb-extended-json");
 
 export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     private _documentNode: IAzureNode<MongoDocumentTreeItem>;
-    private EJSON;
     constructor(collectionNode: IAzureNode<MongoDocumentTreeItem>) {
         this._documentNode = collectionNode;
-        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -33,10 +33,10 @@ export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     }
 
     public convertFromString(data: string): IMongoDocument {
-        return this.EJSON.parse(data);
+        return EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument): string {
-        return this.EJSON.stringify(data, null, 2);
+        return EJSON.stringify(data, null, 2);
     }
 }

--- a/src/mongo/editors/MongoDocumentNodeEditor.ts
+++ b/src/mongo/editors/MongoDocumentNodeEditor.ts
@@ -10,8 +10,10 @@ import { getNodeEditorLabel } from '../../utils/vscodeUtils';
 
 export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     private _documentNode: IAzureNode<MongoDocumentTreeItem>;
+    private EJSON;
     constructor(collectionNode: IAzureNode<MongoDocumentTreeItem>) {
         this._documentNode = collectionNode;
+        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -31,10 +33,10 @@ export class MongoDocumentNodeEditor implements ICosmosEditor<IMongoDocument> {
     }
 
     public convertFromString(data: string): IMongoDocument {
-        return JSON.parse(data);
+        return this.EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument): string {
-        return JSON.stringify(data, null, 2);
+        return this.EJSON.stringify(data, null, 2);
     }
 }

--- a/src/mongo/editors/MongoFindOneResultEditor.ts
+++ b/src/mongo/editors/MongoFindOneResultEditor.ts
@@ -13,12 +13,14 @@ export class MongoFindOneResultEditor implements ICosmosEditor<IMongoDocument> {
     private _collectionName: string;
     private _originalDocument: IMongoDocument;
     private _tree: AzureTreeDataProvider;
+    private EJSON;
 
     constructor(databaseNode: IAzureParentNode<MongoDatabaseTreeItem>, collectionName: string, data: string, tree: AzureTreeDataProvider) {
         this._databaseNode = databaseNode;
         this._collectionName = collectionName;
         this._originalDocument = JSON.parse(data);
         this._tree = tree;
+        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -45,11 +47,11 @@ export class MongoFindOneResultEditor implements ICosmosEditor<IMongoDocument> {
     }
 
     public convertFromString(data: string): IMongoDocument {
-        return JSON.parse(data);
+        return this.EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument): string {
-        return JSON.stringify(data, null, 2);
+        return this.EJSON.stringify(data, null, 2);
     }
 
 }

--- a/src/mongo/editors/MongoFindOneResultEditor.ts
+++ b/src/mongo/editors/MongoFindOneResultEditor.ts
@@ -7,20 +7,20 @@ import { IAzureParentNode, IAzureNode, AzureTreeDataProvider } from "vscode-azur
 import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { MongoDatabaseTreeItem } from "../tree/MongoDatabaseTreeItem";
+// tslint:disable:no-var-requires
+const EJSON = require("mongodb-extended-json");
 
 export class MongoFindOneResultEditor implements ICosmosEditor<IMongoDocument> {
     private _databaseNode: IAzureParentNode<MongoDatabaseTreeItem>;
     private _collectionName: string;
     private _originalDocument: IMongoDocument;
     private _tree: AzureTreeDataProvider;
-    private EJSON;
 
     constructor(databaseNode: IAzureParentNode<MongoDatabaseTreeItem>, collectionName: string, data: string, tree: AzureTreeDataProvider) {
         this._databaseNode = databaseNode;
         this._collectionName = collectionName;
         this._originalDocument = JSON.parse(data);
         this._tree = tree;
-        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -47,11 +47,11 @@ export class MongoFindOneResultEditor implements ICosmosEditor<IMongoDocument> {
     }
 
     public convertFromString(data: string): IMongoDocument {
-        return this.EJSON.parse(data);
+        return EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument): string {
-        return this.EJSON.stringify(data, null, 2);
+        return EJSON.stringify(data, null, 2);
     }
 
 }

--- a/src/mongo/editors/MongoFindResultEditor.ts
+++ b/src/mongo/editors/MongoFindResultEditor.ts
@@ -17,11 +17,13 @@ export class MongoFindResultEditor implements ICosmosEditor<IMongoDocument[]> {
     private _command: MongoCommand;
     private _collectionTreeItem: MongoCollectionTreeItem;
     private _tree: AzureTreeDataProvider;
+    private EJSON;
 
     constructor(databaseNode: IAzureParentNode<MongoDatabaseTreeItem>, command: MongoCommand, tree: AzureTreeDataProvider) {
         this._databaseNode = databaseNode;
         this._command = command;
         this._tree = tree;
+        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -54,11 +56,11 @@ export class MongoFindResultEditor implements ICosmosEditor<IMongoDocument[]> {
     }
 
     public convertFromString(data: string): IMongoDocument[] {
-        return JSON.parse(data);
+        return this.EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument[]): string {
-        return JSON.stringify(data, null, 2);
+        return this.EJSON.stringify(data, null, 2);
     }
 
 }

--- a/src/mongo/editors/MongoFindResultEditor.ts
+++ b/src/mongo/editors/MongoFindResultEditor.ts
@@ -11,19 +11,19 @@ import { ICosmosEditor } from "../../CosmosEditorManager";
 import { MongoDatabaseTreeItem } from "../tree/MongoDatabaseTreeItem";
 import { MongoCommand } from "../MongoCommand";
 import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
+// tslint:disable:no-var-requires
+const EJSON = require("mongodb-extended-json");
 
 export class MongoFindResultEditor implements ICosmosEditor<IMongoDocument[]> {
     private _databaseNode: IAzureParentNode<MongoDatabaseTreeItem>;
     private _command: MongoCommand;
     private _collectionTreeItem: MongoCollectionTreeItem;
     private _tree: AzureTreeDataProvider;
-    private EJSON;
 
     constructor(databaseNode: IAzureParentNode<MongoDatabaseTreeItem>, command: MongoCommand, tree: AzureTreeDataProvider) {
         this._databaseNode = databaseNode;
         this._command = command;
         this._tree = tree;
-        this.EJSON = require('mongodb-extended-json');
     }
 
     public get label(): string {
@@ -56,11 +56,11 @@ export class MongoFindResultEditor implements ICosmosEditor<IMongoDocument[]> {
     }
 
     public convertFromString(data: string): IMongoDocument[] {
-        return this.EJSON.parse(data);
+        return EJSON.parse(data);
     }
 
     public convertToString(data: IMongoDocument[]): string {
-        return this.EJSON.stringify(data, null, 2);
+        return EJSON.stringify(data, null, 2);
     }
 
 }


### PR DESCRIPTION
Fixes #564 
Fixes #534 

Tested: 
ObjectID, nested ObjectID array, ISODate, sampleTime, minKey, MaxKey, undefined, numberLong, numberDecimal.
More types [here](https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations)
