### PR TITLE
fix graph execute when packaged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,4 @@ grammar/.antlr
 dist
 stats.json
 *.tgz
+*.zip

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,3 +22,5 @@ stats.json
 grammar/*.md
 grammar/*.g4
 build
+*.ts
+*.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cosmosdb",
-	"version": "0.9.2-alpha",
+	"version": "0.10.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -924,8 +924,8 @@
 		"vscode-json-languageservice": "^3.0.8",
 		"vscode-languageclient": "^4.4.0",
 		"vscode-languageserver": "^4.4.0",
-		"vscode-uri": "^1.0.1",
-		"vscode-nls": "^4.0.0"
+		"vscode-nls": "^4.0.0",
+		"vscode-uri": "^1.0.1"
 	},
 	"extensionDependencies": [
 		"ms-vscode.azure-account"

--- a/package.json
+++ b/package.json
@@ -924,8 +924,8 @@
 		"vscode-json-languageservice": "^3.0.8",
 		"vscode-languageclient": "^4.4.0",
 		"vscode-languageserver": "^4.4.0",
-		"vscode-nls": "^4.0.0",
-		"vscode-uri": "^1.0.1"
+		"vscode-uri": "^1.0.1",
+		"vscode-nls": "^4.0.0"
 	},
 	"extensionDependencies": [
 		"ms-vscode.azure-account"

--- a/resources/graphClient/graphClient.css
+++ b/resources/graphClient/graphClient.css
@@ -16,8 +16,10 @@ html {
     /*
     NOTE:
 
-        var(--background-color) and var(--color)
+        var(--vscode-editor-background) and var(--vscode-editor-foreground)
             - Picked up at runtime and represent the theme background and foreground colors
+            (see defaultCssRules in
+            https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/contrib/webview/electron-browser/webview-pre.js)
         var(--graph-background-color) and var(--graph-color):
             Specifically just for the graph itself, regardless of theme
     */
@@ -57,7 +59,7 @@ body {
 }
 
 h1 {
-    color: var(--color);
+    color: var(--vscode-editor-foreground);
     font-weight: 100;
 }
 
@@ -146,8 +148,8 @@ h1 span {
     padding: 10px 15px;
 
     /* Intentionally inverted*/
-    color: var(--background-color);
-    background-color: var(--color);
+    color: var(--vscode-editor-background);
+    background-color: var(--vscode-editor-foreground);
 }
 
 button {
@@ -175,8 +177,8 @@ button:active {
 textarea {
     resize: none;
     font-size: 14px;
-    color: var(--background-color);
-    background-color: var(--color);
+    color: var(--vscode-editor-background);
+    background-color: var(--vscode-editor-foreground);
 }
 
 #jsonResults {
@@ -216,9 +218,9 @@ textarea {
 }
 
 .toggle-radio-buttons input[type="radio"]:checked:not([disabled]) + label {
-    color: var(--color);
+    color: var(--vscode-editor-foreground);
     padding-bottom: 3px;
-    border-bottom-color: var(--color);
+    border-bottom-color: var(--vscode-editor-foreground);
 }
 
 #initialWatermark, #graphWatermark {

--- a/resources/graphClient/graphClient.html
+++ b/resources/graphClient/graphClient.html
@@ -11,17 +11,18 @@
 -->
 
 <head>
-    <link rel="stylesheet" type="text/css" href="graphClient.css"></link>
+    <link rel="stylesheet" type="text/css" href="graphClient.css">
+    </link>
 
-    <script src='../../node_modules/d3/d3.js' charset="UTF-8"></script>
+    <script src='../../dist/node_modules/d3/d3.js' charset="UTF-8"></script>
 
     <script>window.exports = {};</script>
-    <script src="../../node_modules/socket.io-client/dist/socket.io.js"></script>
+    <script src="../../dist/node_modules/socket.io-client/dist/socket.io.js"></script>
     <script>
         io = exports.io;
     </script>
 
-    <script src="../../out/src/graph/client/graphClient.js"></script>
+    <script src="../../dist/graphClient.js"></script>
 </head>
 
 <!-- Possible states (set on #states - see "type State" in graphClient.ts)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,10 @@ let config = dev.getDefaultWebpackConfig({
         'require_optional',
         'gremlin',
         'socket.io',
-        'mongodb-core'
+        'mongodb-core',
+
+        // Needed by graphClient.html
+        'd3'
     ],
     entries: {
         // Note: Each entry is a completely separate Node.js application that cannot interact with any
@@ -105,9 +108,11 @@ let config = dev.getDefaultWebpackConfig({
         }
     ], // end of loaderRules
 
+
     plugins: [
         // Replace vscode-languageserver/lib/files.js with a modified version that doesn't have webpack issues
         new webpack.NormalModuleReplacementPlugin(
+
             /[/\\]vscode-languageserver[/\\]lib[/\\]files\.js/,
             require.resolve('./build/vscode-languageserver-files-stub.js')
         ),
@@ -115,7 +120,10 @@ let config = dev.getDefaultWebpackConfig({
         // Copy files to dist folder where the runtime can find them
         new CopyWebpackPlugin([
             // getCoreNodeModule.js -> dist/node_modules/getCoreNodeModule.js
-            { from: './src/utils/getCoreNodeModule.js', to: 'node_modules' }
+            { from: './src/utils/getCoreNodeModule.js', to: 'node_modules' },
+
+            // graphClient.js -> dist, which is used by graphClient.html
+            { from: './out/src/graph/client/graphClient.js', to: 'graphClient.js' }
         ])
     ]
 });


### PR DESCRIPTION
Fixes #1043, fixes #1041, fixes #1040

1) Fix references to graphClient.js and d3. Only repros when packaged.
2) Fix color issues in vscode Insiders (they've removed --color and --background-color -> use --vscode-editor-{background,forecolor} instead)