### PR TITLE
Handle unexpected defaultExp values when labelling account node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "azure-cosmosdb" extension will be documented in this file.
 
+## 0.7.1 - 2018-05-09
+### Fixed
+[Bug fixed](https://github.com/Microsoft/vscode-cosmosdb/issues/623)
+
 ## 0.7.0 - 2018-05-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cosmosdb",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-azuretools",
 	"displayName": "Azure Cosmos DB",

--- a/src/experiences.ts
+++ b/src/experiences.ts
@@ -21,9 +21,8 @@ export enum DBAccountKind {
 export function getExperience(api: API): Experience {
     let info = experiencesMap.get(api);
     if (!info) {
-        throw new RangeError("Unexpected Experience value");
+        info = { api: api, shortName: api, longName: api, kind: DBAccountKind.GlobalDocumentDB };
     }
-
     return info;
 }
 

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -227,8 +227,8 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
                     // Default to Mongo if the value is a string for the sake of backwards compatiblity
                     // (Mongo was originally the only account type that could be attached)
                     id = account;
-                    label = `${account} (${getExperience(api).shortName})`;
                     api = API.MongoDB;
+                    label = `${account} (${getExperience(api).shortName})`;
                     isEmulator = false;
                 } else {
                     id = (<IPersistedAccount>account).id;

--- a/src/tree/CosmosDBAccountProvider.ts
+++ b/src/tree/CosmosDBAccountProvider.ts
@@ -72,19 +72,10 @@ export class CosmosDBAccountProvider implements IChildProvider {
     }
 
     private async initChild(client: CosmosDBManagementClient, databaseAccount: DatabaseAccount): Promise<IAzureTreeItem> {
-        const defaultExperience = <API>databaseAccount.tags.defaultExperience;
+        const defaultExperience = <API>(databaseAccount && databaseAccount.tags && databaseAccount.tags.defaultExperience);
         const resourceGroup: string = azureUtils.getResourceGroupFromId(databaseAccount.id);
-        let accountKind;
-        try {
-            accountKind = getExperience(defaultExperience).shortName;
-        } catch (err) {
-            if (err instanceof RangeError) {
-                accountKind = defaultExperience;
-            } else {
-                throw err;
-            }
-        }
-        const label: string = `${databaseAccount.name} (${accountKind})`;
+        const accountKind = getExperience(defaultExperience).shortName;
+        const label: string = databaseAccount.name + (accountKind ? `(${accountKind})` : ``);
         const isEmulator: boolean = false;
         if (defaultExperience === "MongoDB") {
             const result = await client.databaseAccounts.listConnectionStrings(resourceGroup, databaseAccount.name);

--- a/src/tree/CosmosDBAccountProvider.ts
+++ b/src/tree/CosmosDBAccountProvider.ts
@@ -74,7 +74,17 @@ export class CosmosDBAccountProvider implements IChildProvider {
     private async initChild(client: CosmosDBManagementClient, databaseAccount: DatabaseAccount): Promise<IAzureTreeItem> {
         const defaultExperience = <API>databaseAccount.tags.defaultExperience;
         const resourceGroup: string = azureUtils.getResourceGroupFromId(databaseAccount.id);
-        const label: string = `${databaseAccount.name} (${getExperience(defaultExperience).shortName})`;
+        let accountKind;
+        try {
+            accountKind = getExperience(defaultExperience).shortName;
+        } catch (err) {
+            if (err instanceof RangeError) {
+                accountKind = defaultExperience;
+            } else {
+                throw err;
+            }
+        }
+        const label: string = `${databaseAccount.name} (${accountKind})`;
         const isEmulator: boolean = false;
         if (defaultExperience === "MongoDB") {
             const result = await client.databaseAccounts.listConnectionStrings(resourceGroup, databaseAccount.name);


### PR DESCRIPTION
Redoing #624 due to branches being wrong. 