### PR TITLE
Be leniant of whitespace in docDB connection string

### DIFF
--- a/src/docdb/docDBConnectionStrings.ts
+++ b/src/docdb/docDBConnectionStrings.ts
@@ -17,7 +17,7 @@ export function parseDocDBConnectionString(connectionString: string): ParsedDocD
 }
 
 function getPropertyFromConnectionString(connectionString: string, property: string): string | undefined {
-    const regexp = new RegExp(`(?:^|;)${property}=([^;]+)(?:;|$)`, 'i');
+    const regexp = new RegExp(`(?:^|;)\\s*${property}=([^;]+)(?:;|$)`, 'i');
     const match = connectionString.match(regexp);
     return match && match[1];
 }

--- a/test/docDBConnectionStrings.test.ts
+++ b/test/docDBConnectionStrings.test.ts
@@ -20,6 +20,8 @@ suite(`docDBConnectionStrings`, () => {
     test(`Without database name`, () => {
         // Testing different ordering, different use of ';', different casing, etc.
         testConnectionString('AccountEndpoint=https://abcdef.documents.azure.com:443/;AccountKey=abcdef==', 'https://abcdef.documents.azure.com:443/', 'abcdef==', undefined);
+        testConnectionString('    AccountEndpoint=https://abcdef.documents.azure.com:443/;AccountKey=abcdef==', 'https://abcdef.documents.azure.com:443/', 'abcdef==', undefined);
+        testConnectionString('AccountEndpoint=https://abcdef.documents.azure.com:443/;    AccountKey=abcdef==', 'https://abcdef.documents.azure.com:443/', 'abcdef==', undefined);
         testConnectionString('AccountEndpoint=https://abcdef.documents.azure.com:443/;AccountKey=abcdef==;', 'https://abcdef.documents.azure.com:443/', 'abcdef==', undefined);
         testConnectionString('AccountKey=abcdef==;AccountEndpoint=https://abcdef.documents.azure.com:443/', 'https://abcdef.documents.azure.com:443/', 'abcdef==', undefined);
         testConnectionString('AccountKey=abcdef==;AccountEndpoint=https://abcdef.documents.azure.com:443/;', 'https://abcdef.documents.azure.com:443/', 'abcdef==', undefined);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-cosmosdb/issues/952

Seems easy enough to allow whitespace before the propertyName