### PR TITLE
Fix connecting to emulator via Mongo shell

### DIFF
--- a/src/mongo/shell.ts
+++ b/src/mongo/shell.ts
@@ -15,10 +15,16 @@ export class Shell {
 
 	private onResult: EventEmitter<{ exitCode, result, stderr, code?: string, message?: string }> = new EventEmitter<{ exitCode, result, stderr, code?: string, message?: string }>();
 
-	public static create(execPath: string, connectionString: string): Promise<Shell> {
+	public static create(execPath: string, connectionString: string, isEmulator: boolean): Promise<Shell> {
 		return new Promise((c, e) => {
 			try {
-				const shellProcess = cp.spawn(execPath, ['--quiet', connectionString]);
+				let args = ['--quiet', connectionString];
+				if (isEmulator) {
+					// Without this the connection will fail due to the self-signed DocDB certificate
+					args.push("--ssl");
+					args.push("--sslAllowInvalidCertificates");
+				}
+				const shellProcess = cp.spawn(execPath, args);
 				return c(new Shell(execPath, shellProcess));
 			} catch (error) {
 				e(`Error while creating mongo shell with path '${execPath}': ${error}`);

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -64,7 +64,7 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
             }
             return databases
                 .filter((database: IDatabaseInfo) => !(database.name && database.name.toLowerCase() === "admin" && database.empty)) // Filter out the 'admin' database if it's empty
-                .map(database => new MongoDatabaseTreeItem(database.name, this.connectionString, node.id));
+                .map(database => new MongoDatabaseTreeItem(database.name, this.connectionString, this.isEmulator, node.id));
 
         } catch (error) {
             return [{
@@ -95,7 +95,7 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
             if (collectionName) {
                 showCreatingNode(databaseName);
 
-                const databaseTreeItem = new MongoDatabaseTreeItem(databaseName, this.connectionString, node.id);
+                const databaseTreeItem = new MongoDatabaseTreeItem(databaseName, this.connectionString, this.isEmulator, node.id);
                 await databaseTreeItem.createCollection(collectionName);
                 return databaseTreeItem;
             }

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -163,7 +163,8 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
             }
             if (port) {
                 if (defaultExperience.api === API.MongoDB) {
-                    connectionString = `mongodb://localhost:C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==@localhost:${port}?ssl=true`;
+                    // Mongo shell doesn't parse passwords with slashes, so we need to URI encode it
+                    connectionString = `mongodb://localhost:${encodeURIComponent('C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==')}@localhost:${port}/?ssl=true`;
                 }
                 else {
                     connectionString = `AccountEndpoint=https://localhost:${port}/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;`;


### PR DESCRIPTION
Related to #696, fixes #687, fixes #613, fixes #508

1) Use a URI-encoded form of the password in the emulator connection string
2) Tell shell to ignore invalid certificates for emulator (since the emulator certificate is self-signed)