### PR TITLE
[Delayed] Improve error-handling of Mongo shell commands

### DIFF
--- a/src/mongo/editors/MongoFindOneResultEditor.ts
+++ b/src/mongo/editors/MongoFindOneResultEditor.ts
@@ -40,7 +40,7 @@ export class MongoFindOneResultEditor implements ICosmosEditor<IMongoDocument> {
             node.refresh();
         } else {
             // If the node isn't cached already, just update it to Mongo directly (without worrying about updating the tree)
-            const db = await this._databaseNode.treeItem.getDb();
+            const db = await this._databaseNode.treeItem.connectToDb();
             result = await MongoDocumentTreeItem.update(db.collection(this._collectionName), newDocument);
         }
         return result;

--- a/src/mongo/editors/MongoFindResultEditor.ts
+++ b/src/mongo/editors/MongoFindResultEditor.ts
@@ -33,7 +33,7 @@ export class MongoFindResultEditor implements ICosmosEditor<IMongoDocument[]> {
 
     public async getData(): Promise<IMongoDocument[]> {
         const dbTreeItem: MongoDatabaseTreeItem = this._databaseNode.treeItem;
-        const db = await dbTreeItem.getDb();
+        const db = await dbTreeItem.connectToDb();
         const collection: Collection = db.collection(this._command.collection);
         // NOTE: Intentionally creating a _new_ tree item rather than searching for a cached node in the tree because
         // the executed 'find' command could have a filter or projection that is not handled by a cached tree node

--- a/src/mongo/shell.ts
+++ b/src/mongo/shell.ts
@@ -5,7 +5,7 @@
 import * as cp from 'child_process';
 import * as os from 'os';
 import { IDisposable, toDisposable } from '../utils/vscodeUtils';
-import { EventEmitter, window } from 'vscode';
+import { EventEmitter } from 'vscode';
 import { ext } from '../extensionVariables';
 
 type CommandResult = {

--- a/src/mongo/shell.ts
+++ b/src/mongo/shell.ts
@@ -69,7 +69,7 @@ export class Shell {
 				buffers = [];
 				this.fireOnResult({ stringResult: result });
 			} else {
-				buffers.push(data); // asdf was buffer
+				buffers.push(data);
 			}
 		});
 

--- a/src/mongo/shell.ts
+++ b/src/mongo/shell.ts
@@ -94,6 +94,9 @@ export class Shell {
 		try {
 			this.mongoShell.stdin.write(script, 'utf8');
 			this.mongoShell.stdin.write(os.EOL);
+
+			// Write out a unique number into stdin as a sentinel. We will know we've seen the end of the
+			//   result data when we get this number back out at the end of the data.
 			this.mongoShell.stdin.write(executionId, 'utf8');
 			this.mongoShell.stdin.write(os.EOL);
 		} catch (error) {

--- a/src/mongo/shell.ts
+++ b/src/mongo/shell.ts
@@ -23,12 +23,12 @@ export class Shell {
 	private onResult: EventEmitter<CommandResult> = new EventEmitter<CommandResult>();
 
 	public static create(execPath: string, connectionString: string): Promise<Shell> {
-		return new Promise((c, e) => {
+		return new Promise((resolve, reject) => {
 			try {
 				const shellProcess = cp.spawn(execPath, ['--quiet', connectionString]);
-				return c(new Shell(execPath, shellProcess));
+				return resolve(new Shell(execPath, shellProcess));
 			} catch (error) {
-				e(`Error while creating mongo shell with path '${execPath}': ${error}`);
+				reject(`Error while creating mongo shell with path '${execPath}': ${error}`);
 			}
 		});
 	}

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -102,8 +102,11 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 		return new MongoDocumentTreeItem(newDocument, this.collection);
 	}
 
+	/**
+	 * Tries to execute the command directly via an SDK call if possible, otherwise returns undefined instead of a Promise
+	 */
 	//tslint:disable:cyclomatic-complexity
-	executeCommand(name: string, args?: string[]): Thenable<string> {
+	public tryExecuteCommandDirectly(name: string, args?: string[]): Thenable<string> | undefined {
 		try {
 			if (name === 'findOne') {
 				return reportProgress(this.findOne(args ? args.map(parseJSContent) : undefined), 'Finding');
@@ -140,7 +143,8 @@ export class MongoCollectionTreeItem implements IAzureParentTreeItem {
 				if (name === 'count') {
 					return reportProgress(this.count(argument ? parseJSContent(argument) : undefined), 'Counting');
 				}
-				return null;
+
+				return undefined;
 			}
 		} catch (error) {
 			return Promise.resolve(error);


### PR DESCRIPTION
Part of #508, #613, #687.  With this change, we now see the true error that's occurring on the process stdout:

> db.version()
> Error: FailedToParse: Bad digit "C" while parsing C2y6yDjf5
> try 'c:\Program Files\MongoDB\Server\3.6\bin\mongo.exe --help' for more information
