### PR TITLE
Bump up version of vscode-extension-telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -921,7 +921,7 @@
 		"socket.io-client": "^1.7.3",
 		"underscore": "^1.8.3",
 		"vscode-azureextensionui": "^0.17.5",
-		"vscode-extension-telemetry": "^0.0.18",
+		"vscode-extension-telemetry": "^0.0.22",
 		"vscode-json-languageservice": "^3.0.8",
 		"vscode-languageclient": "^4.4.0",
 		"vscode-languageserver": "^4.4.0",


### PR DESCRIPTION
I followed https://github.com/Microsoft/vscode-docker/pull/525 and https://github.com/Microsoft/vscode-azureappservice/issues/627. It looks like the version bump is all we need to do, correct? 