### PR TITLE
Open Stored Procedure once created. Fixes #578

### DIFF
--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -39,7 +39,7 @@ export function registerDocDBCommands(actionHandler: AzureActionHandler, tree: A
             node = <IAzureParentNode>await tree.showNodePicker(DocDBDocumentsTreeItem.contextValue);
         }
         let childNode = await node.createChild();
-        await commands.executeCommand("cosmosDB.openDocument", childNode);
+        await commands.executeCommand("cosmosDB.openStoredProcedure", childNode);
 
     });
     actionHandler.registerCommand('cosmosDB.deleteDocDBDatabase', async (node?: IAzureNode) => {


### PR DESCRIPTION
Called the wrong function in execute command. 

I let open Stored Procedure be a separate function since the open Document command is now starting to have many if else's, and I didn't want to add to the code smell. 