### PR TITLE
remove minor syntactic grand-fathered tslint issues

### DIFF
--- a/src/docdb/tree/DocDBCollectionTreeItem.ts
+++ b/src/docdb/tree/DocDBCollectionTreeItem.ts
@@ -65,10 +65,7 @@ export class DocDBCollectionTreeItem implements IAzureParentTreeItem {
         if (result === DialogResponses.deleteResponse) {
             const client = this.getDocumentClient();
             await new Promise((resolve, reject) => {
-                // tslint:disable-next-line:no-function-expression // Grandfathered in
-                client.deleteCollection(this.link, function (err) {
-                    err ? reject(err) : resolve();
-                });
+                client.deleteCollection(this.link, err => err ? reject(err) : resolve());
             });
         } else {
             throw new UserCancelledError();

--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -55,10 +55,7 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
         if (result === DialogResponses.deleteResponse) {
             const client = this.getDocumentClient();
             await new Promise((resolve, reject) => {
-                // tslint:disable-next-line:no-function-expression // Grandfathered in
-                client.deleteDatabase(this.link, function (err) {
-                    err ? reject(err) : resolve();
-                });
+                client.deleteDatabase(this.link, err => err ? reject(err) : resolve());
             });
         } else {
             throw new UserCancelledError();

--- a/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
@@ -60,10 +60,7 @@ export class DocDBStoredProcedureTreeItem implements IAzureTreeItem {
         if (result === DialogResponses.deleteResponse) {
             const client = getDocumentClient(this._endpoint, this._masterKey, this._isEmulator);
             await new Promise((resolve, reject) => {
-                // tslint:disable-next-line:no-function-expression // Grandfathered in
-                client.deleteStoredProcedure(this.link, function (err) {
-                    err ? reject(err) : resolve();
-                });
+                client.deleteStoredProcedure(this.link, err => err ? reject(err) : resolve());
             });
         } else {
             throw new UserCancelledError();

--- a/src/graph/tree/GraphCollectionTreeItem.ts
+++ b/src/graph/tree/GraphCollectionTreeItem.ts
@@ -67,10 +67,7 @@ export class GraphCollectionTreeItem implements IAzureTreeItem {
         if (result === DialogResponses.deleteResponse) {
             const client = this._database.getDocumentClient();
             await new Promise((resolve, reject) => {
-                // tslint:disable-next-line:no-function-expression // Grandfathered in
-                client.deleteCollection(this.link, function (err) {
-                    err ? reject(err) : resolve();
-                });
+                client.deleteCollection(this.link, err => err ? reject(err) : resolve());
             });
         } else {
             throw new UserCancelledError();

--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -10,8 +10,7 @@ import * as nls from 'vscode-nls';
 
 const localize = nls.loadMessageBundle();
 
-// tslint:disable-next-line:no-default-export // Grandfathered in
-export default class MongoDBLanguageClient {
+export class MongoDBLanguageClient {
 
 	public client: LanguageClient;
 

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -9,7 +9,7 @@ import { CosmosEditorManager } from "../CosmosEditorManager";
 import { ext } from "../extensionVariables";
 import * as vscodeUtil from '../utils/vscodeUtils';
 import { MongoCollectionNodeEditor } from "./editors/MongoCollectionNodeEditor";
-import MongoDBLanguageClient from "./languageClient";
+import { MongoDBLanguageClient } from "./languageClient";
 import { executeAllCommandsFromActiveEditor, executeCommandFromActiveEditor, executeCommandFromText, getAllErrorsFromTextDocument } from "./MongoScrapbook";
 import { MongoCodeLensProvider } from "./services/MongoCodeLensProvider";
 import { MongoAccountTreeItem } from "./tree/MongoAccountTreeItem";

--- a/src/mongo/services/completionItemProvider.ts
+++ b/src/mongo/services/completionItemProvider.ts
@@ -12,7 +12,7 @@ import { CompletionItem, CompletionItemKind, Position, Range, TextDocument } fro
 import { mongoLexer } from './../grammar/mongoLexer';
 import * as mongoParser from './../grammar/mongoParser';
 import { MongoVisitor } from './../grammar/visitors';
-import SchemaService from './schemaService';
+import { SchemaService } from './schemaService';
 
 export class CompletionItemsVisitor extends MongoVisitor<Promise<CompletionItem[]>> {
 

--- a/src/mongo/services/languageService.ts
+++ b/src/mongo/services/languageService.ts
@@ -10,7 +10,7 @@ import { getLanguageService, LanguageService as JsonLanguageService, SchemaConfi
 import { CompletionItem, IConnection, InitializeParams, InitializeResult, TextDocumentPositionParams, TextDocuments } from 'vscode-languageserver';
 import { connectToMongoClient } from '../connectToMongoClient';
 import { MongoScriptDocumentManager } from './mongoScript';
-import SchemaService from './schemaService';
+import { SchemaService } from './schemaService';
 
 export class LanguageService {
 

--- a/src/mongo/services/mongoScript.ts
+++ b/src/mongo/services/mongoScript.ts
@@ -15,7 +15,7 @@ import { mongoLexer } from './../grammar/mongoLexer';
 import * as mongoParser from './../grammar/mongoParser';
 import { MongoVisitor } from './../grammar/visitors';
 import { CompletionItemsVisitor } from './completionItemProvider';
-import SchemaService from './schemaService';
+import { SchemaService } from './schemaService';
 
 export class MongoScriptDocumentManager {
 

--- a/src/mongo/services/schemaService.ts
+++ b/src/mongo/services/schemaService.ts
@@ -6,11 +6,10 @@ import { Cursor, Db } from 'mongodb';
 import { SchemaConfiguration } from 'vscode-json-languageservice';
 import { JSONSchema } from 'vscode-json-languageservice/lib/umd/jsonSchema';
 
-// tslint:disable:no-reserved-keywords // Grandfathered in ("arguments" and "type")
+// tslint:disable:no-reserved-keywords // Grandfathered in ("type")
 // tslint:disable:no-any
 
-// tslint:disable-next-line:no-default-export // Grandfathered in
-export default class SchemaService {
+export class SchemaService {
 
 	private _db: Db;
 	private _schemasCache: Map<string, string> = new Map<string, string>();


### PR DESCRIPTION
Nothing but syntactic simplification for linting, nevertheless I tested all corresponding functionalities.

Next one will be the use of "type" in SchemaService, but this one requires a bit more attention.
I understand you plan to rewrite graphClient, so I won't fix the issues on that one.

Mind that the changes to default exports are breaking if someone is using vscode-cosmosdb as a library (I don't even think that makes sense).