### PR TITLE
Enforce ordered-imports

### DIFF
--- a/src/CosmosEditorManager.ts
+++ b/src/CosmosEditorManager.ts
@@ -7,18 +7,18 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { UserCancelledError, AzureTreeDataProvider, IAzureParentNode, IAzureNode, IActionContext, DialogResponses } from 'vscode-azureextensionui';
-import * as vscodeUtils from './utils/vscodeUtils';
 import { MessageItem, ViewColumn } from 'vscode';
-import { DocDBDocumentTreeItem } from './docdb/tree/DocDBDocumentTreeItem';
+import { AzureTreeDataProvider, DialogResponses, IActionContext, IAzureNode, IAzureParentNode, UserCancelledError } from 'vscode-azureextensionui';
 import { DocDBDocumentNodeEditor } from './docdb/editors/DocDBDocumentNodeEditor';
-import { MongoDocumentTreeItem } from './mongo/tree/MongoDocumentTreeItem';
+import { DocDBStoredProcedureNodeEditor } from './docdb/editors/DocDBStoredProcedureNodeEditor';
+import { DocDBDocumentTreeItem } from './docdb/tree/DocDBDocumentTreeItem';
+import { DocDBStoredProcedureTreeItem } from './docdb/tree/DocDBStoredProcedureTreeItem';
+import { ext } from './extensionVariables';
+import { MongoCollectionNodeEditor } from './mongo/editors/MongoCollectionNodeEditor';
 import { MongoDocumentNodeEditor } from './mongo/editors/MongoDocumentNodeEditor';
 import { MongoCollectionTreeItem } from './mongo/tree/MongoCollectionTreeItem';
-import { MongoCollectionNodeEditor } from './mongo/editors/MongoCollectionNodeEditor';
-import { DocDBStoredProcedureTreeItem } from './docdb/tree/DocDBStoredProcedureTreeItem';
-import { DocDBStoredProcedureNodeEditor } from './docdb/editors/DocDBStoredProcedureNodeEditor';
-import { ext } from './extensionVariables';
+import { MongoDocumentTreeItem } from './mongo/tree/MongoDocumentTreeItem';
+import * as vscodeUtils from './utils/vscodeUtils';
 
 export interface ICosmosEditor<T = {}> {
     label: string;

--- a/src/commands/deleteCosmosDBAccount.ts
+++ b/src/commands/deleteCosmosDBAccount.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IAzureNode, DialogResponses } from 'vscode-azureextensionui';
-import { azureUtils } from '../utils/azureUtils';
+import { DialogResponses, IAzureNode } from 'vscode-azureextensionui';
 import { UserCancelledError } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
 import { getCosmosDBManagementClient } from '../docdb/getCosmosDBManagementClient';
+import { ext } from '../extensionVariables';
+import { azureUtils } from '../utils/azureUtils';
 
 export async function deleteCosmosDBAccount(node: IAzureNode): Promise<void> {
     const message: string = `Are you sure you want to delete account '${node.treeItem.label}' and its contents?`;

--- a/src/docdb/editors/DocDBDocumentNodeEditor.ts
+++ b/src/docdb/editors/DocDBDocumentNodeEditor.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { RetrievedDocument } from "documentdb";
 import { IAzureNode } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
-import { RetrievedDocument } from "documentdb";
-import { DocDBDocumentTreeItem } from "../tree/DocDBDocumentTreeItem";
 import { getNodeEditorLabel } from '../../utils/vscodeUtils';
+import { DocDBDocumentTreeItem } from "../tree/DocDBDocumentTreeItem";
 
 export class DocDBDocumentNodeEditor implements ICosmosEditor<RetrievedDocument> {
     private _documentNode: IAzureNode<DocDBDocumentTreeItem>;

--- a/src/docdb/getCosmosDBManagementClient.ts
+++ b/src/docdb/getCosmosDBManagementClient.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { addExtensionUserAgent } from "vscode-azureextensionui";
 import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { ServiceClientCredentials } from "ms-rest";
+import { addExtensionUserAgent } from "vscode-azureextensionui";
 
 export function getCosmosDBManagementClient(credentials: ServiceClientCredentials, subscriptionId: string): CosmosDBManagementClient {
     const client = new CosmosDBManagementClient(credentials, subscriptionId);

--- a/src/docdb/getDocumentClient.ts
+++ b/src/docdb/getDocumentClient.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from "vscode";
 import { DocumentClient } from "documentdb";
 import * as DocDBLib from 'documentdb/lib';
-import { ext } from "../extensionVariables";
+import * as vscode from "vscode";
 import { appendExtensionUserAgent } from "vscode-azureextensionui";
+import { ext } from "../extensionVariables";
 
 export function getDocumentClient(documentEndpoint: string, masterKey: string, isEmulator: boolean): DocumentClient {
     const documentBase = DocDBLib.DocumentBase;

--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeDataProvider, IAzureParentNode, IAzureNode, registerCommand } from "vscode-azureextensionui";
-import { DocDBDatabaseTreeItem } from "./tree/DocDBDatabaseTreeItem";
-import { DocDBAccountTreeItem } from "./tree/DocDBAccountTreeItem";
-import { DocDBCollectionTreeItem } from "./tree/DocDBCollectionTreeItem";
-import { DocDBDocumentTreeItem } from "./tree/DocDBDocumentTreeItem";
-import { DocDBDocumentsTreeItem } from "./tree/DocDBDocumentsTreeItem";
-import { DocDBStoredProcedureTreeItem } from "./tree/DocDBStoredProcedureTreeItem";
 import { commands } from "vscode";
+import { AzureTreeDataProvider, IAzureNode, IAzureParentNode, registerCommand } from "vscode-azureextensionui";
 import { CosmosEditorManager } from "../CosmosEditorManager";
 import { DocDBStoredProcedureNodeEditor } from "./editors/DocDBStoredProcedureNodeEditor";
+import { DocDBAccountTreeItem } from "./tree/DocDBAccountTreeItem";
+import { DocDBCollectionTreeItem } from "./tree/DocDBCollectionTreeItem";
+import { DocDBDatabaseTreeItem } from "./tree/DocDBDatabaseTreeItem";
+import { DocDBDocumentsTreeItem } from "./tree/DocDBDocumentsTreeItem";
+import { DocDBDocumentTreeItem } from "./tree/DocDBDocumentTreeItem";
+import { DocDBStoredProcedureTreeItem } from "./tree/DocDBStoredProcedureTreeItem";
 
 export function registerDocDBCommands(tree: AzureTreeDataProvider, editorManager: CosmosEditorManager): void {
     registerCommand('cosmosDB.createDocDBDatabase', async (node?: IAzureParentNode) => {

--- a/src/docdb/tree/DocDBAccountTreeItem.ts
+++ b/src/docdb/tree/DocDBAccountTreeItem.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DocDBDatabaseTreeItem } from './DocDBDatabaseTreeItem';
 import { DatabaseMeta } from 'documentdb';
 import { IAzureTreeItem } from 'vscode-azureextensionui';
 import { DocDBAccountTreeItemBase } from './DocDBAccountTreeItemBase';
 import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
+import { DocDBDatabaseTreeItem } from './DocDBDatabaseTreeItem';
+import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 import { DocDBDocumentTreeItem } from './DocDBDocumentTreeItem';
 import { DocDBStoredProcedureTreeItem } from './DocDBStoredProcedureTreeItem';
-import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 
 export class DocDBAccountTreeItem extends DocDBAccountTreeItemBase {
     public static contextValue: string = "cosmosDBDocumentServer";

--- a/src/docdb/tree/DocDBAccountTreeItemBase.ts
+++ b/src/docdb/tree/DocDBAccountTreeItemBase.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DatabaseMeta, DocumentClient, FeedOptions, QueryIterator } from 'documentdb';
 import * as path from 'path';
-import { DocumentClient, QueryIterator, DatabaseMeta, FeedOptions } from 'documentdb';
-import { IAzureTreeItem, IAzureNode, UserCancelledError } from 'vscode-azureextensionui';
-import { DocDBTreeItemBase } from './DocDBTreeItemBase';
 import * as vscode from 'vscode';
+import { IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
+import { DocDBTreeItemBase } from './DocDBTreeItemBase';
 
 /**
  * This class provides common logic for DocumentDB, Graph, and Table accounts

--- a/src/docdb/tree/DocDBCollectionTreeItem.ts
+++ b/src/docdb/tree/DocDBCollectionTreeItem.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CollectionMeta, DocumentClient, CollectionPartitionKey } from 'documentdb';
-import { IAzureNode, IAzureTreeItem, UserCancelledError, IAzureParentTreeItem, DialogResponses } from 'vscode-azureextensionui';
-import * as vscode from 'vscode';
-import { getDocumentClient } from "../getDocumentClient";
+import { CollectionMeta, CollectionPartitionKey, DocumentClient } from 'documentdb';
 import * as path from "path";
-import { DocDBStoredProceduresTreeItem } from './DocDBStoredProceduresTreeItem';
-import { DocDBStoredProcedureTreeItem } from './DocDBStoredProcedureTreeItem';
+import * as vscode from 'vscode';
+import { DialogResponses, IAzureNode, IAzureParentTreeItem, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
+import { getDocumentClient } from "../getDocumentClient";
 import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 import { DocDBDocumentTreeItem } from './DocDBDocumentTreeItem';
+import { DocDBStoredProceduresTreeItem } from './DocDBStoredProceduresTreeItem';
+import { DocDBStoredProcedureTreeItem } from './DocDBStoredProcedureTreeItem';
 
 /**
  * Represents a DocumentDB collection

--- a/src/docdb/tree/DocDBDatabaseTreeItem.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItem.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
 import { CollectionMeta } from 'documentdb';
 import { IAzureTreeItem } from 'vscode-azureextensionui';
+import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
 import { DocDBDatabaseTreeItemBase } from './DocDBDatabaseTreeItemBase';
 
 export class DocDBDatabaseTreeItem extends DocDBDatabaseTreeItemBase {

--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
-import { DocumentClient, QueryIterator, DatabaseMeta, CollectionMeta, FeedOptions } from 'documentdb';
-import { IAzureTreeItem, IAzureNode, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
-import { DocDBTreeItemBase } from './DocDBTreeItemBase';
-import * as vscode from 'vscode';
+import { CollectionMeta, DatabaseMeta, DocumentClient, FeedOptions, QueryIterator } from 'documentdb';
 import { DocumentBase } from 'documentdb/lib';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { DialogResponses, IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
+import { DocDBTreeItemBase } from './DocDBTreeItemBase';
 
 const minThroughput: number = 1000;
 const maxThroughput: number = 100000;

--- a/src/docdb/tree/DocDBDocumentTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentTreeItem.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+import { DocumentClient, RetrievedDocument } from 'documentdb';
 import * as path from 'path';
-import { IAzureNode, IAzureTreeItem, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
-import { RetrievedDocument, DocumentClient } from 'documentdb';
-import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
+import * as vscode from 'vscode';
+import { DialogResponses, IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { emptyPartitionKeyValue } from '../../constants';
 import { getDocumentTreeItemLabel } from '../../utils/vscodeUtils';
+import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
 
 /**
  * Represents a Cosmos DB DocumentDB (SQL) document

--- a/src/docdb/tree/DocDBDocumentsTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentsTreeItem.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DocumentClient, FeedOptions, QueryIterator, RetrievedDocument } from 'documentdb';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { DocumentClient, QueryIterator, FeedOptions, RetrievedDocument } from 'documentdb';
-import { DocDBTreeItemBase } from './DocDBTreeItemBase';
-import { IAzureTreeItem, UserCancelledError, IAzureNode } from 'vscode-azureextensionui';
-import { DocDBDocumentTreeItem } from './DocDBDocumentTreeItem';
+import { IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
+import { DocDBDocumentTreeItem } from './DocDBDocumentTreeItem';
+import { DocDBTreeItemBase } from './DocDBTreeItemBase';
 
 /**
  * This class provides logic for DocumentDB collections

--- a/src/docdb/tree/DocDBDocumentsTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDocumentsTreeItemBase.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CollectionMeta, DocumentClient, FeedOptions, QueryIterator, RetrievedDocument } from 'documentdb';
 import * as path from 'path';
 import * as vscode from "vscode";
-import { DocumentClient, QueryIterator, CollectionMeta, RetrievedDocument, FeedOptions } from 'documentdb';
 import { DocDBTreeItemBase } from './DocDBTreeItemBase';
 
 /**

--- a/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DocumentClient, ProcedureMeta } from 'documentdb';
 import * as path from 'path';
 import * as vscode from "vscode";
-import { IAzureTreeItem, IAzureNode, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
-import { ProcedureMeta, DocumentClient } from 'documentdb';
+import { DialogResponses, IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { getDocumentClient } from '../getDocumentClient';
 
 /**

--- a/src/docdb/tree/DocDBStoredProceduresTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProceduresTreeItem.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DocumentClient, FeedOptions, ProcedureMeta, QueryIterator } from 'documentdb';
 import * as path from 'path';
 import * as vscode from "vscode";
-import { DocumentClient, QueryIterator, FeedOptions, ProcedureMeta } from 'documentdb';
-import { DocDBTreeItemBase } from './DocDBTreeItemBase';
-import { IAzureTreeItem, UserCancelledError, IAzureNode } from 'vscode-azureextensionui';
-import { DocDBStoredProcedureTreeItem } from './DocDBStoredProcedureTreeItem';
+import { IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { defaultStoredProcedure } from '../../constants';
-import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
 import { GraphCollectionTreeItem } from '../../graph/tree/GraphCollectionTreeItem';
+import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
+import { DocDBStoredProcedureTreeItem } from './DocDBStoredProcedureTreeItem';
+import { DocDBTreeItemBase } from './DocDBTreeItemBase';
 
 /**
  * This class represents the DocumentDB "Stored Procedures" node in the tree

--- a/src/docdb/tree/DocDBTreeItemBase.ts
+++ b/src/docdb/tree/DocDBTreeItemBase.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DocumentClient, QueryIterator, QueryError, FeedOptions } from 'documentdb';
-import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode } from 'vscode-azureextensionui';
-import { getDocumentClient } from "../getDocumentClient";
+import { DocumentClient, FeedOptions, QueryError, QueryIterator } from 'documentdb';
+import { IAzureNode, IAzureParentTreeItem, IAzureTreeItem } from 'vscode-azureextensionui';
 import { DefaultBatchSize } from '../../constants';
+import { getDocumentClient } from "../getDocumentClient";
 
 /**
  * This class provides common iteration logic for DocumentDB accounts, databases, and collections

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,27 +5,27 @@
 
 'use strict';
 
-import * as vscode from 'vscode';
 import * as copypaste from 'copy-paste';
-import * as cpUtil from './utils/cp';
-import { AzureTreeDataProvider, IAzureNode, IAzureParentNode, IActionContext, IAzureUserInput, AzureUserInput, registerCommand, registerEvent, registerUIExtensionVariables } from 'vscode-azureextensionui';
-import { Reporter } from './utils/telemetry';
+import * as vscode from 'vscode';
+import { AzureTreeDataProvider, AzureUserInput, IActionContext, IAzureNode, IAzureParentNode, IAzureUserInput, registerCommand, registerEvent, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { CosmosEditorManager } from './CosmosEditorManager';
-import { CosmosDBAccountProvider } from './tree/CosmosDBAccountProvider';
-import { AttachedAccountsTreeItem, AttachedAccountSuffix } from './tree/AttachedAccountsTreeItem';
-import { MongoDocumentNodeEditor } from './mongo/editors/MongoDocumentNodeEditor';
-import { MongoDocumentTreeItem } from './mongo/tree/MongoDocumentTreeItem';
-import { DocDBDocumentTreeItem } from './docdb/tree/DocDBDocumentTreeItem';
 import { DocDBDocumentNodeEditor } from './docdb/editors/DocDBDocumentNodeEditor';
 import { registerDocDBCommands } from './docdb/registerDocDBCommands';
+import { DocDBAccountTreeItem } from './docdb/tree/DocDBAccountTreeItem';
+import { DocDBAccountTreeItemBase } from './docdb/tree/DocDBAccountTreeItemBase';
+import { DocDBDocumentTreeItem } from './docdb/tree/DocDBDocumentTreeItem';
+import { ext } from './extensionVariables';
 import { registerGraphCommands } from './graph/registerGraphCommands';
+import { GraphAccountTreeItem } from './graph/tree/GraphAccountTreeItem';
+import { MongoDocumentNodeEditor } from './mongo/editors/MongoDocumentNodeEditor';
 import { registerMongoCommands } from './mongo/registerMongoCommands';
 import { MongoAccountTreeItem } from './mongo/tree/MongoAccountTreeItem';
-import { DocDBAccountTreeItemBase } from './docdb/tree/DocDBAccountTreeItemBase';
-import { GraphAccountTreeItem } from './graph/tree/GraphAccountTreeItem';
-import { DocDBAccountTreeItem } from './docdb/tree/DocDBAccountTreeItem';
+import { MongoDocumentTreeItem } from './mongo/tree/MongoDocumentTreeItem';
 import { TableAccountTreeItem } from './table/tree/TableAccountTreeItem';
-import { ext } from './extensionVariables';
+import { AttachedAccountsTreeItem, AttachedAccountSuffix } from './tree/AttachedAccountsTreeItem';
+import { CosmosDBAccountProvider } from './tree/CosmosDBAccountProvider';
+import * as cpUtil from './utils/cp';
+import { Reporter } from './utils/telemetry';
 
 export function activate(context: vscode.ExtensionContext) {
 	registerUIExtensionVariables(ext);

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureNode, IAzureUserInput } from "vscode-azureextensionui";
 import { ExtensionContext, OutputChannel } from "vscode";
+import { IAzureNode, IAzureUserInput } from "vscode-azureextensionui";
 import TelemetryReporter from "vscode-extension-telemetry";
 
 /**

--- a/src/graph/GraphViewServer.ts
+++ b/src/graph/GraphViewServer.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EventEmitter } from 'events';
-import * as http from 'http';
-import * as vscode from 'vscode';
-import * as io from 'socket.io';
-import { GraphConfiguration } from './GraphConfiguration';
 import * as gremlin from "gremlin";
+import * as http from 'http';
+import * as io from 'socket.io';
+import * as vscode from 'vscode';
+import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { removeDuplicatesById } from "../utils/array";
+import { GraphConfiguration } from './GraphConfiguration';
 import { GraphViewServerSocket } from "./GraphViewServerSocket";
 import { IGremlinEndpoint } from "./gremlinEndpoints";
-import { IActionContext, callWithTelemetryAndErrorHandling } from 'vscode-azureextensionui';
 
 class GremlinParseError extends Error {
   constructor(err: Error) {

--- a/src/graph/GraphViewsManager.ts
+++ b/src/graph/GraphViewsManager.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-import * as path from "path";
 import * as fs from "fs";
-import { GraphConfiguration, areConfigsEqual } from './GraphConfiguration';
+import * as path from "path";
+import * as vscode from 'vscode';
+import { areConfigsEqual, GraphConfiguration } from './GraphConfiguration';
 import { GraphViewServer } from './GraphViewServer';
 
 const scheme = "vscode-cosmosdb-graphresults";

--- a/src/graph/registerGraphCommands.ts
+++ b/src/graph/registerGraphCommands.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeDataProvider, IAzureParentNode, IAzureNode, registerCommand } from "vscode-azureextensionui";
 import * as vscode from 'vscode';
-import { GraphAccountTreeItem } from "./tree/GraphAccountTreeItem";
-import { GraphDatabaseTreeItem } from "./tree/GraphDatabaseTreeItem";
-import { GraphCollectionTreeItem } from "./tree/GraphCollectionTreeItem";
+import { AzureTreeDataProvider, IAzureNode, IAzureParentNode, registerCommand } from "vscode-azureextensionui";
 import { GraphViewsManager } from "./GraphViewsManager";
+import { GraphAccountTreeItem } from "./tree/GraphAccountTreeItem";
+import { GraphCollectionTreeItem } from "./tree/GraphCollectionTreeItem";
+import { GraphDatabaseTreeItem } from "./tree/GraphDatabaseTreeItem";
 import { GraphTreeItem } from "./tree/GraphTreeItem";
 
 export function registerGraphCommands(context: vscode.ExtensionContext, tree: AzureTreeDataProvider): void {

--- a/src/graph/tree/GraphAccountTreeItem.ts
+++ b/src/graph/tree/GraphAccountTreeItem.ts
@@ -6,9 +6,9 @@
 import { DatabaseMeta } from 'documentdb';
 import { IAzureTreeItem } from 'vscode-azureextensionui';
 import { DocDBAccountTreeItemBase } from '../../docdb/tree/DocDBAccountTreeItemBase';
-import { GraphDatabaseTreeItem } from './GraphDatabaseTreeItem';
-import { GraphCollectionTreeItem } from './GraphCollectionTreeItem';
 import { IGremlinEndpoint } from '../gremlinEndpoints';
+import { GraphCollectionTreeItem } from './GraphCollectionTreeItem';
+import { GraphDatabaseTreeItem } from './GraphDatabaseTreeItem';
 
 export class GraphAccountTreeItem extends DocDBAccountTreeItemBase {
     public static contextValue: string = "cosmosDBGraphAccount";

--- a/src/graph/tree/GraphCollectionTreeItem.ts
+++ b/src/graph/tree/GraphCollectionTreeItem.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
-import { IAzureTreeItem, IAzureNode, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
-import * as vscode from 'vscode';
 import { CollectionMeta, DocumentClient } from 'documentdb';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { DialogResponses, IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
+import { getDocumentClient } from '../../docdb/getDocumentClient';
+import { DocDBStoredProceduresTreeItem } from '../../docdb/tree/DocDBStoredProceduresTreeItem';
 import { GraphDatabaseTreeItem } from './GraphDatabaseTreeItem';
 import { GraphTreeItem } from './GraphTreeItem';
-import { DocDBStoredProceduresTreeItem } from '../../docdb/tree/DocDBStoredProceduresTreeItem';
-import { getDocumentClient } from '../../docdb/getDocumentClient';
 
 export class GraphCollectionTreeItem implements IAzureTreeItem {
     public static contextValue: string = "cosmosDBGraph";

--- a/src/graph/tree/GraphDatabaseTreeItem.ts
+++ b/src/graph/tree/GraphDatabaseTreeItem.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureTreeItem } from 'vscode-azureextensionui';
 import { CollectionMeta, DatabaseMeta } from 'documentdb';
+import { IAzureTreeItem } from 'vscode-azureextensionui';
 import { DocDBDatabaseTreeItemBase } from '../../docdb/tree/DocDBDatabaseTreeItemBase';
+import { getPossibleGremlinEndpoints, IGremlinEndpoint } from '../gremlinEndpoints';
 import { GraphCollectionTreeItem } from './GraphCollectionTreeItem';
-import { IGremlinEndpoint, getPossibleGremlinEndpoints } from '../gremlinEndpoints';
 
 export class GraphDatabaseTreeItem extends DocDBDatabaseTreeItemBase {
     public static contextValue: string = "cosmosDBGraphDatabase";

--- a/src/graph/tree/GraphTreeItem.ts
+++ b/src/graph/tree/GraphTreeItem.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
-import { IAzureTreeItem } from 'vscode-azureextensionui';
-import { GraphViewsManager } from '../GraphViewsManager';
-import { GraphConfiguration } from '../GraphConfiguration';
-import * as vscode from 'vscode';
 import { CollectionMeta } from 'documentdb';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { IAzureTreeItem } from 'vscode-azureextensionui';
+import { GraphConfiguration } from '../GraphConfiguration';
+import { GraphViewsManager } from '../GraphViewsManager';
 import { GraphDatabaseTreeItem } from './GraphDatabaseTreeItem';
 
 export class GraphTreeItem implements IAzureTreeItem {

--- a/src/mongo/MongoCommand.ts
+++ b/src/mongo/MongoCommand.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { RecognitionException } from 'antlr4ts';
+import * as vscode from 'vscode';
 
 export interface MongoCommand {
     range: vscode.Range;

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -3,24 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { ANTLRInputStream as InputStream } from 'antlr4ts/ANTLRInputStream';
 import { CommonTokenStream } from 'antlr4ts/CommonTokenStream';
+import { ErrorNode } from 'antlr4ts/tree/ErrorNode';
+import { ParseTree } from 'antlr4ts/tree/ParseTree';
+import * as vscode from 'vscode';
+import { AzureTreeDataProvider, IActionContext, IAzureParentNode } from 'vscode-azureextensionui';
+import { CosmosEditorManager } from '../CosmosEditorManager';
+import { ext } from '../extensionVariables';
+import { filterType, findType } from '../utils/array';
+import * as vscodeUtil from './../utils/vscodeUtils';
+import { MongoFindOneResultEditor } from './editors/MongoFindOneResultEditor';
+import { MongoFindResultEditor } from './editors/MongoFindResultEditor';
+import { LexerErrorListener, ParserErrorListener } from './errorListeners';
+import { mongoLexer } from './grammar/mongoLexer';
 import * as mongoParser from './grammar/mongoParser';
 import { MongoVisitor } from './grammar/visitors';
-import { mongoLexer } from './grammar/mongoLexer';
-import * as vscodeUtil from './../utils/vscodeUtils';
-import { CosmosEditorManager } from '../CosmosEditorManager';
-import { IAzureParentNode, AzureTreeDataProvider, IActionContext } from 'vscode-azureextensionui';
-import { MongoFindResultEditor } from './editors/MongoFindResultEditor';
-import { MongoFindOneResultEditor } from './editors/MongoFindOneResultEditor';
 import { MongoCommand } from './MongoCommand';
 import { MongoDatabaseTreeItem, stripQuotes } from './tree/MongoDatabaseTreeItem';
-import { filterType, findType } from '../utils/array';
-import { LexerErrorListener, ParserErrorListener } from './errorListeners';
-import { ext } from '../extensionVariables';
-import { ErrorNode } from 'antlr4ts/tree/ErrorNode';
 
 const notInScrapbookMessage = "You must have a MongoDB scrapbook (*.mongo) open to run a MongoDB command.";
 

--- a/src/mongo/connectToMongoClient.ts
+++ b/src/mongo/connectToMongoClient.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MongoClient, Db, MongoClientOptions } from 'mongodb';
+import { Db, MongoClient, MongoClientOptions } from 'mongodb';
 
 // Can't call appendExtensionUserAgent() here because languageClient.ts can't take a dependency on vscode-azureextensionui and hence vscode, so have
 //   to pass the user agent string in

--- a/src/mongo/editors/MongoCollectionNodeEditor.ts
+++ b/src/mongo/editors/MongoCollectionNodeEditor.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureParentNode, IAzureNode } from "vscode-azureextensionui";
-import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
+import { IAzureNode, IAzureParentNode } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
-import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
 import { getNodeEditorLabel } from '../../utils/vscodeUtils';
+import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
+import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 // tslint:disable:no-var-requires
 const EJSON = require("mongodb-extended-json");
 

--- a/src/mongo/editors/MongoDocumentNodeEditor.ts
+++ b/src/mongo/editors/MongoDocumentNodeEditor.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAzureNode } from "vscode-azureextensionui";
-import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { getNodeEditorLabel } from '../../utils/vscodeUtils';
+import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 // tslint:disable:no-var-requires
 const EJSON = require("mongodb-extended-json");
 

--- a/src/mongo/editors/MongoFindOneResultEditor.ts
+++ b/src/mongo/editors/MongoFindOneResultEditor.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureParentNode, IAzureNode, AzureTreeDataProvider } from "vscode-azureextensionui";
-import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
+import { AzureTreeDataProvider, IAzureNode, IAzureParentNode } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { MongoDatabaseTreeItem } from "../tree/MongoDatabaseTreeItem";
+import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 // tslint:disable:no-var-requires
 const EJSON = require("mongodb-extended-json");
 

--- a/src/mongo/editors/MongoFindResultEditor.ts
+++ b/src/mongo/editors/MongoFindResultEditor.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureParentNode, AzureTreeDataProvider } from "vscode-azureextensionui";
-import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
 import { Collection } from "mongodb";
-import { MongoCollectionNodeEditor } from "./MongoCollectionNodeEditor";
+import { AzureTreeDataProvider, IAzureParentNode } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
-import { MongoDatabaseTreeItem } from "../tree/MongoDatabaseTreeItem";
 import { MongoCommand } from "../MongoCommand";
 import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
+import { MongoDatabaseTreeItem } from "../tree/MongoDatabaseTreeItem";
+import { IMongoDocument, MongoDocumentTreeItem } from "../tree/MongoDocumentTreeItem";
+import { MongoCollectionNodeEditor } from "./MongoCollectionNodeEditor";
 // tslint:disable:no-var-requires
 const EJSON = require("mongodb-extended-json");
 

--- a/src/mongo/errorListeners.ts
+++ b/src/mongo/errorListeners.ts
@@ -5,8 +5,8 @@
 
 import * as vscode from "vscode";
 import { ANTLRErrorListener } from '../../node_modules/antlr4ts/ANTLRErrorListener';
-import { Recognizer } from '../../node_modules/antlr4ts/Recognizer';
 import { RecognitionException } from '../../node_modules/antlr4ts/RecognitionException';
+import { Recognizer } from '../../node_modules/antlr4ts/Recognizer';
 import { Token } from '../../node_modules/antlr4ts/Token';
 import { errorDescription } from './MongoCommand';
 

--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as path from 'path';
-import * as nls from 'vscode-nls';
 import { ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 import { appendExtensionUserAgent } from 'vscode-azureextensionui';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+import * as nls from 'vscode-nls';
 
 const localize = nls.loadMessageBundle();
 

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -3,19 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureParentNode, AzureTreeDataProvider, IAzureNode, IActionContext, callWithTelemetryAndErrorHandling, registerCommand, registerEvent } from "vscode-azureextensionui";
 import * as vscode from 'vscode';
+import { AzureTreeDataProvider, callWithTelemetryAndErrorHandling, IActionContext, IAzureNode, IAzureParentNode, registerCommand, registerEvent } from "vscode-azureextensionui";
+import { CosmosEditorManager } from "../CosmosEditorManager";
+import { ext } from "../extensionVariables";
+import * as vscodeUtil from '../utils/vscodeUtils';
+import { MongoCollectionNodeEditor } from "./editors/MongoCollectionNodeEditor";
+import MongoDBLanguageClient from "./languageClient";
+import { executeAllCommandsFromActiveEditor, executeCommandFromActiveEditor, executeCommandFromText, getAllErrorsFromTextDocument } from "./MongoScrapbook";
+import { MongoCodeLensProvider } from "./services/MongoCodeLensProvider";
+import { MongoAccountTreeItem } from "./tree/MongoAccountTreeItem";
 import { MongoCollectionTreeItem } from "./tree/MongoCollectionTreeItem";
 import { MongoDatabaseTreeItem } from "./tree/MongoDatabaseTreeItem";
-import { MongoAccountTreeItem } from "./tree/MongoAccountTreeItem";
-import MongoDBLanguageClient from "./languageClient";
-import * as vscodeUtil from '../utils/vscodeUtils';
 import { MongoDocumentTreeItem } from "./tree/MongoDocumentTreeItem";
-import { MongoCollectionNodeEditor } from "./editors/MongoCollectionNodeEditor";
-import { CosmosEditorManager } from "../CosmosEditorManager";
-import { MongoCodeLensProvider } from "./services/MongoCodeLensProvider";
-import { ext } from "../extensionVariables";
-import { executeCommandFromText, executeCommandFromActiveEditor, executeAllCommandsFromActiveEditor, getAllErrorsFromTextDocument } from "./MongoScrapbook";
 
 const connectedDBKey: string = 'ms-azuretools.vscode-cosmosdb.connectedDB';
 let diagnosticsCollection: vscode.DiagnosticCollection;

--- a/src/mongo/services/MongoCodeLensProvider.ts
+++ b/src/mongo/services/MongoCodeLensProvider.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
-import { getAllCommandsFromTextDocument } from "../MongoScrapbook";
 import { callWithTelemetryAndErrorHandling, IActionContext } from "vscode-azureextensionui";
+import { getAllCommandsFromTextDocument } from "../MongoScrapbook";
 
 export class MongoCodeLensProvider implements vscode.CodeLensProvider {
 	private _onDidChangeEmitter = new vscode.EventEmitter<void>();

--- a/src/mongo/services/completionItemProvider.ts
+++ b/src/mongo/services/completionItemProvider.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { ParserRuleContext } from 'antlr4ts/ParserRuleContext';
-import { TerminalNode } from 'antlr4ts/tree/TerminalNode';
-import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { ErrorNode } from 'antlr4ts/tree/ErrorNode';
+import { ParseTree } from 'antlr4ts/tree/ParseTree';
+import { TerminalNode } from 'antlr4ts/tree/TerminalNode';
 import { Db } from 'mongodb';
-import * as mongoParser from './../grammar/mongoParser';
-import { mongoLexer } from './../grammar/mongoLexer';
-import { MongoVisitor } from './../grammar/visitors';
-import { TextDocument, CompletionItem, Position, Range, CompletionItemKind } from 'vscode-languageserver';
-import SchemaService from './schemaService';
 import { LanguageService as JsonLanguageService } from 'vscode-json-languageservice';
+import { CompletionItem, CompletionItemKind, Position, Range, TextDocument } from 'vscode-languageserver';
+import { mongoLexer } from './../grammar/mongoLexer';
+import * as mongoParser from './../grammar/mongoParser';
+import { MongoVisitor } from './../grammar/visitors';
+import SchemaService from './schemaService';
 
 export class CompletionItemsVisitor extends MongoVisitor<Promise<CompletionItem[]>> {
 

--- a/src/mongo/services/languageService.ts
+++ b/src/mongo/services/languageService.ts
@@ -5,12 +5,12 @@
 
 // NOTE: This file may not take a dependencey on vscode or anything that takes a dependency on it (such as vscode-azureextensionui)
 
-import { TextDocumentPositionParams, TextDocuments, IConnection, InitializeParams, InitializeResult, CompletionItem } from 'vscode-languageserver';
 import { Db } from 'mongodb';
+import { getLanguageService, LanguageService as JsonLanguageService, SchemaConfiguration } from 'vscode-json-languageservice';
+import { CompletionItem, IConnection, InitializeParams, InitializeResult, TextDocumentPositionParams, TextDocuments } from 'vscode-languageserver';
+import { connectToMongoClient } from '../connectToMongoClient';
 import { MongoScriptDocumentManager } from './mongoScript';
 import SchemaService from './schemaService';
-import { getLanguageService, LanguageService as JsonLanguageService, SchemaConfiguration } from 'vscode-json-languageservice';
-import { connectToMongoClient } from '../connectToMongoClient';
 
 export class LanguageService {
 

--- a/src/mongo/services/mongoScript.ts
+++ b/src/mongo/services/mongoScript.ts
@@ -4,18 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 import { ANTLRInputStream as InputStream } from 'antlr4ts/ANTLRInputStream';
 import { CommonTokenStream } from 'antlr4ts/CommonTokenStream';
-import { ParserRuleContext } from 'antlr4ts/ParserRuleContext';
-import { TerminalNode } from 'antlr4ts/tree/TerminalNode';
-import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { Interval } from 'antlr4ts/misc/Interval';
+import { ParserRuleContext } from 'antlr4ts/ParserRuleContext';
+import { ParseTree } from 'antlr4ts/tree/ParseTree';
+import { TerminalNode } from 'antlr4ts/tree/TerminalNode';
 import { Db } from 'mongodb';
-import * as mongoParser from './../grammar/mongoParser';
+import { LanguageService as JsonLanguageService } from 'vscode-json-languageservice';
+import { CompletionItem, Position, TextDocument } from 'vscode-languageserver';
 import { mongoLexer } from './../grammar/mongoLexer';
+import * as mongoParser from './../grammar/mongoParser';
 import { MongoVisitor } from './../grammar/visitors';
 import { CompletionItemsVisitor } from './completionItemProvider';
 import SchemaService from './schemaService';
-import { LanguageService as JsonLanguageService } from 'vscode-json-languageservice';
-import { TextDocument, CompletionItem, Position } from 'vscode-languageserver';
 
 export class MongoScriptDocumentManager {
 

--- a/src/mongo/services/schemaService.ts
+++ b/src/mongo/services/schemaService.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Db, Cursor } from 'mongodb';
+import { Cursor, Db } from 'mongodb';
 import { SchemaConfiguration } from 'vscode-json-languageservice';
 import { JSONSchema } from 'vscode-json-languageservice/lib/umd/jsonSchema';
 

--- a/src/mongo/shell.ts
+++ b/src/mongo/shell.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import * as cp from 'child_process';
 import * as os from 'os';
-import { IDisposable, toDisposable } from '../utils/vscodeUtils';
 import { EventEmitter, window } from 'vscode';
 import { ext } from '../extensionVariables';
+import { IDisposable, toDisposable } from '../utils/vscodeUtils';
 
 export class Shell {
 

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-import * as path from 'path';
 import { Db } from 'mongodb';
-import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, appendExtensionUserAgent } from 'vscode-azureextensionui';
-import { MongoDatabaseTreeItem, validateMongoCollectionName } from './MongoDatabaseTreeItem';
-import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
-import { MongoDocumentTreeItem } from './MongoDocumentTreeItem';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { appendExtensionUserAgent, IAzureNode, IAzureParentTreeItem, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
-import { getDatabaseNameFromConnectionString } from '../mongoConnectionStrings';
 import { connectToMongoClient } from '../connectToMongoClient';
+import { getDatabaseNameFromConnectionString } from '../mongoConnectionStrings';
+import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
+import { MongoDatabaseTreeItem, validateMongoCollectionName } from './MongoDatabaseTreeItem';
+import { MongoDocumentTreeItem } from './MongoDocumentTreeItem';
 
 export class MongoAccountTreeItem implements IAzureParentTreeItem {
     public static contextValue: string = "cosmosDBMongoServer";

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+import { BulkWriteOpResultObject, Collection, CollectionInsertManyOptions, Cursor, InsertOneWriteOpResult } from 'mongodb';
 import * as path from 'path';
 import * as _ from 'underscore';
-import { Collection, Cursor, InsertOneWriteOpResult, BulkWriteOpResultObject, CollectionInsertManyOptions } from 'mongodb';
-import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
+import * as vscode from 'vscode';
+import { DialogResponses, IAzureNode, IAzureParentTreeItem, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { DefaultBatchSize } from '../../constants';
-import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';
 import { ext } from '../../extensionVariables';
+import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';
 // tslint:disable:no-var-requires
 const EJSON = require("mongodb-extended-json");
 

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-import * as cpUtils from '../../utils/cp';
+import { Collection, Db } from 'mongodb';
 import * as path from 'path';
-import { Db, Collection } from 'mongodb';
-import { Shell } from '../shell';
-import { IAzureParentTreeItem, IAzureTreeItem, IAzureNode, UserCancelledError, IActionContext, DialogResponses, appendExtensionUserAgent } from 'vscode-azureextensionui';
-import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
-import { MongoCommand } from '../MongoCommand';
+import * as vscode from 'vscode';
+import { appendExtensionUserAgent, DialogResponses, IActionContext, IAzureNode, IAzureParentTreeItem, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
+import * as cpUtils from '../../utils/cp';
 import { connectToMongoClient } from '../connectToMongoClient';
+import { MongoCommand } from '../MongoCommand';
+import { Shell } from '../shell';
+import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
 
 export class MongoDatabaseTreeItem implements IAzureParentTreeItem {
 	public static contextValue: string = "mongoDb";

--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Collection, DeleteWriteOpResultObject, ObjectID, UpdateWriteOpResult } from 'mongodb';
+import * as path from 'path';
 import * as _ from 'underscore';
 import * as vscode from 'vscode';
-import * as path from 'path';
-import { Collection, ObjectID, DeleteWriteOpResultObject, UpdateWriteOpResult } from 'mongodb';
-import { IAzureTreeItem, IAzureNode, UserCancelledError, DialogResponses } from 'vscode-azureextensionui';
+import { DialogResponses, IAzureNode, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { getDocumentTreeItemLabel } from '../../utils/vscodeUtils';
 
 export interface IMongoDocument {

--- a/src/table/tree/TableAccountTreeItem.ts
+++ b/src/table/tree/TableAccountTreeItem.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAzureNode, IAzureTreeItem } from "vscode-azureextensionui";
-import { DocDBAccountTreeItemBase } from "../../docdb/tree/DocDBAccountTreeItemBase";
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
+import { DocDBAccountTreeItemBase } from "../../docdb/tree/DocDBAccountTreeItemBase";
 
 export class TableAccountTreeItem extends DocDBAccountTreeItemBase {
     public static contextValue: string = "cosmosDBTableAccount";

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -3,19 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-import * as path from 'path';
 import * as keytarType from 'keytar';
 import { ReplSet } from "mongodb";
-import { IAzureTreeItem, IAzureNode, IAzureParentTreeItem, UserCancelledError, AzureTreeDataProvider, appendExtensionUserAgent } from 'vscode-azureextensionui';
-import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
-import { GraphAccountTreeItem } from '../graph/tree/GraphAccountTreeItem';
-import { TableAccountTreeItem } from '../table/tree/TableAccountTreeItem';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { appendExtensionUserAgent, AzureTreeDataProvider, IAzureNode, IAzureParentTreeItem, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { DocDBAccountTreeItem } from '../docdb/tree/DocDBAccountTreeItem';
-import { tryfetchNodeModule } from '../utils/vscodeUtils';
-import { getDatabaseNameFromConnectionString } from '../mongo/mongoConnectionStrings';
-import { API, getExperienceQuickPicks, getExperienceQuickPick, getExperience } from '../experiences';
+import { API, getExperience, getExperienceQuickPick, getExperienceQuickPicks } from '../experiences';
+import { GraphAccountTreeItem } from '../graph/tree/GraphAccountTreeItem';
 import { connectToMongoClient } from '../mongo/connectToMongoClient';
+import { getDatabaseNameFromConnectionString } from '../mongo/mongoConnectionStrings';
+import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
+import { TableAccountTreeItem } from '../table/tree/TableAccountTreeItem';
+import { tryfetchNodeModule } from '../utils/vscodeUtils';
 
 interface IPersistedAccount {
     id: string;

--- a/src/tree/CosmosDBAccountProvider.ts
+++ b/src/tree/CosmosDBAccountProvider.ts
@@ -3,22 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { azureUtils } from '../utils/azureUtils';
-import { IAzureTreeItem, IAzureNode, IChildProvider, ResourceGroupListStep, LocationListStep, AzureWizard, IActionContext, parseError } from 'vscode-azureextensionui';
-import { TableAccountTreeItem } from "../table/tree/TableAccountTreeItem";
-import { GraphAccountTreeItem } from "../graph/tree/GraphAccountTreeItem";
-import { DocDBAccountTreeItem } from "../docdb/tree/DocDBAccountTreeItem";
-import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
 import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
-import { DatabaseAccountsListResult, DatabaseAccount, DatabaseAccountListKeysResult } from 'azure-arm-cosmosdb/lib/models';
-import { TryGetGremlinEndpointFromAzure } from '../graph/gremlinEndpoints';
-import { ICosmosDBWizardContext } from './CosmosDBAccountWizard/ICosmosDBWizardContext';
-import { CosmosDBAccountNameStep } from './CosmosDBAccountWizard/CosmosDBAccountNameStep';
+import { DatabaseAccount, DatabaseAccountListKeysResult, DatabaseAccountsListResult } from 'azure-arm-cosmosdb/lib/models';
 import * as vscode from 'vscode';
-import { CosmosDBAccountApiStep } from './CosmosDBAccountWizard/CosmosDBAccountApiStep';
-import { API, getExperience } from '../experiences';
-import { CosmosDBAccountCreateStep } from './CosmosDBAccountWizard/CosmosDBAccountCreateStep';
+import { AzureWizard, IActionContext, IAzureNode, IAzureTreeItem, IChildProvider, LocationListStep, parseError, ResourceGroupListStep } from 'vscode-azureextensionui';
 import { getCosmosDBManagementClient } from '../docdb/getCosmosDBManagementClient';
+import { DocDBAccountTreeItem } from "../docdb/tree/DocDBAccountTreeItem";
+import { API, getExperience } from '../experiences';
+import { TryGetGremlinEndpointFromAzure } from '../graph/gremlinEndpoints';
+import { GraphAccountTreeItem } from "../graph/tree/GraphAccountTreeItem";
+import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
+import { TableAccountTreeItem } from "../table/tree/TableAccountTreeItem";
+import { azureUtils } from '../utils/azureUtils';
+import { CosmosDBAccountApiStep } from './CosmosDBAccountWizard/CosmosDBAccountApiStep';
+import { CosmosDBAccountCreateStep } from './CosmosDBAccountWizard/CosmosDBAccountCreateStep';
+import { CosmosDBAccountNameStep } from './CosmosDBAccountWizard/CosmosDBAccountNameStep';
+import { ICosmosDBWizardContext } from './CosmosDBAccountWizard/ICosmosDBWizardContext';
 
 export class CosmosDBAccountProvider implements IChildProvider {
     public childTypeLabel: string = 'Account';

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountApiStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountApiStep.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureQuickPickItem, AzureWizardPromptStep } from 'vscode-azureextensionui';
-import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
+import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { Experience, getExperienceQuickPicks } from '../../experiences';
 import { ext } from '../../extensionVariables';
+import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
 
 export class CosmosDBAccountApiStep extends AzureWizardPromptStep<ICosmosDBWizardContext> {
     public async prompt(wizardContext: ICosmosDBWizardContext): Promise<ICosmosDBWizardContext> {

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountCreateStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountCreateStep.ts
@@ -5,10 +5,10 @@
 
 import { Capability } from 'azure-arm-cosmosdb/lib/models';
 import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
-import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
+import { getCosmosDBManagementClient } from '../../docdb/getCosmosDBManagementClient';
 import { API } from '../../experiences';
 import { ext } from '../../extensionVariables';
-import { getCosmosDBManagementClient } from '../../docdb/getCosmosDBManagementClient';
+import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
 
 export class CosmosDBAccountCreateStep extends AzureWizardExecuteStep<ICosmosDBWizardContext> {
     public async execute(wizardContext: ICosmosDBWizardContext): Promise<ICosmosDBWizardContext> {

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountNameStep.ts
@@ -5,10 +5,10 @@
 
 import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { AzureNameStep, ResourceGroupListStep, resourceGroupNamingRules } from 'vscode-azureextensionui';
-import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
-import { validOnTimeoutOrException } from "../../utils/inputValidation";
-import { ext } from '../../extensionVariables';
 import { getCosmosDBManagementClient } from '../../docdb/getCosmosDBManagementClient';
+import { ext } from '../../extensionVariables';
+import { validOnTimeoutOrException } from "../../utils/inputValidation";
+import { ICosmosDBWizardContext } from './ICosmosDBWizardContext';
 
 export class CosmosDBAccountNameStep extends AzureNameStep<ICosmosDBWizardContext> {
     protected async isRelatedNameAvailable(wizardContext: ICosmosDBWizardContext, name: string): Promise<boolean> {

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
+import { RetrievedDocument } from 'documentdb';
 import * as fse from 'fs-extra';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { IAzureNode, IAzureTreeItem } from 'vscode-azureextensionui';
-import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
 import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
-import { IMongoDocument } from '../mongo/tree/MongoDocumentTreeItem';
-import { RetrievedDocument } from 'documentdb';
 import { ext } from '../extensionVariables';
+import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
+import { IMongoDocument } from '../mongo/tree/MongoDocumentTreeItem';
 
 export interface IDisposable {
     dispose(): void;

--- a/tslint.json
+++ b/tslint.json
@@ -176,7 +176,7 @@
         "object-literal-sort-keys": false,
         "one-variable-per-declaration": true,
         "only-arrow-functions": false,
-        // TODO: "ordered-imports": true,
+        "ordered-imports": true,
         "prefer-array-literal": true,
         "prefer-const": false, // changed
         "prefer-for-of": true,


### PR DESCRIPTION
In order to enforce the ordering on save, place the following in your user preferences: 
```
"editor.codeActionsOnSave": {
		"source.organizeImports": true
	}
```

