### PR TITLE
Support 'DatabaseAccount' as resourceType in pickTreeItem api

### DIFF
--- a/src/commands/api/pickTreeItem.ts
+++ b/src/commands/api/pickTreeItem.ts
@@ -61,7 +61,7 @@ export async function pickTreeItem(options: PickTreeItemOptions): Promise<Databa
             break;
         case 'DatabaseAccount':
             contextValuesToFind = options.apiType ? options.apiType.map(getAccountContextValue) : accountContextValues;
-            contextValuesToFind = contextValuesToFind.concat(contextValuesToFind.map((val: string) => val += AttachedAccountSuffix));
+            contextValuesToFind = contextValuesToFind.concat(contextValuesToFind.map((val: string) => val + AttachedAccountSuffix));
             break;
         default:
             throw new RangeError(`Unsupported resource type "${options.resourceType}".`);


### PR DESCRIPTION
We're not using this directly as a part of the App Service Connections feature, but I believe this is the last "Not supported" part of the api. Plus I might start leveraging this in the Functions extension