### PR TITLE
Finish debugtelemetry

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,10 @@
 			"outFiles": [
 				"${workspaceRoot}/out/src/**/*.js"
 			],
-			"preLaunchTask": "npm: compile"
+			"preLaunchTask": "npm: compile",
+			"env": {
+				"DEBUGTELEMETRY": "1"
+			}
 		},
 		{
 			"name": "Launch Tests",


### PR DESCRIPTION
I thought I fixed https://github.com/Microsoft/vscode-cosmosdb/issues/855 as a part of switching to Azure Pipelines, but I missed one piece (setting debugtelemetry on launch)