### PR TITLE
Reuse window for scrapbook results.

### DIFF
--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -122,7 +122,8 @@ async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDa
 				}
 				await editorManager.showDocument(new MongoFindOneResultEditor(database, command.collection, result), 'cosmos-result.json', { showInNextColumn: true });
 			} else {
-				await vscodeUtil.showNewFile(result, extensionPath, 'result', '.json', activeEditor.viewColumn + 1);
+				await vscodeUtil.showFile(result, extensionPath, 'scrapbook-result', '.json', activeEditor.viewColumn + 1);
+
 				await refreshTreeAfterCommand(database, command);
 			}
 		}

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -37,6 +37,16 @@ export async function showNewFile(data: string, extensionPath: string, fileName:
     await writeToEditor(editor, data);
 }
 
+export async function showFile(data: string, extensionPath: string, fileName: string, fileExtension: string, column?: vscode.ViewColumn): Promise<void> {
+    let uri: vscode.Uri;
+    const folderPath: string = vscode.workspace.rootPath || extensionPath;
+    const fullFileName: string | undefined = await getFileName(fileName, fileExtension);
+    uri = vscode.Uri.file(path.join(folderPath, fullFileName)).with({ scheme: 'untitled' });
+    const textDocument = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(textDocument, column ? column > vscode.ViewColumn.Three ? vscode.ViewColumn.One : column : undefined, true);
+    await writeToEditor(editor, data);
+}
+
 export async function writeToEditor(editor: vscode.TextEditor, data: string): Promise<void> {
     await editor.edit((editBuilder: vscode.TextEditorEdit) => {
         if (editor.document.lineCount > 0) {
@@ -66,6 +76,11 @@ async function getUniqueFileName(folderPath: string, fileName: string, fileExten
     }
 
     throw new Error('Could not find unique name for new file.');
+}
+
+async function getFileName(fileName: string, fileExtension: string): Promise<string> {
+    const fullFileName: string = fileName + fileExtension;
+    return fullFileName;
 }
 
 export function tryfetchNodeModule(moduleName: string) {


### PR DESCRIPTION
In #607 @EricJizbaMSFT commented that he rarely wanted to save the results of some of the queries he made in the scrapbook, so he disliked the window that was opened and disliked that he had to select "Don't Save" in a dialog box in order to close the window. He suggested putting the results in the Output tab. @StephenWeatherford suggested using "virtual file loading." @dprice later commented that running the same aggregation via "Execute MongoDB Command" multiple times would cause multiple windows to open. I later commented that even running something like `find().limit(1)` multiple times would cause multiple result windows to open.

This PR causes the results of all commands that are not `find` and `findOne` to appear in a window called `scrapbook-result.json`. The window is reused for future commands and the user is able to close the window without being prompted to save. It accomplishes this by adding a `showFile` function to `vscodeUtils`.

I haven't done any work with VS Code extensions in the past, so I'm not sure if this heading in the right direction. Let me know if you're interested in or would like changes.