### PR TITLE
Mongo- Doc&Coll - Remove ObjectID constructor from update operation

### DIFF
--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -36,7 +36,7 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 		const operations = documents.map((document) => {
 			return {
 				updateOne: {
-					filter: { _id: new ObjectID(document._id) },
+					filter: { _id: document._id },
 					update: _.omit(document, '_id'),
 					upsert: false
 				}

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as _ from 'underscore';
 import * as vscodeUtils from '../../utils/vscodeUtils';
-import { Collection, Cursor, ObjectID, InsertOneWriteOpResult, BulkWriteOpResultObject, CollectionInsertManyOptions } from 'mongodb';
+import { Collection, Cursor, InsertOneWriteOpResult, BulkWriteOpResultObject, CollectionInsertManyOptions } from 'mongodb';
 import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
 import { DefaultBatchSize } from '../../constants';
 import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';

--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -67,7 +67,7 @@ export class MongoDocumentTreeItem implements IAzureTreeItem {
         if (!newDocument["_id"]) {
             throw new Error(`The "_id" field is required to update a document.`);
         }
-        const filter: object = { _id: new ObjectID(newDocument._id) };
+        const filter: object = { _id: newDocument._id };
         const result: UpdateWriteOpResult = await collection.updateOne(filter, _.omit(newDocument, '_id'));
         if (result.modifiedCount != 1) {
             throw new Error(`Failed to update document with _id '${newDocument._id}'.`);


### PR DESCRIPTION
Fixes #534, #664, #663 (dupes)


Case I've Tested : 
Create these documents in the portal - non ObjectID _id, _id being a number, _id is a string, _id is a boolean
Create standard documents in the portal (_id being an ObjectID). 
Perform collection and document updates. 

