### PR TITLE
Add user agent to docdb and mongo calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -853,7 +853,7 @@
 		"socket.io": "^1.7.3",
 		"socket.io-client": "^1.7.3",
 		"underscore": "^1.8.3",
-		"vscode-azureextensionui": "~0.16.0",
+		"vscode-azureextensionui": "~0.16.1",
 		"vscode-extension-telemetry": "^0.0.15",
 		"vscode-json-languageservice": "^3.0.8",
 		"vscode-languageclient": "^4.0.0",

--- a/src/commands/deleteCosmosDBAccount.ts
+++ b/src/commands/deleteCosmosDBAccount.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { IAzureNode, DialogResponses } from 'vscode-azureextensionui';
 import { azureUtils } from '../utils/azureUtils';
 import { UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
+import { getCosmosDBManagementClient } from '../docdb/getCosmosDBManagementClient';
 
 export async function deleteCosmosDBAccount(node: IAzureNode): Promise<void> {
     const message: string = `Are you sure you want to delete account '${node.treeItem.label}' and its contents?`;
     const result = await vscode.window.showWarningMessage(message, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
     if (result === DialogResponses.deleteResponse) {
-        const docDBClient = new CosmosDBManagementClient(node.credentials, node.subscriptionId);
+        const docDBClient = getCosmosDBManagementClient(node.credentials, node.subscriptionId);
         const resourceGroup: string = azureUtils.getResourceGroupFromId(node.treeItem.id);
         const accountName: string = azureUtils.getAccountNameFromId(node.treeItem.id);
         ext.outputChannel.appendLine(`Deleting account "${accountName}"...`);

--- a/src/docdb/getCosmosDBManagementClient.ts
+++ b/src/docdb/getCosmosDBManagementClient.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { addExtensionUserAgent } from "vscode-azureextensionui";
+import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
+import { ServiceClientCredentials } from "ms-rest";
+
+export function getCosmosDBManagementClient(credentials: ServiceClientCredentials, subscriptionId: string): CosmosDBManagementClient {
+    const client = new CosmosDBManagementClient(credentials, subscriptionId);
+    addExtensionUserAgent(client);
+
+    return client;
+}

--- a/src/docdb/getDocumentClient.ts
+++ b/src/docdb/getDocumentClient.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import { DocumentClient } from "documentdb";
 import * as DocDBLib from 'documentdb/lib';
 import { ext } from "../extensionVariables";
+import { appendExtensionUserAgent } from "vscode-azureextensionui";
 
 export function getDocumentClient(documentEndpoint: string, masterKey: string, isEmulator: boolean): DocumentClient {
     const documentBase = DocDBLib.DocumentBase;
@@ -16,5 +17,14 @@ export function getDocumentClient(documentEndpoint: string, masterKey: string, i
     let strictSSL = !isEmulator && vscodeStrictSSL;
     connectionPolicy.DisableSSLVerification = !strictSSL;
     const client = new DocumentClient(documentEndpoint, { masterKey: masterKey }, connectionPolicy);
+
+    // User agent isn't formally exposed on the client (https://github.com/Azure/azure-documentdb-node/issues/244) but nevertheless can be accessed via defaultHeaders
+    // tslint:disable-next-line:no-any
+    let defaultHeaders = (<{ defaultHeaders: { "User-Agent"?: string } }><any>client).defaultHeaders;
+    if (defaultHeaders) {
+        let userAgent = appendExtensionUserAgent(defaultHeaders['User-Agent']);
+        defaultHeaders['User-Agent'] = userAgent;
+    }
+
     return client;
 }

--- a/src/mongo/connectToMongoClient.ts
+++ b/src/mongo/connectToMongoClient.ts
@@ -4,15 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MongoClient, Db, MongoClientOptions } from 'mongodb';
-import { appendExtensionUserAgent } from 'vscode-azureextensionui';
 
-export async function connectToMongoClient(connectionString: string): Promise<Db> {
-    let extensionUserAgent = appendExtensionUserAgent();
-
+// Can't call appendExtensionUserAgent() here because languageClient.ts can't take a dependency on vscode-azureextensionui and hence vscode, so have
+//   to pass the user agent string in
+export async function connectToMongoClient(connectionString: string, extensionUserAgent: string): Promise<Db> {
     // appname appears to be the correct equivalent to user-agent for mongo
     let options: MongoClientOptions = <MongoClientOptions>{
         appname: extensionUserAgent,
-
     };
 
     return await MongoClient.connect(connectionString, options);

--- a/src/mongo/connectToMongoClient.ts
+++ b/src/mongo/connectToMongoClient.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MongoClient, Db, MongoClientOptions } from 'mongodb';
+import { appendExtensionUserAgent } from 'vscode-azureextensionui';
+
+export async function connectToMongoClient(connectionString: string): Promise<Db> {
+    let extensionUserAgent = appendExtensionUserAgent();
+
+    // appname appears to be the correct equivalent to user-agent for mongo
+    let options: MongoClientOptions = <MongoClientOptions>{
+        appname: extensionUserAgent,
+
+    };
+
+    return await MongoClient.connect(connectionString, options);
+}

--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as nls from 'vscode-nls';
 import { ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { appendExtensionUserAgent } from 'vscode-azureextensionui';
 
 const localize = nls.loadMessageBundle();
 
@@ -33,7 +34,7 @@ export default class MongoDBLanguageClient {
 			documentSelector: [
 				{ language: 'mongo', scheme: 'file' },
 				{ language: 'mongo', scheme: 'untitled' }
-			],
+			]
 		};
 
 		// Create the language client and start the client.
@@ -46,7 +47,7 @@ export default class MongoDBLanguageClient {
 	}
 
 	async connect(connectionString: string, databaseName: string) {
-		await this.client.sendRequest('connect', { connectionString: connectionString, databaseName: databaseName });
+		await this.client.sendRequest('connect', <IConnectionParams>{ connectionString: connectionString, databaseName: databaseName, extensionUserAgent: appendExtensionUserAgent() });
 	}
 
 	disconnect(): void {

--- a/src/mongo/services/IConnectionParams.ts
+++ b/src/mongo/services/IConnectionParams.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+interface IConnectionParams {
+    connectionString: string;
+    databaseName: string;
+    extensionUserAgent: string;
+}

--- a/src/mongo/services/languageService.ts
+++ b/src/mongo/services/languageService.ts
@@ -2,11 +2,13 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+
 import { TextDocumentPositionParams, TextDocuments, IConnection, InitializeParams, InitializeResult, CompletionItem } from 'vscode-languageserver';
-import { MongoClient, Db } from 'mongodb';
+import { Db } from 'mongodb';
 import { MongoScriptDocumentManager } from './mongoScript';
 import SchemaService from './schemaService';
 import { getLanguageService, LanguageService as JsonLanguageService, SchemaConfiguration } from 'vscode-json-languageservice';
+import { connectToMongoClient } from '../connectToMongoClient';
 
 export class LanguageService {
 
@@ -39,7 +41,7 @@ export class LanguageService {
 		});
 
 		connection.onRequest('connect', (connectionParams) => {
-			MongoClient.connect(connectionParams.connectionString)
+			connectToMongoClient(connectionParams.connectionString)
 				.then(account => {
 					this.db = account.db(connectionParams.databaseName);
 					this.schemaService.registerSchemas(this.db)

--- a/src/mongo/services/languageService.ts
+++ b/src/mongo/services/languageService.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// NOTE: This file may not take a dependencey on vscode or anything that takes a dependency on it (such as vscode-azureextensionui)
+
+import * as assert from "assert";
 import { TextDocumentPositionParams, TextDocuments, IConnection, InitializeParams, InitializeResult, CompletionItem } from 'vscode-languageserver';
 import { Db } from 'mongodb';
 import { MongoScriptDocumentManager } from './mongoScript';
@@ -40,8 +43,8 @@ export class LanguageService {
 			return this.provideCompletionItems(textDocumentPosition);
 		});
 
-		connection.onRequest('connect', (connectionParams) => {
-			connectToMongoClient(connectionParams.connectionString)
+		connection.onRequest('connect', (connectionParams: IConnectionParams) => {
+			connectToMongoClient(connectionParams.connectionString, connectionParams.extensionUserAgent)
 				.then(account => {
 					this.db = account.db(connectionParams.databaseName);
 					this.schemaService.registerSchemas(this.db)

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { Db } from 'mongodb';
-import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError } from 'vscode-azureextensionui';
+import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, appendExtensionUserAgent } from 'vscode-azureextensionui';
 import { MongoDatabaseTreeItem, validateMongoCollectionName } from './MongoDatabaseTreeItem';
 import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
 import { MongoDocumentTreeItem } from './MongoDocumentTreeItem';
@@ -51,7 +51,7 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
                 throw new Error('Missing connection string');
             }
 
-            db = await connectToMongoClient(this.connectionString);
+            db = await connectToMongoClient(this.connectionString, appendExtensionUserAgent());
             let databaseInConnectionString = getDatabaseNameFromConnectionString(this.connectionString);
             if (databaseInConnectionString && !this.isEmulator) { // emulator violates the connection string format
                 // If the database is in the connection string, that's all we connect to (we might not even have permissions to list databases)

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -5,13 +5,14 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { MongoClient, Db } from 'mongodb';
+import { Db } from 'mongodb';
 import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError } from 'vscode-azureextensionui';
 import { MongoDatabaseTreeItem, validateMongoCollectionName } from './MongoDatabaseTreeItem';
 import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
 import { MongoDocumentTreeItem } from './MongoDocumentTreeItem';
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
 import { getDatabaseNameFromConnectionString } from '../mongoConnectionStrings';
+import { connectToMongoClient } from '../connectToMongoClient';
 
 export class MongoAccountTreeItem implements IAzureParentTreeItem {
     public static contextValue: string = "cosmosDBMongoServer";
@@ -50,7 +51,7 @@ export class MongoAccountTreeItem implements IAzureParentTreeItem {
                 throw new Error('Missing connection string');
             }
 
-            db = await MongoClient.connect(this.connectionString);
+            db = await connectToMongoClient(this.connectionString);
             let databaseInConnectionString = getDatabaseNameFromConnectionString(this.connectionString);
             if (databaseInConnectionString && !this.isEmulator) { // emulator violates the connection string format
                 // If the database is in the connection string, that's all we connect to (we might not even have permissions to list databases)

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -6,12 +6,13 @@
 import * as vscode from 'vscode';
 import * as cpUtils from '../../utils/cp';
 import * as path from 'path';
-import { MongoClient, Db, Collection } from 'mongodb';
+import { Db, Collection } from 'mongodb';
 import { Shell } from '../shell';
 import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, IActionContext, DialogResponses } from 'vscode-azureextensionui';
 import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
 import { MongoCommand } from '../MongoCommand';
 import { ext } from '../../extensionVariables';
+import { connectToMongoClient } from '../connectToMongoClient';
 
 export class MongoDatabaseTreeItem implements IAzureParentTreeItem {
 	public static contextValue: string = "mongoDb";
@@ -87,7 +88,7 @@ export class MongoDatabaseTreeItem implements IAzureParentTreeItem {
 	}
 
 	public async getDb(): Promise<Db> {
-		const accountConnection = await MongoClient.connect(this.connectionString);
+		const accountConnection = await connectToMongoClient(this.connectionString);
 		return accountConnection.db(this.databaseName);
 	}
 

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -8,7 +8,7 @@ import * as cpUtils from '../../utils/cp';
 import * as path from 'path';
 import { Db, Collection } from 'mongodb';
 import { Shell } from '../shell';
-import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, IActionContext, DialogResponses } from 'vscode-azureextensionui';
+import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, IActionContext, DialogResponses, appendExtensionUserAgent } from 'vscode-azureextensionui';
 import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
 import { MongoCommand } from '../MongoCommand';
 import { ext } from '../../extensionVariables';
@@ -88,7 +88,7 @@ export class MongoDatabaseTreeItem implements IAzureParentTreeItem {
 	}
 
 	public async getDb(): Promise<Db> {
-		const accountConnection = await connectToMongoClient(this.connectionString);
+		const accountConnection = await connectToMongoClient(this.connectionString, appendExtensionUserAgent());
 		return accountConnection.db(this.databaseName);
 	}
 

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as keytarType from 'keytar';
-import { MongoClient, ReplSet } from "mongodb";
+import { ReplSet } from "mongodb";
 import { IAzureTreeItem, IAzureNode, IAzureParentTreeItem, UserCancelledError, AzureTreeDataProvider } from 'vscode-azureextensionui';
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
 import { GraphAccountTreeItem } from '../graph/tree/GraphAccountTreeItem';
@@ -15,6 +15,7 @@ import { DocDBAccountTreeItem } from '../docdb/tree/DocDBAccountTreeItem';
 import { tryfetchNodeModule } from '../utils/vscodeUtils';
 import { getDatabaseNameFromConnectionString } from '../mongo/mongoConnectionStrings';
 import { API, getExperienceQuickPicks, getExperienceQuickPick, getExperience } from '../experiences';
+import { connectToMongoClient } from '../mongo/connectToMongoClient';
 
 interface IPersistedAccount {
     id: string;
@@ -98,7 +99,7 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
 
     private async canConnectToLocalMongoDB(): Promise<boolean> {
         try {
-            let db = await MongoClient.connect(localMongoConnectionString);
+            let db = await connectToMongoClient(localMongoConnectionString);
             db.close();
             return true;
         } catch (error) {
@@ -210,7 +211,7 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
         let host: string;
         let port: string;
 
-        const db = await MongoClient.connect(connectionString);
+        const db = await connectToMongoClient(connectionString);
         const serverConfig = db.serverConfig;
         // Azure CosmosDB comes back as a ReplSet
         if (serverConfig instanceof ReplSet) {

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as keytarType from 'keytar';
 import { ReplSet } from "mongodb";
-import { IAzureTreeItem, IAzureNode, IAzureParentTreeItem, UserCancelledError, AzureTreeDataProvider } from 'vscode-azureextensionui';
+import { IAzureTreeItem, IAzureNode, IAzureParentTreeItem, UserCancelledError, AzureTreeDataProvider, appendExtensionUserAgent } from 'vscode-azureextensionui';
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
 import { GraphAccountTreeItem } from '../graph/tree/GraphAccountTreeItem';
 import { TableAccountTreeItem } from '../table/tree/TableAccountTreeItem';
@@ -99,7 +99,7 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
 
     private async canConnectToLocalMongoDB(): Promise<boolean> {
         try {
-            let db = await connectToMongoClient(localMongoConnectionString);
+            let db = await connectToMongoClient(localMongoConnectionString, appendExtensionUserAgent());
             db.close();
             return true;
         } catch (error) {
@@ -211,7 +211,7 @@ export class AttachedAccountsTreeItem implements IAzureParentTreeItem {
         let host: string;
         let port: string;
 
-        const db = await connectToMongoClient(connectionString);
+        const db = await connectToMongoClient(connectionString, appendExtensionUserAgent());
         const serverConfig = db.serverConfig;
         // Azure CosmosDB comes back as a ReplSet
         if (serverConfig instanceof ReplSet) {

--- a/src/tree/CosmosDBAccountProvider.ts
+++ b/src/tree/CosmosDBAccountProvider.ts
@@ -18,6 +18,7 @@ import * as vscode from 'vscode';
 import { CosmosDBAccountApiStep } from './CosmosDBAccountWizard/CosmosDBAccountApiStep';
 import { API, getExperience } from '../experiences';
 import { CosmosDBAccountCreateStep } from './CosmosDBAccountWizard/CosmosDBAccountCreateStep';
+import { getCosmosDBManagementClient } from '../docdb/getCosmosDBManagementClient';
 
 export class CosmosDBAccountProvider implements IChildProvider {
     public childTypeLabel: string = 'Account';
@@ -27,7 +28,7 @@ export class CosmosDBAccountProvider implements IChildProvider {
     }
 
     public async loadMoreChildren(node: IAzureNode): Promise<IAzureTreeItem[]> {
-        const client = new CosmosDBManagementClient(node.credentials, node.subscriptionId);
+        const client = getCosmosDBManagementClient(node.credentials, node.subscriptionId);
         const accounts: DatabaseAccountsListResult = await client.databaseAccounts.list();
         let accountTreeItems = [];
         await Promise.all(
@@ -47,7 +48,7 @@ export class CosmosDBAccountProvider implements IChildProvider {
     }
 
     public async createChild(node: IAzureNode, showCreatingNode: (label: string) => void, actionContext?: IActionContext): Promise<IAzureTreeItem> {
-        const client = new CosmosDBManagementClient(node.credentials, node.subscriptionId);
+        const client = getCosmosDBManagementClient(node.credentials, node.subscriptionId);
         const wizardContext: ICosmosDBWizardContext = {
             credentials: node.credentials,
             subscriptionId: node.subscriptionId,

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountCreateStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountCreateStep.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { Capability } from 'azure-arm-cosmosdb/lib/models';
 import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
 import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
 import { API } from '../../experiences';
 import { ext } from '../../extensionVariables';
+import { getCosmosDBManagementClient } from '../../docdb/getCosmosDBManagementClient';
 
 export class CosmosDBAccountCreateStep extends AzureWizardExecuteStep<ICosmosDBWizardContext> {
     public async execute(wizardContext: ICosmosDBWizardContext): Promise<ICosmosDBWizardContext> {
-        const client = new CosmosDBManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = getCosmosDBManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
         ext.outputChannel.appendLine(`Creating Cosmos DB account "${wizardContext.accountName}" with API "${wizardContext.defaultExperience.shortName}"...`);
         let options = {
             location: wizardContext.location.name,

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
@@ -8,6 +8,7 @@ import { AzureNameStep, ResourceGroupListStep, resourceGroupNamingRules } from '
 import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
 import { validOnTimeoutOrException } from "../../utils/inputValidation";
 import { ext } from '../../extensionVariables';
+import { getCosmosDBManagementClient } from '../../docdb/getCosmosDBManagementClient';
 
 export class CosmosDBAccountNameStep extends AzureNameStep<ICosmosDBWizardContext> {
     protected async isRelatedNameAvailable(wizardContext: ICosmosDBWizardContext, name: string): Promise<boolean> {
@@ -15,7 +16,7 @@ export class CosmosDBAccountNameStep extends AzureNameStep<ICosmosDBWizardContex
     }
 
     public async prompt(wizardContext: ICosmosDBWizardContext): Promise<ICosmosDBWizardContext> {
-        const client = new CosmosDBManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
+        const client = getCosmosDBManagementClient(wizardContext.credentials, wizardContext.subscriptionId);
         wizardContext.accountName = (await ext.ui.showInputBox({
             placeHolder: "Account name",
             prompt: "Provide a Cosmos DB account name",


### PR DESCRIPTION
I had to revert this PR yesterday due to a dependency issue - mongo language server can't load vscode and therefore can't depend on vscode-azureextensionui.

The first commit in this PR is the same as yesterday, please review the second one, which is the fix.  Thx.