### PR TITLE
Mongo Document treeItem: show "null" if _id is null

### DIFF
--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -34,7 +34,7 @@ export class MongoDocumentTreeItem implements IAzureTreeItem {
     }
 
     get id(): string {
-        return this.document._id.toString();
+        return (this.document._id && this.document._id.toString()) || "null";
     }
 
     public async refreshLabel(): Promise<void> {


### PR DESCRIPTION
vscode has a problem with treeItems having no id field. 

It is possible to insert a document with the _id field as _null_. The following commands executes successfully. 
```
db.coll.insertOne({_id: null})
```
(_id can have any data type except for arrays)

This PR handles this edge-case on our end. 