### PR TITLE
Add empty api provider for 0.9.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
 	"activationEvents": [
 		"onLanguage:mongo",
 		"onView:cosmosDBExplorer",
-		"onCommand:cosmosDB.api.getConnectionString",
-		"onCommand:cosmosDB.api.getDatabase",
-		"onCommand:cosmosDB.api.revealTreeItem",
 		"onCommand:cosmosDB.attachDatabaseAccount",
 		"onCommand:cosmosDB.attachEmulator",
 		"onCommand:cosmosDB.createAccount",
@@ -336,21 +333,6 @@
 				"category": "Cosmos DB",
 				"command": "cosmosDB.openStoredProcedure",
 				"title": "Open Stored Procedure"
-			},
-			{
-				"category": "Cosmos DB",
-				"command": "cosmosDB.api.getConnectionString",
-				"title": "Get Connection String"
-			},
-			{
-				"category": "Cosmos DB",
-				"command": "cosmosDB.api.getDatabase",
-				"title": "Get Database Id"
-			},
-			{
-				"category": "Cosmos DB",
-				"command": "cosmosDB.api.revealTreeItem",
-				"title": "Reveal Database in Explorer"
 			}
 		],
 		"menus": {
@@ -714,18 +696,6 @@
 					"when": "never"
 				},
 				{
-					"command": "cosmosDB.api.getConnectionString",
-					"when": "never"
-				},
-				{
-					"command": "cosmosDB.api.getDatabase",
-					"when": "never"
-				},
-				{
-					"command": "cosmosDB.api.revealTreeItem",
-					"when": "never"
-				},
-				{
 					"command": "cosmosDB.executeAllMongoCommands",
 					"when": "editorLangId == 'mongo'"
 				},
@@ -938,7 +908,7 @@
 		"socket.io": "^1.7.3",
 		"socket.io-client": "^1.7.3",
 		"underscore": "^1.8.3",
-		"vscode-azureextensionui": "^0.18.2",
+		"vscode-azureextensionui": "^0.18.6",
 		"vscode-json-languageservice": "^3.0.8",
 		"vscode-languageclient": "^4.4.0",
 		"vscode-languageserver": "^4.4.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,10 +7,8 @@
 
 import * as copypaste from 'copy-paste';
 import * as vscode from 'vscode';
-import { AzureTreeDataProvider, AzureTreeItem, AzureUserInput, createTelemetryReporter, IActionContext, IAzureUserInput, registerCommand, registerEvent, registerUIExtensionVariables, SubscriptionTreeItem } from 'vscode-azureextensionui';
-import { getConnectionString } from './commands/api/getConnectionString';
-import { getDatabase } from './commands/api/getDatabase';
-import { revealTreeItem } from './commands/api/revealTreeItem';
+import { AzureTreeDataProvider, AzureTreeItem, AzureUserInput, createApiProvider, createTelemetryReporter, IActionContext, IAzureUserInput, registerCommand, registerEvent, registerUIExtensionVariables, SubscriptionTreeItem } from 'vscode-azureextensionui';
+import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { importDocuments } from './commands/importDocuments';
 import { CosmosEditorManager } from './CosmosEditorManager';
 import { DocDBDocumentNodeEditor } from './docdb/editors/DocDBDocumentNodeEditor';
@@ -32,7 +30,7 @@ import { AttachedAccountsTreeItem, AttachedAccountSuffix } from './tree/Attached
 import { CosmosDBAccountProvider } from './tree/CosmosDBAccountProvider';
 import * as cpUtil from './utils/cp';
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext): Promise<AzureExtensionApiProvider> {
 	registerUIExtensionVariables(ext);
 	ext.context = context;
 	ext.reporter = createTelemetryReporter(context);
@@ -144,9 +142,8 @@ export function activate(context: vscode.ExtensionContext) {
 				await vscode.commands.executeCommand("cosmosDB.refresh");
 			}
 		});
-	registerCommand('cosmosDB.api.getConnectionString', getConnectionString);
-	registerCommand('cosmosDB.api.getDatabase', getDatabase);
-	registerCommand('cosmosDB.api.revealTreeItem', revealTreeItem);
+
+	return createApiProvider([]);
 }
 
 async function copyConnectionString(node: MongoAccountTreeItem | DocDBAccountTreeItemBase) {


### PR DESCRIPTION
Dependent on this PR: https://github.com/Microsoft/vscode-azuretools/pull/303

The sooner we get the api provider released - the sooner it can start working it's versioning magic going forward.