### PR TITLE
MongoCollectionTreeItem: fix findOne's result to recognize ObjectIDs

### DIFF
--- a/src/mongo/editors/MongoFindOneResultEditor.ts
+++ b/src/mongo/editors/MongoFindOneResultEditor.ts
@@ -19,7 +19,7 @@ export class MongoFindOneResultEditor implements ICosmosEditor<IMongoDocument> {
     constructor(databaseNode: IAzureParentNode<MongoDatabaseTreeItem>, collectionName: string, data: string, tree: AzureTreeDataProvider) {
         this._databaseNode = databaseNode;
         this._collectionName = collectionName;
-        this._originalDocument = JSON.parse(data);
+        this._originalDocument = EJSON.parse(data);
         this._tree = tree;
     }
 

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -12,6 +12,8 @@ import { Collection, Cursor, ObjectID, InsertOneWriteOpResult, BulkWriteOpResult
 import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
 import { DefaultBatchSize } from '../../constants';
 import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';
+// tslint:disable:no-var-requires
+const EJSON = require("mongodb-extended-json");
 
 export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 	public static contextValue: string = "MongoCollection";
@@ -181,7 +183,7 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 		} else {
 			return Promise.reject(new Error("Too many arguments passed to findOne."));
 		}
-		return this.stringify(result);
+		return EJSON.stringify(result, null, '\t');
 	}
 
 	private insert(document: Object): Thenable<string> {

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -183,7 +183,7 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 		} else {
 			return Promise.reject(new Error("Too many arguments passed to findOne."));
 		}
-		// findOne is the only command in this file requiring EJSON support.
+		// findOne is the only command in this file whose output requires EJSON support.
 		// Hence that's the only function which uses EJSON.stringify rather than this.stringify.
 		return EJSON.stringify(result, null, '\t');
 	}
@@ -273,12 +273,7 @@ function reportProgress<T>(promise: Thenable<T>, title: string): Thenable<T> {
 // tslint:disable-next-line:no-any
 function parseJSContent(content: string): any {
 	try {
-		const sandbox = {};
-		// tslint:disable-next-line:insecure-random
-		const key = 'parse' + Math.floor(Math.random() * 1000000);
-		sandbox[key] = {};
-		vm.runInNewContext(key + '=' + content, sandbox);
-		return sandbox[key];
+		return EJSON.parse(content);
 	} catch (error) {
 		throw error.message;
 	}

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -183,6 +183,8 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 		} else {
 			return Promise.reject(new Error("Too many arguments passed to findOne."));
 		}
+		// findOne is the only command in this file requiring EJSON support.
+		// Hence that's the only function which uses EJSON.stringify rather than this.stringify.
 		return EJSON.stringify(result, null, '\t');
 	}
 

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as vm from 'vm';
 import * as path from 'path';
 import * as _ from 'underscore';
 import * as util from '../../utils/vscodeUtils';


### PR DESCRIPTION
Fixes #608 

The beast of JSON.parse runs deep. :P  findOne is the only command which uses this `MongoCollectionTreeItem` while also requiring EJSON support. Hence that's the only function which uses `EJSON.stringify` rather than `this.stringify`. 