### PR TITLE
Perform null check before assigning functionCallContext name.

### DIFF
--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -201,7 +201,7 @@ class FindMongoCommandsVisitor extends MongoVisitor<MongoCommand[]> {
 	}
 
 	visitFunctionCall(ctx: mongoParser.FunctionCallContext): MongoCommand[] {
-		if (ctx.parent instanceof mongoParser.CommandContext) {
+		if (ctx.parent instanceof mongoParser.CommandContext && ctx._FUNCTION_NAME) {
 			this.commands[this.commands.length - 1].name = (ctx._FUNCTION_NAME && ctx._FUNCTION_NAME.text) || "";
 		}
 		return super.visitFunctionCall(ctx);

--- a/test/mongoGetCommand.test.ts
+++ b/test/mongoGetCommand.test.ts
@@ -696,13 +696,12 @@ suite("scrapbook parsing Tests", () => {
     });
 
 
-    //This test will fail. See https://github.com/Microsoft/vscode-cosmosdb/issues/689
-    // test("test incomplete function call - replicate user typing - no function call yet", () => {
-    //     let text = `db.test1.`;
-    //     let command = getCommandFromTextAtLocation(text, new Position(0, 0));
-    //     assert.deepEqual(command.argumentObjects, undefined);
-    //     assert.deepEqual(command.collection, "test1");
-    // });
+    test("test incomplete function call - replicate user typing - no function call yet", () => {
+        let text = `db.test1.`;
+        let command = getCommandFromTextAtLocation(text, new Position(0, 0));
+        assert.deepEqual(command.argumentObjects, []);
+        assert.deepEqual(command.collection, "test1");
+    });
 
 
 });


### PR DESCRIPTION
Fixes #689 