### PR TITLE
Show errors in the error list

### DIFF
--- a/package.json
+++ b/package.json
@@ -792,8 +792,9 @@
 		"lint": "tslint --project tsconfig.json -t verbose",
 		"lint-fix": "tslint --project tsconfig.json -t verbose --fix",
 		"postinstall": "node ./node_modules/vscode/bin/install",
-		"test": "node ./node_modules/vscode/bin/test",
-		"update-grammar": "antlr4ts -visitor ./grammar/mongo.g4 -o ./src/mongo/grammar"
+		"test": "npm run build && node ./node_modules/vscode/bin/test",
+		"update-grammar": "antlr4ts -visitor ./grammar/mongo.g4 -o ./src/mongo/grammar",
+		"all": "npm i && npm run lint && npm test"
 	},
 	"devDependencies": {
 		"@types/copy-paste": "^1.1.30",

--- a/src/mongo/MongoCommand.ts
+++ b/src/mongo/MongoCommand.ts
@@ -16,6 +16,6 @@ export interface MongoCommand {
 }
 
 interface errorDescription {
-    position: vscode.Position;
-    text: string;
+    range: vscode.Range;
+    message: string;
 }

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -22,8 +22,8 @@ import { ErrorNode } from 'antlr4ts/tree/ErrorNode';
 const output = vscodeUtil.getOutputChannel();
 const notInScrapbookMessage = "You must have a MongoDB scrapbook (*.mongo) open to run a MongoDB command.";
 
-export function getAllErrorsFromActiveEditor(): vscode.Diagnostic[] {
-	let commands = getAllCommandsFromActiveEditor();
+export function getAllErrorsFromTextDocument(document: vscode.TextDocument): vscode.Diagnostic[] {
+	let commands = getAllCommandsFromTextDocument(document);
 	let errors: vscode.Diagnostic[] = [];
 	for (let command of commands) {
 		for (let error of (command.errors || [])) {

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -18,7 +18,7 @@ import { reporter } from "../utils/telemetry";
 import { MongoCodeLensProvider } from "./services/MongoCodeLensProvider";
 import { ext } from "../extensionVariables";
 import { executeCommandFromText, executeCommandFromActiveEditor, executeAllCommandsFromActiveEditor, getAllErrorsFromTextDocument } from "./MongoScrapbook";
-import TelemetryReporter from "../../../vscode-azuretools/ui/node_modules/vscode-extension-telemetry";
+import TelemetryReporter from "vscode-extension-telemetry";
 
 const connectedDBKey: string = 'ms-azuretools.vscode-cosmosdb.connectedDB';
 let diagnosticsCollection: vscode.DiagnosticCollection;

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -181,7 +181,7 @@ function setUpErrorReporting(handler: AzureActionHandler, reporter: TelemetryRep
         'vscode.workspace.onDidChangeTextDocument',
         vscode.workspace.onDidChangeTextDocument,
         async function (this: IActionContext, event: vscode.TextDocumentChangeEvent) {
-            // Always suppress success telemetry - even happens on every keystroke
+            // Always suppress success telemetry - event happens on every keystroke
             this.suppressTelemetry = true;
 
             updateErrorsInScrapbook(this, event.document);

--- a/test/mongoGetCommand.test.ts
+++ b/test/mongoGetCommand.test.ts
@@ -20,7 +20,7 @@ function testParse(text: string, expected: { collection: string, name: string, a
 
         if (errors && errors.firstErrorText) {
             assert.equal((command.errors || []).length > 0, true, "Expected at least one error");
-            assert.equal(command.errors[0].text, errors.firstErrorText, "First error text was incorrect")
+            assert.equal(command.errors[0].message, errors.firstErrorText, "First error text was incorrect")
         } else {
             assert.equal((command.errors || []).length, 0, "Expected no errors");
         }
@@ -304,9 +304,9 @@ suite("scrapbook parsing Tests", () => {
         let text = `db.test1.insertMany(${arg0}   ${arg1})`;
         let command = getCommandFromText(text, new Position(0, 0));
         const err = command.errors[0];
-        assert.deepEqual(err.text, "{");
-        assert.deepEqual(err.position.line, 0);
-        assert.deepEqual(err.position.character, 61);
+        assert.deepEqual(err.message, "{");
+        assert.deepEqual(err.range.start.line, 0);
+        assert.deepEqual(err.range.start.character, 61);
     });
     test("test function call with erroneous syntax: missing comma, parameters separated with newline", () => {
         let arg0 = `{"name": {"First" : "a", "Last":"b"} }`;
@@ -314,26 +314,26 @@ suite("scrapbook parsing Tests", () => {
         let text = `db.test1.insertMany(${arg0} \n  ${arg1})`;
         let command = getCommandFromText(text, new Position(0, 0));
         const err = command.errors[0];
-        assert.deepEqual(err.text, "{");
-        assert.deepEqual(err.position.line, 1);
-        assert.deepEqual(err.position.character, 2);
+        assert.deepEqual(err.message, "{");
+        assert.deepEqual(err.range.start.line, 1);
+        assert.deepEqual(err.range.start.character, 2);
     });
     test("test function call with erroneous syntax: missing double quote", () => {
         let arg0 = `{name": {"First" : "a", "Last":"b"} }`;
         let text = `db.test1.insertMany(${arg0})`;
         let command = getCommandFromText(text, new Position(0, 0));
         const err = command.errors[0];
-        assert.deepEqual(err.text, "name");
-        assert.deepEqual(err.position.line, 0);
-        assert.deepEqual(err.position.character, 21);
+        assert.deepEqual(err.message, "name");
+        assert.deepEqual(err.range.start.line, 0);
+        assert.deepEqual(err.range.start.character, 21);
     });
     test("test function call with erroneous syntax: missing opening brace", () => {
         let arg0 = `"name": {"First" : "a", "Last":"b"} }`;
         let text = `db.test1.insertMany(${arg0})`;
         let command = getCommandFromText(text, new Position(0, 0));
         const err = command.errors[0];
-        assert.deepEqual(err.text, ":");
-        assert.deepEqual(err.position.line, 0);
-        assert.deepEqual(err.position.character, 26);
+        assert.deepEqual(err.message, ":");
+        assert.deepEqual(err.range.start.line, 0);
+        assert.deepEqual(err.range.start.character, 26);
     });
 });


### PR DESCRIPTION
This displays scrapbook parse errors in the Errors pane.  Right now it's pretty ugly due to various error-handling issues, but I'm enabling it now because it makes it a lot easier to see those other problems.  We can easily disable before shipping if we need to but hopefully the others will be fixed first.

![image](https://user-images.githubusercontent.com/6913354/40944505-e8cbe154-6809-11e8-9781-8bc8778d0585.png)

Depends on https://github.com/Microsoft/vscode-azuretools/pull/189