### PR TITLE
Allow valid MongoDB connection strings

### DIFF
--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -23,6 +23,7 @@ interface IPersistedAccount {
 }
 
 export const AttachedAccountSuffix: string = 'Attached';
+export const MONGO_CONNECTION_EXPECTED: string = 'Connection string must start with "mongodb://" or "mongodb+srv://"';
 
 export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
     public static contextValue: string = 'cosmosDBAttachedAccounts';
@@ -306,12 +307,11 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
         await this._globalState.update(this._serviceName, JSON.stringify(value));
     }
 
-    private static validateMongoConnectionString(value: string): string | undefined {
-        if (!value || !value.startsWith('mongodb://')) {
-            return 'Connection string must start with "mongodb://"';
-        } else {
+    static validateMongoConnectionString(value: string): string | undefined {
+        if (value && value.match(/^mongodb(\+srv)?:\/\//)) {
             return undefined;
         }
+        return MONGO_CONNECTION_EXPECTED;
     }
 
     private static validateDocDBConnectionString(value: string): string | undefined {

--- a/test/attachedAccountsTreeItem.test.ts
+++ b/test/attachedAccountsTreeItem.test.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+
+import { AttachedAccountsTreeItem, MONGO_CONNECTION_EXPECTED } from '../src/tree/AttachedAccountsTreeItem';
+
+function assertConnectionValid(connectionString: string, expected: string | undefined) {
+    const actual = AttachedAccountsTreeItem.validateMongoConnectionString(connectionString);
+    assert.equal(actual, expected);
+}
+
+
+suite(`attachedAccountsTreeItem`, () => {
+    suite(`validateDocDBConnectionString`, () => {
+        // Connection strings follow the following format (https://docs.mongodb.com/manual/reference/connection-string/):
+        // mongodb[+srv]://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+        test('allows "mongodb://"', () => assertConnectionValid(`mongodb://your-mongo.documents.azure.com:10255`, undefined));
+
+        test('allows "mongodb+srv://"', () => assertConnectionValid(`mongodb+srv://usr:pwd@mongodb.net:27017`, undefined));
+
+        test('rejects bad prefix', () => assertConnectionValid(`http://localhost/`, MONGO_CONNECTION_EXPECTED));
+
+        test('rejects null', () => assertConnectionValid(null, MONGO_CONNECTION_EXPECTED));
+    });
+});
+


### PR DESCRIPTION
Allow valid MongoDB connection string when attaching to a server.

Current code disallowed a connection string of the form `mongodb+srv://yourhost/`, even though it is a valid [MongoDB connection](https://docs.mongodb.com/manual/reference/connection-string/#standard-connection-string-format) string.

This pull request expands the validation code to allow connections that start with both `mongodb://` and `mongodb+srv://`.

Other places in the code base account for and correctly parse the +srv variant, such as the code that parses database name from the connection URL.

