### PR TITLE
Fix comparing explicitly against null

### DIFF
--- a/src/mongo/grammar/visitors.ts
+++ b/src/mongo/grammar/visitors.ts
@@ -72,7 +72,7 @@ export class MongoVisitor<T> implements mongoVisitor<T> {
 	}
 
 	protected aggregateResult(aggregate: T, nextResult: T): T {
-		return nextResult === null ? aggregate : nextResult;
+		return !nextResult ? aggregate : nextResult;
 	}
 
 	shouldVisitNextChild(_node, _currentResult: T): boolean {

--- a/src/mongo/services/completionItemProvider.ts
+++ b/src/mongo/services/completionItemProvider.ts
@@ -385,7 +385,7 @@ export class CompletionItemsVisitor extends MongoVisitor<Promise<CompletionItem[
 		if (parserRuleContext instanceof ParserRuleContext) {
 			let startToken = parserRuleContext.start;
 			let stopToken = parserRuleContext.stop;
-			if (stopToken === null || startToken.type === mongoParser.mongoParser.EOF) {
+			if (!stopToken || startToken.type === mongoParser.mongoParser.EOF) {
 				stopToken = startToken;
 			}
 
@@ -403,7 +403,7 @@ export class CompletionItemsVisitor extends MongoVisitor<Promise<CompletionItem[
 	private createRangeAfter(parserRuleContext: ParseTree): Range {
 		if (parserRuleContext instanceof ParserRuleContext) {
 			let stopToken = parserRuleContext.stop;
-			if (stopToken === null) {
+			if (!stopToken) {
 				stopToken = parserRuleContext.start;
 			}
 

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -7,7 +7,7 @@ export namespace azureUtils {
     export function getResourceGroupFromId(id: string): string {
         const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/(.*)\/(.*)/);
 
-        if (matches === null || matches.length < 3) {
+        if (!matches || matches.length < 3) {
             throw new Error('Invalid Azure Resource Id');
         }
 
@@ -16,7 +16,7 @@ export namespace azureUtils {
     export function getAccountNameFromId(id: string): string {
         const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/(.*)\/databaseAccounts\/(.*)/);
 
-        if (matches === null || matches.length < 5) {
+        if (!matches || matches.length < 5) {
             throw new Error('Invalid Azure Resource Id');
         }
 


### PR DESCRIPTION
This was causing some exceptions in the language server (i.e. a value was undefined but we were checking it against null).  It's possible these were caused by the mismatched grammar, but either way this is a bad idea.