### PR TITLE
Hard-code version of "event-stream" to 3.3.4 for current release

### DIFF
--- a/package.json
+++ b/package.json
@@ -901,6 +901,7 @@
 		"fs-extra": "^4.0.2",
 		"gremlin": "^2.6.0",
 		"mongodb": "^2.2.25",
+		"event-stream": "3.3.4",
 		"mongodb-extended-json": "^1.10.0",
 		"ms-rest": "^2.2.1",
 		"opn": "^5.4.0",


### PR DESCRIPTION
"mongodb-extended-json" has a dependency on "event-stream", which is having problems right now: https://github.com/dominictarr/event-stream/issues/116

For this release, I propose we just hard-code event-stream to the version before all of the problems started happening. However going forward, I filed an issue to change our use of "mongodb-extended-json" and hopefully remove our production dependency on "event-stream": https://github.com/Microsoft/vscode-cosmosdb/issues/963