### PR TITLE
Improve error-handling of Mongo shell commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ dist
 stats.json
 *.tgz
 *.zip
+
+# Scrapbooks
+*.mongo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,6 @@
 			],
 			"preLaunchTask": "npm: webpack",
 			"env": {
-				"AZCODE_DOCKER_IGNORE_BUNDLE": "1",
 				"DEBUGTELEMETRY": "1",
 				"NODE_DEBUG": ""
 			}
@@ -59,10 +58,11 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "npm: webpack",
+			"preLaunchTask": "npm: compile",
 			"env": {
 				"MOCHA_grep": "", // RegExp of tests to run (empty for all)
 				"MOCHA_enableTimeouts": "0", // Disable time-outs
+				"AZCODE_DOCKER_IGNORE_BUNDLE": "1",
 				"DEBUGTELEMETRY": "1",
 				"NODE_DEBUG": ""
 			}
@@ -87,8 +87,7 @@
 				"MOCHA_grep": "ongo shell", // RegExp of tests to run (empty for all)
 				"MOCHA_enableTimeouts": "0", // Disable time-outs
 				"DEBUGTELEMETRY": "1",
-				"NODE_DEBUG": "",
-				"AZCODE_COSMOS_IGNORE_BUNDLE": "1"
+				"NODE_DEBUG": ""
 			}
 		},
 		{

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,7 +50,7 @@
 			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/dist/test"
+				"--extensionTestsPath=${workspaceFolder}/out/test"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
@@ -80,11 +80,11 @@
 			"sourceMaps": true,
 			// outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
 			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
+				"${workspaceFolder}/dist/**/*.js"
 			],
 			"preLaunchTask": "npm: webpack",
 			"env": {
-				"MOCHA_grep": "ongo shell", // RegExp of tests to run (empty for all)
+				"MOCHA_grep": "", // RegExp of tests to run (empty for all)
 				"MOCHA_enableTimeouts": "0", // Disable time-outs
 				"DEBUGTELEMETRY": "1",
 				"NODE_DEBUG": ""

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,35 +8,38 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceRoot}"
+				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			// outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
 			"outFiles": [
-				"${workspaceFolder}/**/*.js"
+				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "npm: webpack",
+			"preLaunchTask": "npm: compile",
 			"env": {
+				"AZCODE_DOCKER_IGNORE_BUNDLE": "1",
 				"DEBUGTELEMETRY": "1",
 				"NODE_DEBUG": ""
 			}
 		},
 		{
-			"name": "Launch Extension (no build)",
+			"name": "Launch Extension (Webpack)",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceRoot}"
+				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			// outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
 			"outFiles": [
-				"${workspaceFolder}/**/*.js"
+				"${workspaceFolder}/dist/**/*.js"
 			],
+			"preLaunchTask": "npm: webpack",
 			"env": {
+				"AZCODE_DOCKER_IGNORE_BUNDLE": "1",
 				"DEBUGTELEMETRY": "1",
 				"NODE_DEBUG": ""
 			}
@@ -47,14 +50,14 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceRoot}",
-				"--extensionTestsPath=${workspaceRoot}/dist/test"
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/dist/test"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			// outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
 			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
+				"${workspaceFolder}/out/**/*.js"
 			],
 			"preLaunchTask": "npm: webpack",
 			"env": {
@@ -65,6 +68,30 @@
 			}
 		},
 		{
+			"name": "Launch Tests (Webpack)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/dist/test"
+			],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			// outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: webpack",
+			"env": {
+				"MOCHA_grep": "ongo shell", // RegExp of tests to run (empty for all)
+				"MOCHA_enableTimeouts": "0", // Disable time-outs
+				"DEBUGTELEMETRY": "1",
+				"NODE_DEBUG": "",
+				"AZCODE_COSMOS_IGNORE_BUNDLE": "1"
+			}
+		},
+		{
 			"type": "node",
 			"request": "attach",
 			"name": "Attach to Language Server",
@@ -72,7 +99,7 @@
 			"port": 6005,
 			"sourceMaps": true,
 			"outFiles": [
-				"${workspaceRoot}/dist/**/*.js"
+				"${workspaceFolder}/dist/**/*.js"
 			]
 		},
 		{
@@ -84,7 +111,7 @@
 			"sourceMaps": true,
 			"restart": true,
 			"outFiles": [
-				"${workspaceRoot}/out/src"
+				"${workspaceFolder}/out/src"
 			]
 		},
 		{
@@ -98,7 +125,7 @@
 			"name": "Debug Mongo grammar",
 			"type": "antlr-debug",
 			"request": "launch",
-			// This doesn't seem to work: "input": "${workspaceRoot}/${command:AskForTestInput}",
+			// This doesn't seem to work: "input": "${workspaceFolder}/${command:AskForTestInput}",
 			"input": "c:/temp/debugger-input.mongo",
 			"grammar": "grammar/mongo.g4",
 			"startRule": "mongoCommands",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
 	},
 	"editor.codeActionsOnSave": {
 		"source.fixAll.tslint": true,
-	}
+	},
+	"typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -24,3 +24,4 @@ grammar/*.g4
 build
 *.ts
 *.zip
+*.mongo

--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -27,6 +27,7 @@ export { addDatabaseToAccountConnectionString, getDatabaseNameFromConnectionStri
 export { MongoCommand } from './src/mongo/MongoCommand';
 export { getAllCommandsFromText, getCommandFromTextAtLocation } from './src/mongo/MongoScrapbook';
 export { rejectOnTimeout, valueOnTimeout } from './src/utils/timeout';
+export { splitArguments } from './src/utils/splitArguments';
 
 // The tests use instanceof against these and therefore we need to make sure we're using the same version of the bson module in the tests as in the bundle,
 //   so export it from the bundle itself.

--- a/main.js
+++ b/main.js
@@ -16,7 +16,9 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const extension = require("./dist/extension.bundle");
+const ignoreBundle = !/^(false|0)?$/i.test(process.env.AZCODE_DOCKER_IGNORE_BUNDLE || '');
+const extensionPath = ignoreBundle ? "./out/src/extension" : "./dist/extension.bundle";
+const extension = require(extensionPath);
 
 async function activate(ctx) {
     return await extension.activateInternal(ctx, perfStats);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4290,7 +4290,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				},
 				"node-uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/clipboardy": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/clipboardy/-/clipboardy-1.1.0.tgz",
-			"integrity": "sha512-KOxf4ah9diZWmREM5jCupx2+pZaBPwKk5d5jeNK2+TY6IgEO35uhG55NnDT4cdXeRX8irDSHQPtdRrr0JOTQIw==",
-			"dev": true
-		},
 		"@types/d3": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.0.0.tgz",
@@ -744,11 +738,6 @@
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
-		},
-		"arch": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-			"integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
 		},
 		"archive-type": {
 			"version": "4.0.0",
@@ -1720,15 +1709,6 @@
 				"rimraf": "^2.6.1"
 			}
 		},
-		"clipboardy": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-			"integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-			"requires": {
-				"arch": "^2.1.0",
-				"execa": "^0.8.0"
-			}
-		},
 		"cliui": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -2171,16 +2151,6 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
-			}
-		},
-		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
 			}
 		},
 		"crypt": {
@@ -3051,20 +3021,6 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"execa": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			}
-		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -3557,14 +3513,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "^2.12.1",
+				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3586,7 +3542,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3612,7 +3568,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3642,16 +3598,16 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3700,7 +3656,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3720,12 +3676,12 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -3790,17 +3746,17 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3818,35 +3774,35 @@
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^4.1.0",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -3863,13 +3819,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3946,12 +3902,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -3981,16 +3937,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -4008,7 +3964,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -4061,17 +4017,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -4082,12 +4038,12 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -4097,7 +4053,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -4105,9 +4061,9 @@
 			}
 		},
 		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -4127,11 +4083,6 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
-		},
-		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -4339,7 +4290,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				},
 				"node-uuid": {
@@ -5354,6 +5305,11 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
 		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5362,7 +5318,8 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -5382,9 +5339,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -5813,6 +5770,7 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -6448,9 +6406,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true,
 			"optional": true
 		},
@@ -6607,6 +6565,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -6770,6 +6729,14 @@
 				"wrappy": "1"
 			}
 		},
+		"opn": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+			"integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+			"requires": {
+				"is-wsl": "^1.1.0"
+			}
+		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -6839,7 +6806,8 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
@@ -7037,7 +7005,8 @@
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -7197,7 +7166,8 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.1.31",
@@ -7779,6 +7749,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -7786,7 +7757,8 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"shell-quote": {
 			"version": "1.6.1",
@@ -7803,7 +7775,8 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -8395,7 +8368,8 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"style-loader": {
 			"version": "0.8.3",
@@ -8476,13 +8450,13 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
 			"dev": true,
 			"requires": {
 				"block-stream": "*",
-				"fstream": "^1.0.2",
+				"fstream": "^1.0.12",
 				"inherits": "2"
 			}
 		},
@@ -9904,9 +9878,9 @@
 			}
 		},
 		"vscode-azureextensionui": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.23.1.tgz",
-			"integrity": "sha512-1bCFeaDYdQv/YhheNeqajQhRQf4/a07BRhb1YEnzPzxXOPR8ib6SZqYwR29P4fy2x1f3cDW/ucis2o2kCDsSuA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.25.0.tgz",
+			"integrity": "sha512-uyCBLPn79MGroHV/nQJI3BrYTABpNrEnYjVZFf7MJK3xo9vsAyIUCwycarNm3Rzw1jOOLa4jMWbsszoH2odVPA==",
 			"requires": {
 				"azure-arm-resource": "^3.0.0-preview",
 				"azure-arm-storage": "^3.1.0",
@@ -9914,6 +9888,7 @@
 				"html-to-text": "^4.0.0",
 				"ms-rest": "^2.2.2",
 				"ms-rest-azure": "^2.4.4",
+				"opn": "^6.0.0",
 				"semver": "^5.6.0",
 				"vscode-extension-telemetry": "^0.1.0",
 				"vscode-nls": "^4.0.0"
@@ -10333,6 +10308,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -10430,7 +10406,8 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yargs": {
 			"version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"displayName": "Azure Cosmos DB",
 	"description": "Create, browse, and update globally distributed, multi-model databases in Azure.",
 	"engines": {
-		"vscode": "^1.26.0"
+		"vscode": "^1.31.0"
 	},
 	"galleryBanner": {
 		"color": "#3c3c3c",
@@ -97,6 +97,10 @@
 		"languages": [
 			{
 				"id": "mongo",
+				"aliases": [
+					"Mongo Scrapbook",
+					"mongo"
+				],
 				"extensions": [
 					".mongo"
 				],
@@ -696,6 +700,10 @@
 					"when": "never"
 				},
 				{
+					"command": "cosmosDB.update",
+					"when": "never"
+				},
+				{
 					"command": "cosmosDB.executeAllMongoCommands",
 					"when": "editorLangId == 'mongo'"
 				},
@@ -732,8 +740,13 @@
 						"string",
 						"null"
 					],
-					"description": "Command to execute or full path to folder and executable to start the Mongo shell, needed by some Mongo scrapbook commands. If empty, will search in the system path for 'mongo'.",
+					"description": "Full path to folder and executable to start the Mongo shell, needed by some Mongo scrapbook commands. If empty, will search in the system path for 'mongo'.",
 					"default": null
+				},
+				"mongo.shell.args": {
+					"type": "string",
+					"description": "Arguments to pass when starting the Mongo shell.",
+					"default": ""
 				},
 				"mongo.shell.timeout": {
 					"type": "number",
@@ -871,7 +884,6 @@
 		"all": "npm i && npm run lint && npm test"
 	},
 	"devDependencies": {
-		"@types/clipboardy": "^1.1.0",
 		"@types/d3": "5.0.0",
 		"@types/documentdb": "^1.10.2",
 		"@types/fs-extra": "^4.0.3",
@@ -905,7 +917,6 @@
 		"antlr4ts": "^0.4.1-alpha.0",
 		"azure-arm-cosmosdb": "^1.1.2",
 		"azure-arm-resource": "^3.0.0-preview",
-		"clipboardy": "^1.2.3",
 		"d3": "^3.0.0",
 		"documentdb": "^1.14.2",
 		"event-stream": "3.3.4",
@@ -918,7 +929,7 @@
 		"socket.io": "^1.7.3",
 		"socket.io-client": "^1.7.3",
 		"underscore": "^1.8.3",
-		"vscode-azureextensionui": "^0.23.2",
+		"vscode-azureextensionui": "^0.25.0",
 		"vscode-json-languageservice": "^3.0.8",
 		"vscode-languageclient": "^4.4.0",
 		"vscode-languageserver": "^4.4.0",

--- a/src/commands/api/findTreeItem.ts
+++ b/src/commands/api/findTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { parseDocDBConnectionString } from '../../docdb/docDBConnectionStrings';
 import { DocDBAccountTreeItemBase } from '../../docdb/tree/DocDBAccountTreeItemBase';
 import { DocDBDatabaseTreeItemBase } from '../../docdb/tree/DocDBDatabaseTreeItemBase';
@@ -12,61 +12,66 @@ import { parseMongoConnectionString } from '../../mongo/mongoConnectionStrings';
 import { MongoAccountTreeItem } from '../../mongo/tree/MongoAccountTreeItem';
 import { MongoDatabaseTreeItem } from '../../mongo/tree/MongoDatabaseTreeItem';
 import { ParsedConnectionString } from '../../ParsedConnectionString';
-import { CosmosDBAccountProvider } from '../../tree/CosmosDBAccountProvider';
+import { SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 import { DatabaseAccountTreeItem, DatabaseTreeItem, TreeItemQuery } from '../../vscode-cosmosdb.api';
 import { cacheTreeItem, tryGetTreeItemFromCache } from './apiCache';
 import { DatabaseAccountTreeItemInternal } from './DatabaseAccountTreeItemInternal';
 import { DatabaseTreeItemInternal } from './DatabaseTreeItemInternal';
 
 export async function findTreeItem(query: TreeItemQuery): Promise<DatabaseAccountTreeItem | DatabaseTreeItem | undefined> {
-    const connectionString = query.connectionString;
-    let parsedCS: ParsedConnectionString;
-    if (/^mongodb[^:]*:\/\//i.test(connectionString)) {
-        parsedCS = await parseMongoConnectionString(connectionString);
-    } else {
-        parsedCS = parseDocDBConnectionString(connectionString);
-    }
+    return await callWithTelemetryAndErrorHandling('api.findTreeItem', async (context: IActionContext) => {
+        context.errorHandling.suppressDisplay = true;
+        context.errorHandling.rethrow = true;
 
-    const maxTime = Date.now() + 10 * 1000; // Give up searching subscriptions after 10 seconds and just attach the account
+        const connectionString = query.connectionString;
+        let parsedCS: ParsedConnectionString;
+        if (/^mongodb[^:]*:\/\//i.test(connectionString)) {
+            parsedCS = await parseMongoConnectionString(connectionString);
+        } else {
+            parsedCS = parseDocDBConnectionString(connectionString);
+        }
 
-    // 1. Get result from cache if possible
-    let result: DatabaseAccountTreeItem | DatabaseTreeItem | undefined = tryGetTreeItemFromCache(parsedCS);
+        const maxTime = Date.now() + 10 * 1000; // Give up searching subscriptions after 10 seconds and just attach the account
 
-    // 2. Search attached accounts (do this before subscriptions because it's faster)
-    if (!result) {
-        const attachedDbAccounts = await ext.attachedAccountsNode.getCachedChildren();
-        result = await searchDbAccounts(attachedDbAccounts, parsedCS, maxTime);
-    }
+        // 1. Get result from cache if possible
+        let result: DatabaseAccountTreeItem | DatabaseTreeItem | undefined = tryGetTreeItemFromCache(parsedCS);
 
-    // 3. Search subscriptions
-    if (!result) {
-        const rootNodes = await ext.tree.getChildren();
-        for (const rootNode of rootNodes) {
-            if (Date.now() > maxTime) {
-                break;
-            }
+        // 2. Search attached accounts (do this before subscriptions because it's faster)
+        if (!result) {
+            const attachedDbAccounts = await ext.attachedAccountsNode.getCachedChildren(context);
+            result = await searchDbAccounts(attachedDbAccounts, parsedCS, context, maxTime);
+        }
 
-            if (rootNode instanceof CosmosDBAccountProvider) {
-                const dbAccounts = await rootNode.getCachedChildren();
-                result = await searchDbAccounts(dbAccounts, parsedCS, maxTime);
-                if (result) {
+        // 3. Search subscriptions
+        if (!result) {
+            const rootNodes = await ext.tree.getChildren();
+            for (const rootNode of rootNodes) {
+                if (Date.now() > maxTime) {
                     break;
+                }
+
+                if (rootNode instanceof SubscriptionTreeItem) {
+                    const dbAccounts = await rootNode.getCachedChildren(context);
+                    result = await searchDbAccounts(dbAccounts, parsedCS, context, maxTime);
+                    if (result) {
+                        break;
+                    }
                 }
             }
         }
-    }
 
-    // 4. If all else fails, just attach a new node
-    if (!result) {
-        result = new DatabaseTreeItemInternal(parsedCS);
-    }
+        // 4. If all else fails, just attach a new node
+        if (!result) {
+            result = new DatabaseTreeItemInternal(parsedCS);
+        }
 
-    cacheTreeItem(parsedCS, result);
+        cacheTreeItem(parsedCS, result);
 
-    return result;
+        return result;
+    });
 }
 
-async function searchDbAccounts(dbAccounts: AzureTreeItem[], expected: ParsedConnectionString, maxTime: number): Promise<DatabaseAccountTreeItem | DatabaseTreeItem | undefined> {
+async function searchDbAccounts(dbAccounts: AzExtTreeItem[], expected: ParsedConnectionString, context: IActionContext, maxTime: number): Promise<DatabaseAccountTreeItem | DatabaseTreeItem | undefined> {
     for (const dbAccount of dbAccounts) {
         if (Date.now() > maxTime) {
             return undefined;
@@ -83,7 +88,7 @@ async function searchDbAccounts(dbAccounts: AzureTreeItem[], expected: ParsedCon
 
         if (expected.accountId === actual.accountId) {
             if (expected.databaseName) {
-                const dbs = await dbAccount.getCachedChildren();
+                const dbs = await dbAccount.getCachedChildren(context);
                 for (const db of dbs) {
                     if ((db instanceof MongoDatabaseTreeItem || db instanceof DocDBDatabaseTreeItemBase) && expected.databaseName === db.databaseName) {
                         return new DatabaseTreeItemInternal(expected, dbAccount, db);

--- a/src/commands/importDocuments.ts
+++ b/src/commands/importDocuments.ts
@@ -6,12 +6,12 @@
 import { NewDocument } from 'documentdb';
 import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
-import { parseError } from 'vscode-azureextensionui';
+import { IActionContext, parseError } from 'vscode-azureextensionui';
 import { DocDBCollectionTreeItem } from '../docdb/tree/DocDBCollectionTreeItem';
 import { ext } from '../extensionVariables';
 import { MongoCollectionTreeItem } from '../mongo/tree/MongoCollectionTreeItem';
 
-export async function importDocuments(uris: vscode.Uri[] | undefined, collectionNode: MongoCollectionTreeItem | DocDBCollectionTreeItem | undefined): Promise<void> {
+export async function importDocuments(actionContext: IActionContext, uris: vscode.Uri[] | undefined, collectionNode: MongoCollectionTreeItem | DocDBCollectionTreeItem | undefined): Promise<void> {
     if (!uris) {
         uris = await askForDocuments();
     }
@@ -30,7 +30,7 @@ export async function importDocuments(uris: vscode.Uri[] | undefined, collection
         ext.outputChannel.show();
     }
     if (!collectionNode) {
-        collectionNode = <MongoCollectionTreeItem | DocDBCollectionTreeItem>await ext.tree.showTreeItemPicker([MongoCollectionTreeItem.contextValue, DocDBCollectionTreeItem.contextValue]);
+        collectionNode = <MongoCollectionTreeItem | DocDBCollectionTreeItem>await ext.tree.showTreeItemPicker([MongoCollectionTreeItem.contextValue, DocDBCollectionTreeItem.contextValue], actionContext);
     }
     let result: string;
     result = await vscode.window.withProgress(
@@ -43,7 +43,7 @@ export async function importDocuments(uris: vscode.Uri[] | undefined, collection
             const documents = await parseDocuments(uris);
             progress.report({ increment: 30, message: "Parsed documents. Importing" });
             if (collectionNode instanceof MongoCollectionTreeItem) {
-                result = processMongoResults(await collectionNode.executeCommand('insertMany', [JSON.stringify(documents)]));
+                result = processMongoResults(await collectionNode.tryExecuteCommandDirectly('insertMany', [JSON.stringify(documents)]));
             } else {
                 result = await insertDocumentsIntoDocdb(collectionNode, documents, uris);
             }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,37 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as assert from 'assert';
+import * as fs from 'fs';
 import * as path from 'path';
+import { ext } from './extensionVariables';
 
-export const resourcesPath = path.join(__dirname, '..', 'resources'); // (relative to dist folder)
+export interface IThemedIconPath {
+    light: string;
+    dark: string;
+}
+
+export function getThemedIconPath(iconName: string): IThemedIconPath {
+    let a = {
+        light: path.join(getResourcesPath(), 'icons', 'light', iconName),
+        dark: path.join(getResourcesPath(), 'icons', 'dark', iconName)
+    };
+    assert(fs.existsSync(a.light));
+    return a;
+}
+
+export function getThemeAgnosticIconPath(iconName: string): IThemedIconPath {
+    let a = {
+        light: path.join(getResourcesPath(), 'icons', 'theme-agnostic', iconName),
+        dark: path.join(getResourcesPath(), 'icons', 'theme-agnostic', iconName)
+    };
+    assert(fs.existsSync(a.light));
+    return a;
+}
+
+export function getResourcesPath(): string {
+    return ext.context.asAbsolutePath('resources');
+}
 
 export const defaultBatchSize: number = 50;
 

--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { commands } from "vscode";
-import { registerCommand } from "vscode-azureextensionui";
+import { IActionContext, registerCommand } from "vscode-azureextensionui";
 import { doubleClickDebounceDelay } from "../constants";
 import { CosmosEditorManager } from "../CosmosEditorManager";
 import { ext } from "../extensionVariables";
@@ -18,68 +18,68 @@ import { DocDBStoredProceduresTreeItem } from "./tree/DocDBStoredProceduresTreeI
 import { DocDBStoredProcedureTreeItem } from "./tree/DocDBStoredProcedureTreeItem";
 
 export function registerDocDBCommands(editorManager: CosmosEditorManager): void {
-    registerCommand('cosmosDB.createDocDBDatabase', async (node?: DocDBAccountTreeItem) => {
+    registerCommand('cosmosDB.createDocDBDatabase', async (context: IActionContext, node?: DocDBAccountTreeItem) => {
         if (!node) {
-            node = <DocDBAccountTreeItem>await ext.tree.showTreeItemPicker(DocDBAccountTreeItem.contextValue);
+            node = <DocDBAccountTreeItem>await ext.tree.showTreeItemPicker(DocDBAccountTreeItem.contextValue, context);
         }
-        const databaseNode: DocDBDatabaseTreeItem = <DocDBDatabaseTreeItem>await node.createChild();
+        const databaseNode: DocDBDatabaseTreeItem = <DocDBDatabaseTreeItem>await node.createChild(context);
         await ext.treeView.reveal(databaseNode, { focus: false });
-        const collectionNode: DocDBCollectionTreeItem = <DocDBCollectionTreeItem>await databaseNode.createChild();
+        const collectionNode: DocDBCollectionTreeItem = <DocDBCollectionTreeItem>await databaseNode.createChild(context);
         await ext.treeView.reveal(collectionNode);
     });
-    registerCommand('cosmosDB.createDocDBCollection', async (node?: DocDBDatabaseTreeItem) => {
+    registerCommand('cosmosDB.createDocDBCollection', async (context: IActionContext, node?: DocDBDatabaseTreeItem) => {
         if (!node) {
-            node = <DocDBDatabaseTreeItem>await ext.tree.showTreeItemPicker(DocDBDatabaseTreeItem.contextValue);
+            node = <DocDBDatabaseTreeItem>await ext.tree.showTreeItemPicker(DocDBDatabaseTreeItem.contextValue, context);
         }
-        const collectionNode: DocDBCollectionTreeItem = <DocDBCollectionTreeItem>await node.createChild();
+        const collectionNode: DocDBCollectionTreeItem = <DocDBCollectionTreeItem>await node.createChild(context);
         await ext.treeView.reveal(collectionNode);
     });
-    registerCommand('cosmosDB.createDocDBDocument', async (node?: DocDBDocumentsTreeItem) => {
+    registerCommand('cosmosDB.createDocDBDocument', async (context: IActionContext, node?: DocDBDocumentsTreeItem) => {
         if (!node) {
-            node = <DocDBDocumentsTreeItem>await ext.tree.showTreeItemPicker(DocDBDocumentsTreeItem.contextValue);
+            node = <DocDBDocumentsTreeItem>await ext.tree.showTreeItemPicker(DocDBDocumentsTreeItem.contextValue, context);
         }
-        let documentNode = <DocDBDocumentTreeItem>await node.createChild();
+        let documentNode = <DocDBDocumentTreeItem>await node.createChild(context);
         await ext.treeView.reveal(documentNode);
         await commands.executeCommand("cosmosDB.openDocument", documentNode);
 
     });
-    registerCommand('cosmosDB.createDocDBStoredProcedure', async (node?: DocDBStoredProceduresTreeItem) => {
+    registerCommand('cosmosDB.createDocDBStoredProcedure', async (context: IActionContext, node?: DocDBStoredProceduresTreeItem) => {
         if (!node) {
-            node = <DocDBStoredProceduresTreeItem>await ext.tree.showTreeItemPicker(DocDBStoredProceduresTreeItem.contextValue);
+            node = <DocDBStoredProceduresTreeItem>await ext.tree.showTreeItemPicker(DocDBStoredProceduresTreeItem.contextValue, context);
         }
-        let childNode = await node.createChild();
+        let childNode = await node.createChild(context);
         await commands.executeCommand("cosmosDB.openStoredProcedure", childNode);
 
     });
-    registerCommand('cosmosDB.deleteDocDBDatabase', async (node?: DocDBDatabaseTreeItem) => {
+    registerCommand('cosmosDB.deleteDocDBDatabase', async (context: IActionContext, node?: DocDBDatabaseTreeItem) => {
         if (!node) {
-            node = <DocDBDatabaseTreeItem>await ext.tree.showTreeItemPicker(DocDBDatabaseTreeItem.contextValue);
+            node = <DocDBDatabaseTreeItem>await ext.tree.showTreeItemPicker(DocDBDatabaseTreeItem.contextValue, context);
         }
-        await node.deleteTreeItem();
+        await node.deleteTreeItem(context);
     });
-    registerCommand('cosmosDB.deleteDocDBCollection', async (node?: DocDBCollectionTreeItem) => {
+    registerCommand('cosmosDB.deleteDocDBCollection', async (context: IActionContext, node?: DocDBCollectionTreeItem) => {
         if (!node) {
-            node = <DocDBCollectionTreeItem>await ext.tree.showTreeItemPicker(DocDBCollectionTreeItem.contextValue);
+            node = <DocDBCollectionTreeItem>await ext.tree.showTreeItemPicker(DocDBCollectionTreeItem.contextValue, context);
         }
-        await node.deleteTreeItem();
+        await node.deleteTreeItem(context);
     });
-    registerCommand('cosmosDB.openStoredProcedure', async (node?: DocDBStoredProcedureTreeItem) => {
+    registerCommand('cosmosDB.openStoredProcedure', async (context: IActionContext, node?: DocDBStoredProcedureTreeItem) => {
         if (!node) {
-            node = <DocDBStoredProcedureTreeItem>await ext.tree.showTreeItemPicker([DocDBStoredProcedureTreeItem.contextValue]);
+            node = <DocDBStoredProcedureTreeItem>await ext.tree.showTreeItemPicker([DocDBStoredProcedureTreeItem.contextValue], context);
         }
-        await editorManager.showDocument(new DocDBStoredProcedureNodeEditor(node), node.label + '-cosmos-stored-procedure.js');
+        await editorManager.showDocument(context, new DocDBStoredProcedureNodeEditor(node), node.label + '-cosmos-stored-procedure.js');
         // tslint:disable-next-line:align
     }, doubleClickDebounceDelay);
-    registerCommand('cosmosDB.deleteDocDBDocument', async (node?: DocDBDocumentTreeItem) => {
+    registerCommand('cosmosDB.deleteDocDBDocument', async (context: IActionContext, node?: DocDBDocumentTreeItem) => {
         if (!node) {
-            node = <DocDBDocumentTreeItem>await ext.tree.showTreeItemPicker(DocDBDocumentTreeItem.contextValue);
+            node = <DocDBDocumentTreeItem>await ext.tree.showTreeItemPicker(DocDBDocumentTreeItem.contextValue, context);
         }
-        await node.deleteTreeItem();
+        await node.deleteTreeItem(context);
     });
-    registerCommand('cosmosDB.deleteDocDBStoredProcedure', async (node?: DocDBStoredProcedureTreeItem) => {
+    registerCommand('cosmosDB.deleteDocDBStoredProcedure', async (context: IActionContext, node?: DocDBStoredProcedureTreeItem) => {
         if (!node) {
-            node = <DocDBStoredProcedureTreeItem>await ext.tree.showTreeItemPicker(DocDBStoredProcedureTreeItem.contextValue);
+            node = <DocDBStoredProcedureTreeItem>await ext.tree.showTreeItemPicker(DocDBStoredProcedureTreeItem.contextValue, context);
         }
-        await node.deleteTreeItem();
+        await node.deleteTreeItem(context);
     });
 }

--- a/src/docdb/tree/DocDBCollectionTreeItem.ts
+++ b/src/docdb/tree/DocDBCollectionTreeItem.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CollectionMeta, CollectionPartitionKey } from 'documentdb';
-import * as path from "path";
 import * as vscode from 'vscode';
 import { AzureParentTreeItem, AzureTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { resourcesPath } from '../../constants';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { DocDBDatabaseTreeItem } from './DocDBDatabaseTreeItem';
 import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 import { DocDBDocumentTreeItem } from './DocDBDocumentTreeItem';
@@ -40,10 +39,7 @@ export class DocDBCollectionTreeItem extends AzureParentTreeItem<IDocDBTreeRoot>
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg')
-        };
+        return getThemeAgnosticIconPath('Collection.svg');
     }
 
     public get link(): string {
@@ -75,18 +71,19 @@ export class DocDBCollectionTreeItem extends AzureParentTreeItem<IDocDBTreeRoot>
         return false;
     }
 
-    public pickTreeItemImpl(expectedContextValue: string): AzureTreeItem<IDocDBTreeRoot> | undefined {
-        switch (expectedContextValue) {
-            case DocDBDocumentsTreeItem.contextValue:
-            case DocDBDocumentTreeItem.contextValue:
-                return this.documentsTreeItem;
-
-            case DocDBStoredProceduresTreeItem.contextValue:
-            case DocDBStoredProcedureTreeItem.contextValue:
-                return this._storedProceduresTreeItem;
-
-            default:
-                return undefined;
+    public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): AzureTreeItem<IDocDBTreeRoot> | undefined {
+        for (const expectedContextValue of expectedContextValues) {
+            switch (expectedContextValue) {
+                case DocDBDocumentsTreeItem.contextValue:
+                case DocDBDocumentTreeItem.contextValue:
+                    return this.documentsTreeItem;
+                case DocDBStoredProceduresTreeItem.contextValue:
+                case DocDBStoredProcedureTreeItem.contextValue:
+                    return this._storedProceduresTreeItem;
+                default:
+            }
         }
+
+        return undefined;
     }
 }

--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -5,10 +5,9 @@
 
 import { Collection, CollectionMeta, DatabaseMeta, DocumentClient, FeedOptions, QueryIterator } from 'documentdb';
 import { DocumentBase } from 'documentdb/lib';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzureTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { resourcesPath } from '../../constants';
+import { AzureTreeItem, DialogResponses, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { DocDBAccountTreeItemBase } from './DocDBAccountTreeItemBase';
 import { DocDBTreeItemBase } from './DocDBTreeItemBase';
@@ -32,10 +31,7 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Database.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Database.svg')
-        };
+        return getThemeAgnosticIconPath('Database.svg');
     }
 
     public get id(): string {
@@ -77,7 +73,7 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
     }
 
     // Create a DB collection
-    public async createChildImpl(showCreatingTreeItem: (label: string) => void): Promise<AzureTreeItem<IDocDBTreeRoot>> {
+    public async createChildImpl(context: ICreateChildImplContext): Promise<AzureTreeItem<IDocDBTreeRoot>> {
         const collectionName = await ext.ui.showInputBox({
             placeHolder: `Enter an id for your ${this.childTypeLabel}`,
             ignoreFocusOut: true,
@@ -114,7 +110,7 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Collec
 
         const options = { offerThroughput: throughput };
 
-        showCreatingTreeItem(collectionName);
+        context.showCreatingTreeItem(collectionName);
         const client = this.root.getDocumentClient();
         const collection: CollectionMeta = await new Promise<CollectionMeta>((resolve, reject) => {
             client.createCollection(this.link, collectionDef, options, (err, result) => {

--- a/src/docdb/tree/DocDBDocumentTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentTreeItem.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentClient, RetrievedDocument } from 'documentdb';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { emptyPartitionKeyValue, resourcesPath } from '../../constants';
+import { emptyPartitionKeyValue, getThemeAgnosticIconPath } from '../../constants';
 import { getDocumentTreeItemLabel } from '../../utils/vscodeUtils';
 import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
@@ -55,10 +54,7 @@ export class DocDBDocumentTreeItem extends AzureTreeItem<IDocDBTreeRoot> {
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Document.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Document.svg')
-        };
+        return getThemeAgnosticIconPath('Document.svg');
     }
 
     public async deleteTreeItemImpl(): Promise<void> {

--- a/src/docdb/tree/DocDBDocumentsTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentsTreeItem.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentClient, FeedOptions, NewDocument, QueryIterator, RetrievedDocument } from 'documentdb';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { UserCancelledError } from 'vscode-azureextensionui';
-import { resourcesPath } from '../../constants';
+import { ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
 import { DocDBDocumentTreeItem } from './DocDBDocumentTreeItem';
 import { DocDBTreeItemBase } from './DocDBTreeItemBase';
@@ -26,10 +25,7 @@ export class DocDBDocumentsTreeItem extends DocDBTreeItemBase<RetrievedDocument>
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg')
-        };
+        return getThemeAgnosticIconPath('Collection.svg');
     }
 
     public get id(): string {
@@ -52,7 +48,7 @@ export class DocDBDocumentsTreeItem extends DocDBTreeItemBase<RetrievedDocument>
         return new DocDBDocumentTreeItem(this, document);
     }
 
-    public async createChildImpl(showCreatingTreeItem: (label: string) => void): Promise<DocDBDocumentTreeItem> {
+    public async createChildImpl(context: ICreateChildImplContext): Promise<DocDBDocumentTreeItem> {
         let docID = await vscode.window.showInputBox({
             prompt: "Enter a document ID or leave blank for a generated ID",
             ignoreFocusOut: true
@@ -62,7 +58,7 @@ export class DocDBDocumentsTreeItem extends DocDBTreeItemBase<RetrievedDocument>
             docID = docID.trim();
             let body = { 'id': docID };
             body = <NewDocument>(await this.promptForPartitionKey(body));
-            showCreatingTreeItem(docID);
+            context.showCreatingTreeItem(docID);
             const document = await this.createDocument(body);
 
             return this.initChild(document);

--- a/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ProcedureMeta } from 'documentdb';
-import * as path from 'path';
 import * as vscode from "vscode";
 import { AzureTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { resourcesPath } from '../../constants';
+import { getThemedIconPath } from '../../constants';
 import { DocDBStoredProceduresTreeItem } from './DocDBStoredProceduresTreeItem';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
 
@@ -52,10 +51,7 @@ export class DocDBStoredProcedureTreeItem extends AzureTreeItem<IDocDBTreeRoot> 
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'light', 'Process_16x.svg'),
-            dark: path.join(resourcesPath, 'icons', 'dark', 'Process_16x.svg')
-        };
+        return getThemedIconPath('Process_16x.svg');
     }
 
     public async deleteTreeItemImpl(): Promise<void> {

--- a/src/docdb/tree/DocDBStoredProceduresTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProceduresTreeItem.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentClient, FeedOptions, ProcedureMeta, QueryIterator } from 'documentdb';
-import * as path from 'path';
 import * as vscode from "vscode";
-import { UserCancelledError } from 'vscode-azureextensionui';
-import { defaultStoredProcedure, resourcesPath } from '../../constants';
+import { ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
+import { defaultStoredProcedure, getThemeAgnosticIconPath } from '../../constants';
 import { GraphCollectionTreeItem } from '../../graph/tree/GraphCollectionTreeItem';
 import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
 import { DocDBStoredProcedureTreeItem } from './DocDBStoredProcedureTreeItem';
@@ -31,13 +30,10 @@ export class DocDBStoredProceduresTreeItem extends DocDBTreeItemBase<ProcedureMe
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'stored procedures.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'stored procedures.svg')
-        };
+        return getThemeAgnosticIconPath('stored procedures.svg');
     }
 
-    public async createChildImpl(showCreatingTreeItem: (label: string) => void): Promise<DocDBStoredProcedureTreeItem> {
+    public async createChildImpl(context: ICreateChildImplContext): Promise<DocDBStoredProcedureTreeItem> {
         const client = this.root.getDocumentClient();
         let spID = await vscode.window.showInputBox({
             prompt: "Enter a unique stored procedure ID",
@@ -47,7 +43,7 @@ export class DocDBStoredProceduresTreeItem extends DocDBTreeItemBase<ProcedureMe
 
         if (spID || spID === "") {
             spID = spID.trim();
-            showCreatingTreeItem(spID);
+            context.showCreatingTreeItem(spID);
             const sproc: ProcedureMeta = await new Promise<ProcedureMeta>((resolve, reject) => {
                 client.createStoredProcedure(this.link, { id: spID, body: defaultStoredProcedure }, (err, result: ProcedureMeta) => {
                     if (err) {

--- a/src/docdb/tree/DocDBTreeItemBase.ts
+++ b/src/docdb/tree/DocDBTreeItemBase.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentClient, FeedOptions, QueryError, QueryIterator } from 'documentdb';
-import { AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
 import { defaultBatchSize } from '../../constants';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
 
@@ -29,7 +29,7 @@ export abstract class DocDBTreeItemBase<T> extends AzureParentTreeItem<IDocDBTre
 
     public abstract getIterator(client: DocumentClient, feedOptions: FeedOptions): Promise<QueryIterator<T>>;
 
-    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzureTreeItem<IDocDBTreeRoot>[]> {
+    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
         if (clearCache || this._iterator === undefined) {
             this._hasMoreChildren = true;
             const client = this.root.getDocumentClient();

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext, OutputChannel, TreeView } from "vscode";
-import { AzureTreeDataProvider, AzureTreeItem, IAzureUserInput, ISubscriptionRoot, ITelemetryReporter } from "vscode-azureextensionui";
+import { AzExtTreeDataProvider, AzExtTreeItem, IAzureUserInput, ITelemetryReporter } from "vscode-azureextensionui";
 import { MongoDatabaseTreeItem } from "./mongo/tree/MongoDatabaseTreeItem";
 import { AttachedAccountsTreeItem } from "./tree/AttachedAccountsTreeItem";
 
@@ -17,12 +17,13 @@ export namespace ext {
     export let context: ExtensionContext;
     export let outputChannel: OutputChannel;
     export let reporter: ITelemetryReporter;
-    export let tree: AzureTreeDataProvider;
-    export let treeView: TreeView<AzureTreeItem<ISubscriptionRoot>>;
+    export let tree: AzExtTreeDataProvider;
+    export let treeView: TreeView<AzExtTreeItem>;
     export let attachedAccountsNode: AttachedAccountsTreeItem;
 
     export namespace settingsKeys {
         export const mongoShellPath = 'mongo.shell.path';
+        export const mongoShellArgs = 'mongo.shell.args';
         export const documentLabelFields = 'cosmosDB.documentLabelFields';
         export const mongoShellTimeout = 'mongo.shell.timeout';
 

--- a/src/graph/GraphViewsManager.ts
+++ b/src/graph/GraphViewsManager.ts
@@ -7,7 +7,8 @@ import * as fse from 'fs-extra';
 import * as path from "path";
 import * as vscode from 'vscode';
 import { parseError } from 'vscode-azureextensionui';
-import { resourcesPath } from '../constants';
+import { getResourcesPath } from '../constants';
+import { ext } from '../extensionVariables';
 import { areConfigsEqual, GraphConfiguration } from './GraphConfiguration';
 import { GraphViewServer } from './GraphViewServer';
 
@@ -22,10 +23,6 @@ export class GraphViewsManager implements IServerProvider { //Graphviews Panel
   private readonly _servers = new Map<number, GraphViewServer>(); // map of id -> server
   private readonly _panels = new Map<number, vscode.WebviewPanel>(); // map of id -> webview panel
   private readonly _panelViewType: string = "CosmosDB.GraphExplorer";
-
-  constructor(private _context: vscode.ExtensionContext) {
-
-  }
 
   public async showGraphViewer(
     tabTitle: string,
@@ -48,10 +45,10 @@ export class GraphViewsManager implements IServerProvider { //Graphviews Panel
       enableCommandUris: true,
       enableFindWidget: true,
       retainContextWhenHidden: true,
-      localResourceRoots: [vscode.Uri.file(this._context.extensionPath)]
+      localResourceRoots: [vscode.Uri.file(ext.context.extensionPath)]
     };
     const panel = vscode.window.createWebviewPanel(this._panelViewType, tabTitle, { viewColumn: column, preserveFocus: true }, options);
-    let contentProvider = new WebviewContentProvider(this, this._context);
+    let contentProvider = new WebviewContentProvider(this);
     panel.webview.html = await contentProvider.provideHtmlContent(id);
     this._panels.set(id, panel);
     panel.onDidDispose(
@@ -97,7 +94,7 @@ export class GraphViewsManager implements IServerProvider { //Graphviews Panel
 class WebviewContentProvider {
   public onDidChange?: vscode.Event<vscode.Uri>;
 
-  public constructor(private _serverProvider: IServerProvider, private _context: vscode.ExtensionContext) { }
+  public constructor(private _serverProvider: IServerProvider) { }
 
   public async provideHtmlContent(serverId: number): Promise<string> {
     console.assert(serverId > 0);
@@ -110,12 +107,12 @@ class WebviewContentProvider {
   }
 
   private async _graphClientHtmlAsString(port: number): Promise<string> {
-    const graphClientAbsolutePath = path.join(resourcesPath, 'graphClient', 'graphClient.html');
+    const graphClientAbsolutePath = path.join(getResourcesPath(), 'graphClient', 'graphClient.html');
     let htmlContents: string = await fse.readFile(graphClientAbsolutePath, 'utf8');
     const portPlaceholder: RegExp = /\$CLIENTPORT/g;
     htmlContents = htmlContents.replace(portPlaceholder, String(port));
     const uriPlaceholder: RegExp = /\$BASEURI/g;
-    let uri = vscode.Uri.parse(path.join("file:" + this._context.extensionPath));
+    let uri = vscode.Uri.parse(path.join("file:" + ext.context.extensionPath));
     const baseUri = `vscode-resource:${uri.fsPath}`;
     htmlContents = htmlContents.replace(uriPlaceholder, baseUri);
 

--- a/src/graph/registerGraphCommands.ts
+++ b/src/graph/registerGraphCommands.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-import { registerCommand } from "vscode-azureextensionui";
+import { IActionContext, registerCommand } from "vscode-azureextensionui";
 import { doubleClickDebounceDelay } from '../constants';
 import { ext } from '../extensionVariables';
 import { GraphViewsManager } from "./GraphViewsManager";
@@ -13,36 +12,36 @@ import { GraphCollectionTreeItem } from "./tree/GraphCollectionTreeItem";
 import { GraphDatabaseTreeItem } from "./tree/GraphDatabaseTreeItem";
 import { GraphTreeItem } from "./tree/GraphTreeItem";
 
-export function registerGraphCommands(context: vscode.ExtensionContext): void {
-    let graphViewsManager = new GraphViewsManager(context);
+export function registerGraphCommands(): void {
+    let graphViewsManager = new GraphViewsManager();
 
-    registerCommand('cosmosDB.createGraphDatabase', async (node?: GraphAccountTreeItem) => {
+    registerCommand('cosmosDB.createGraphDatabase', async (context: IActionContext, node?: GraphAccountTreeItem) => {
         if (!node) {
-            node = <GraphAccountTreeItem>await ext.tree.showTreeItemPicker(GraphAccountTreeItem.contextValue);
+            node = <GraphAccountTreeItem>await ext.tree.showTreeItemPicker(GraphAccountTreeItem.contextValue, context);
         }
-        await node.createChild();
+        await node.createChild(context);
     });
-    registerCommand('cosmosDB.createGraph', async (node?: GraphDatabaseTreeItem) => {
+    registerCommand('cosmosDB.createGraph', async (context: IActionContext, node?: GraphDatabaseTreeItem) => {
         if (!node) {
-            node = <GraphDatabaseTreeItem>await ext.tree.showTreeItemPicker(GraphDatabaseTreeItem.contextValue);
+            node = <GraphDatabaseTreeItem>await ext.tree.showTreeItemPicker(GraphDatabaseTreeItem.contextValue, context);
         }
-        await node.createChild();
+        await node.createChild(context);
     });
-    registerCommand('cosmosDB.deleteGraphDatabase', async (node?: GraphDatabaseTreeItem) => {
+    registerCommand('cosmosDB.deleteGraphDatabase', async (context: IActionContext, node?: GraphDatabaseTreeItem) => {
         if (!node) {
-            node = <GraphDatabaseTreeItem>await ext.tree.showTreeItemPicker(GraphDatabaseTreeItem.contextValue);
+            node = <GraphDatabaseTreeItem>await ext.tree.showTreeItemPicker(GraphDatabaseTreeItem.contextValue, context);
         }
-        await node.deleteTreeItem();
+        await node.deleteTreeItem(context);
     });
-    registerCommand('cosmosDB.deleteGraph', async (node?: GraphCollectionTreeItem) => {
+    registerCommand('cosmosDB.deleteGraph', async (context: IActionContext, node?: GraphCollectionTreeItem) => {
         if (!node) {
-            node = <GraphCollectionTreeItem>await ext.tree.showTreeItemPicker(GraphCollectionTreeItem.contextValue);
+            node = <GraphCollectionTreeItem>await ext.tree.showTreeItemPicker(GraphCollectionTreeItem.contextValue, context);
         }
-        await node.deleteTreeItem();
+        await node.deleteTreeItem(context);
     });
-    registerCommand('cosmosDB.openGraphExplorer', async (node: GraphTreeItem) => {
+    registerCommand('cosmosDB.openGraphExplorer', async (context: IActionContext, node: GraphTreeItem) => {
         if (!node) {
-            node = <GraphTreeItem>await ext.tree.showTreeItemPicker(GraphTreeItem.contextValue);
+            node = <GraphTreeItem>await ext.tree.showTreeItemPicker(GraphTreeItem.contextValue, context);
         }
         await node.showExplorer(graphViewsManager);
         // tslint:disable-next-line:align

--- a/src/graph/tree/GraphCollectionTreeItem.ts
+++ b/src/graph/tree/GraphCollectionTreeItem.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CollectionMeta } from 'documentdb';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureParentTreeItem, AzureTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { resourcesPath } from '../../constants';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { DocDBStoredProceduresTreeItem } from '../../docdb/tree/DocDBStoredProceduresTreeItem';
 import { DocDBStoredProcedureTreeItem } from '../../docdb/tree/DocDBStoredProcedureTreeItem';
 import { IDocDBTreeRoot } from '../../docdb/tree/IDocDBTreeRoot';
@@ -44,10 +43,7 @@ export class GraphCollectionTreeItem extends AzureParentTreeItem<IDocDBTreeRoot>
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg')
-        };
+        return getThemeAgnosticIconPath('Collection.svg');
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzureTreeItem<IDocDBTreeRoot>[]> {
@@ -71,17 +67,19 @@ export class GraphCollectionTreeItem extends AzureParentTreeItem<IDocDBTreeRoot>
         }
     }
 
-    public pickTreeItemImpl(expectedContextValue: string): AzureTreeItem<IDocDBTreeRoot> | undefined {
-        switch (expectedContextValue) {
-            case GraphTreeItem.contextValue:
-                return this._graphTreeItem;
+    public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): AzureTreeItem<IDocDBTreeRoot> | undefined {
+        for (const expectedContextValue of expectedContextValues) {
+            switch (expectedContextValue) {
+                case GraphTreeItem.contextValue:
+                    return this._graphTreeItem;
+                case DocDBStoredProceduresTreeItem.contextValue:
+                case DocDBStoredProcedureTreeItem.contextValue:
+                    return this._storedProceduresTreeItem;
 
-            case DocDBStoredProceduresTreeItem.contextValue:
-            case DocDBStoredProcedureTreeItem.contextValue:
-                return this._storedProceduresTreeItem;
-
-            default:
-                return undefined;
+                default:
+            }
         }
+
+        return undefined;
     }
 }

--- a/src/graph/tree/GraphTreeItem.ts
+++ b/src/graph/tree/GraphTreeItem.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CollectionMeta } from 'documentdb';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureTreeItem } from 'vscode-azureextensionui';
-import { resourcesPath } from '../../constants';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { IDocDBTreeRoot } from '../../docdb/tree/IDocDBTreeRoot';
 import { GraphConfiguration } from '../GraphConfiguration';
 import { GraphViewsManager } from '../GraphViewsManager';
@@ -40,10 +39,7 @@ export class GraphTreeItem extends AzureTreeItem<IDocDBTreeRoot> {
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg')
-        };
+        return getThemeAgnosticIconPath('Collection.svg');
     }
 
     public async showExplorer(graphViewsManager: GraphViewsManager): Promise<void> {

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -41,24 +41,24 @@ export function getAllErrorsFromTextDocument(document: vscode.TextDocument): vsc
 	return errors;
 }
 
-export async function executeAllCommandsFromActiveEditor(database: MongoDatabaseTreeItem, extensionPath, editorManager: CosmosEditorManager, context: IActionContext): Promise<void> {
+export async function executeAllCommandsFromActiveEditor(database: MongoDatabaseTreeItem, editorManager: CosmosEditorManager, context: IActionContext): Promise<void> {
 	ext.outputChannel.appendLine("Running all commands in scrapbook...");
 	let commands = getAllCommandsFromActiveEditor();
-	await executeCommands(vscode.window.activeTextEditor, database, extensionPath, editorManager, context, commands);
+	await executeCommands(vscode.window.activeTextEditor, database, editorManager, context, commands);
 }
 
-export async function executeCommandFromActiveEditor(database: MongoDatabaseTreeItem, extensionPath, editorManager: CosmosEditorManager, context: IActionContext): Promise<void> {
+export async function executeCommandFromActiveEditor(database: MongoDatabaseTreeItem, editorManager: CosmosEditorManager, context: IActionContext): Promise<void> {
 	const commands = getAllCommandsFromActiveEditor();
 	const activeEditor = vscode.window.activeTextEditor;
 	const selection = activeEditor.selection;
 	const command = findCommandAtPosition(commands, selection.start);
-	return await executeCommand(activeEditor, database, extensionPath, editorManager, context, command);
+	return await executeCommand(activeEditor, database, editorManager, context, command);
 }
 
-export async function executeCommandFromText(database: MongoDatabaseTreeItem, extensionPath, editorManager: CosmosEditorManager, context: IActionContext, commandText: string): Promise<void> {
+export async function executeCommandFromText(database: MongoDatabaseTreeItem, editorManager: CosmosEditorManager, context: IActionContext, commandText: string): Promise<void> {
 	const activeEditor = vscode.window.activeTextEditor;
 	const command = getCommandFromTextAtLocation(commandText, new vscode.Position(0, 0));
-	return await executeCommand(activeEditor, database, extensionPath, editorManager, context, command);
+	return await executeCommand(activeEditor, database, editorManager, context, command);
 }
 
 function getAllCommandsFromActiveEditor(): MongoCommand[] {
@@ -76,10 +76,10 @@ export function getAllCommandsFromTextDocument(document: vscode.TextDocument): M
 	return getAllCommandsFromText(document.getText());
 }
 
-async function executeCommands(activeEditor: vscode.TextEditor, database: MongoDatabaseTreeItem, extensionPath, editorManager: CosmosEditorManager, context: IActionContext, commands: MongoCommand[]): Promise<void> {
+async function executeCommands(activeEditor: vscode.TextEditor, database: MongoDatabaseTreeItem, editorManager: CosmosEditorManager, context: IActionContext, commands: MongoCommand[]): Promise<void> {
 	for (let command of commands) {
 		try {
-			await executeCommand(activeEditor, database, extensionPath, editorManager, context, command);
+			await executeCommand(activeEditor, database, editorManager, context, command);
 		} catch (e) {
 			const err = parseError(e);
 			if (err.isUserCancelledError) {
@@ -92,13 +92,13 @@ async function executeCommands(activeEditor: vscode.TextEditor, database: MongoD
 	}
 }
 
-async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDatabaseTreeItem, extensionPath, editorManager: CosmosEditorManager, context: IActionContext, command: MongoCommand): Promise<void> {
+async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDatabaseTreeItem, editorManager: CosmosEditorManager, context: IActionContext, command: MongoCommand): Promise<void> {
 	if (command) {
-		ext.outputChannel.appendLine(command.text);
+		ext.outputChannel.appendLine(`Executing: ${command.text}`);
 
 		try {
-			context.properties["command"] = command.name;
-			context.properties["argsCount"] = String(command.arguments ? command.arguments.length : 0);
+			context.telemetry.properties["command"] = command.name;
+			context.telemetry.properties["argsCount"] = String(command.arguments ? command.arguments.length : 0);
 		} catch (error) {
 			// Ignore
 		}
@@ -113,17 +113,17 @@ async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDa
 		}
 
 		if (command.name === 'find') {
-			await editorManager.showDocument(new MongoFindResultEditor(database, command), 'cosmos-result.json', { showInNextColumn: true });
+			await editorManager.showDocument(context, new MongoFindResultEditor(database, command), 'cosmos-result.json', { showInNextColumn: true });
 		} else {
 			const result = await database.executeCommand(command, context);
 			if (command.name === 'findOne') {
 				if (result === "null") {
 					throw new Error(`Could not find any documents`);
 				}
-				await editorManager.showDocument(new MongoFindOneResultEditor(database, command.collection, result), 'cosmos-result.json', { showInNextColumn: true });
+				await editorManager.showDocument(context, new MongoFindOneResultEditor(database, command.collection, result), 'cosmos-result.json', { showInNextColumn: true });
 			} else {
-				await vscodeUtil.showNewFile(result, extensionPath, 'result', '.json', activeEditor.viewColumn + 1);
-				await refreshTreeAfterCommand(database, command);
+				await vscodeUtil.showNewFile(result, 'result', '.json', activeEditor.viewColumn + 1);
+				await refreshTreeAfterCommand(database, command, context);
 			}
 		}
 	} else {
@@ -131,12 +131,12 @@ async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDa
 	}
 }
 
-async function refreshTreeAfterCommand(database: MongoDatabaseTreeItem, command: MongoCommand) {
+async function refreshTreeAfterCommand(database: MongoDatabaseTreeItem, command: MongoCommand, context: IActionContext) {
 	if (command.name === 'drop') {
 		database.refresh();
 	}
 	else if (command.collection && /^(insert|update|delete|replace|remove|write|bulkWrite)/i.test(command.name)) {
-		const collectionNode = await ext.tree.findTreeItem(database.fullId + "/" + command.collection);
+		const collectionNode = await ext.tree.findTreeItem(database.fullId + "/" + command.collection, context);
 		if (collectionNode) {
 			collectionNode.refresh();
 		}

--- a/src/mongo/editors/MongoCollectionNodeEditor.ts
+++ b/src/mongo/editors/MongoCollectionNodeEditor.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { getNodeEditorLabel } from '../../utils/vscodeUtils';
 import { MongoCollectionTreeItem } from "../tree/MongoCollectionTreeItem";
@@ -20,19 +21,19 @@ export class MongoCollectionNodeEditor implements ICosmosEditor<IMongoDocument[]
         return getNodeEditorLabel(this._collectionNode);
     }
 
-    public async getData(): Promise<IMongoDocument[]> {
-        const children = <MongoDocumentTreeItem[]>await this._collectionNode.getCachedChildren();
+    public async getData(context: IActionContext): Promise<IMongoDocument[]> {
+        const children = <MongoDocumentTreeItem[]>await this._collectionNode.getCachedChildren(context);
         return children.map((child) => child.document);
     }
 
-    public async update(documents: IMongoDocument[]): Promise<IMongoDocument[]> {
+    public async update(documents: IMongoDocument[], context: IActionContext): Promise<IMongoDocument[]> {
         const updatedDocs = await this._collectionNode.update(documents);
-        await MongoCollectionNodeEditor.updateCachedDocNodes(updatedDocs, this._collectionNode);
+        await MongoCollectionNodeEditor.updateCachedDocNodes(updatedDocs, this._collectionNode, context);
         return updatedDocs;
     }
 
-    public static async updateCachedDocNodes(updatedDocs: IMongoDocument[], collectionNode: MongoCollectionTreeItem): Promise<void> {
-        const documentNodes = <MongoDocumentTreeItem[]>await collectionNode.getCachedChildren();
+    public static async updateCachedDocNodes(updatedDocs: IMongoDocument[], collectionNode: MongoCollectionTreeItem, context: IActionContext): Promise<void> {
+        const documentNodes = <MongoDocumentTreeItem[]>await collectionNode.getCachedChildren(context);
         for (const updatedDoc of updatedDocs) {
             const documentNode = documentNodes.find((node) => node.document._id.toString() === updatedDoc._id.toString());
             if (documentNode) {

--- a/src/mongo/editors/MongoFindOneResultEditor.ts
+++ b/src/mongo/editors/MongoFindOneResultEditor.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from "vscode-azureextensionui";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { ext } from "../../extensionVariables";
 import { MongoDatabaseTreeItem } from "../tree/MongoDatabaseTreeItem";
@@ -30,15 +31,15 @@ export class MongoFindOneResultEditor implements ICosmosEditor<IMongoDocument> {
         return this._originalDocument;
     }
 
-    public async update(newDocument: IMongoDocument): Promise<IMongoDocument> {
-        const node = <MongoDocumentTreeItem | undefined>await ext.tree.findTreeItem(this.id);
+    public async update(newDocument: IMongoDocument, context: IActionContext): Promise<IMongoDocument> {
+        const node = <MongoDocumentTreeItem | undefined>await ext.tree.findTreeItem(this.id, context);
         let result: IMongoDocument;
         if (node) {
             result = await node.update(newDocument);
             node.refresh();
         } else {
             // If the node isn't cached already, just update it to Mongo directly (without worrying about updating the tree)
-            const db = await this._databaseNode.getDb();
+            const db = await this._databaseNode.connectToDb();
             result = await MongoDocumentTreeItem.update(db.collection(this._collectionName), newDocument);
         }
         return result;

--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as path from 'path';
-import { ExtensionContext } from 'vscode';
 import { appendExtensionUserAgent } from 'vscode-azureextensionui';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 import * as nls from 'vscode-nls';
+import { ext } from '../extensionVariables';
 
 const localize = nls.loadMessageBundle();
 
@@ -14,9 +14,12 @@ export class MongoDBLanguageClient {
 
 	public client: LanguageClient;
 
-	constructor(context: ExtensionContext) {
+	constructor() {
 		// The server is implemented in node
-		let serverModule = context.asAbsolutePath(path.join('dist', 'mongo-languageServer.bundle.js'));
+		const ignoreBundle = !/^(false|0)?$/i.test(process.env.AZCODE_DOCKER_IGNORE_BUNDLE || '');
+		let serverModule = ignoreBundle ?
+			ext.context.asAbsolutePath(path.join('out', 'src', 'mongo', 'languageServer.js')) :
+			ext.context.asAbsolutePath(path.join('dist', 'mongo-languageServer.bundle.js'));
 		// The debug options for the server
 		let debugOptions = { execArgv: ['--nolazy', '--debug=6005', '--inspect'] };
 
@@ -42,7 +45,7 @@ export class MongoDBLanguageClient {
 
 		// Push the disposable to the context's subscriptions so that the
 		// client can be deactivated on extension deactivation
-		context.subscriptions.push(disposable);
+		ext.context.subscriptions.push(disposable);
 	}
 
 	async connect(connectionString: string, databaseName: string) {

--- a/src/mongo/services/MongoCodeLensProvider.ts
+++ b/src/mongo/services/MongoCodeLensProvider.ts
@@ -21,16 +21,13 @@ export class MongoCodeLensProvider implements vscode.CodeLensProvider {
 	}
 
 	public provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
-		// tslint:disable-next-line:no-var-self
-		const me: MongoCodeLensProvider = this;
-
-		return callWithTelemetryAndErrorHandling("mongo.provideCodeLenses", function (this: IActionContext) {
+		return callWithTelemetryAndErrorHandling("mongo.provideCodeLenses", (context: IActionContext) => {
 			// Suppress except for errors - this can fire on every keystroke
-			this.suppressTelemetry = true;
+			context.telemetry.suppressIfSuccessful = true;
 
-			let isInitialized = me._connectedDatabaseInitialized;
-			let isConnected = !!me._connectedDatabase;
-			let database = isConnected && me._connectedDatabase;
+			let isInitialized = this._connectedDatabaseInitialized;
+			let isConnected = !!this._connectedDatabase;
+			let database = isConnected && this._connectedDatabase;
 			let lenses: vscode.CodeLens[] = [];
 
 			// Allow displaying and changing connected database

--- a/src/mongo/tree/IMongoTreeRoot.ts
+++ b/src/mongo/tree/IMongoTreeRoot.ts
@@ -4,8 +4,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ISubscriptionRoot } from "vscode-azureextensionui";
+import { ISubscriptionContext } from "vscode-azureextensionui";
 
-export interface IMongoTreeRoot extends ISubscriptionRoot {
+export interface IMongoTreeRoot extends ISubscriptionContext {
     isEmulator: boolean;
 }

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -5,11 +5,10 @@
 
 import { DatabaseAccount } from 'azure-arm-cosmosdb/lib/models';
 import { Db } from 'mongodb';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import { appendExtensionUserAgent, AzureParentTreeItem, AzureTreeItem, parseError } from 'vscode-azureextensionui';
+import { appendExtensionUserAgent, AzureParentTreeItem, AzureTreeItem, ICreateChildImplContext, parseError } from 'vscode-azureextensionui';
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
-import { resourcesPath } from '../../constants';
+import { getThemedIconPath } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { connectToMongoClient } from '../connectToMongoClient';
 import { getDatabaseNameFromConnectionString } from '../mongoConnectionStrings';
@@ -36,16 +35,13 @@ export class MongoAccountTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
         this._root = Object.assign({}, parent.root, { isEmulator });
     }
 
-    // overrides ISubscriptionRoot with an object that also has Mongo info
+    // overrides ISubscriptionContext with an object that also has Mongo info
     public get root(): IMongoTreeRoot {
         return this._root;
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'light', 'CosmosDBAccount.svg'),
-            dark: path.join(resourcesPath, 'icons', 'dark', 'CosmosDBAccount.svg')
-        };
+        return getThemedIconPath('CosmosDBAccount.svg');
     }
 
     public hasMoreChildrenImpl(): boolean {
@@ -90,13 +86,13 @@ export class MongoAccountTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
         }
     }
 
-    public async createChildImpl(showCreatingTreeItem: (label: string) => void): Promise<MongoDatabaseTreeItem> {
+    public async createChildImpl(context: ICreateChildImplContext): Promise<MongoDatabaseTreeItem> {
         const databaseName = await ext.ui.showInputBox({
             placeHolder: "Database Name",
             prompt: "Enter the name of the database",
             validateInput: validateDatabaseName
         });
-        showCreatingTreeItem(databaseName);
+        context.showCreatingTreeItem(databaseName);
 
         const databaseTreeItem = new MongoDatabaseTreeItem(this, databaseName, this.connectionString);
         return databaseTreeItem;

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -5,11 +5,10 @@
 
 import * as assert from 'assert';
 import { BulkWriteOpResultObject, Collection, CollectionInsertManyOptions, Cursor, DeleteWriteOpResultObject, InsertOneWriteOpResult, InsertWriteOpResult, MongoCountPreferences } from 'mongodb';
-import * as path from 'path';
 import * as _ from 'underscore';
 import * as vscode from 'vscode';
-import { AzureParentTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { defaultBatchSize, resourcesPath } from '../../constants';
+import { AzureParentTreeItem, DialogResponses, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
+import { defaultBatchSize, getThemeAgnosticIconPath } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { IMongoTreeRoot } from './IMongoTreeRoot';
 import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';
@@ -68,10 +67,7 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 	}
 
 	public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-		return {
-			light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg'),
-			dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Collection.svg')
-		};
+		return getThemeAgnosticIconPath('Collection.svg');
 	}
 
 	public hasMoreChildrenImpl(): boolean {
@@ -104,14 +100,14 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 		return docTreeItems;
 	}
 
-	public async createChildImpl(showCreatingTreeItem: (label: string) => void): Promise<MongoDocumentTreeItem> {
-		showCreatingTreeItem("");
+	public async createChildImpl(context: ICreateChildImplContext): Promise<MongoDocumentTreeItem> {
+		context.showCreatingTreeItem("");
 		const result: InsertOneWriteOpResult = await this.collection.insertOne({});
 		const newDocument: IMongoDocument = await this.collection.findOne({ _id: result.insertedId });
 		return new MongoDocumentTreeItem(this, newDocument);
 	}
 
-	executeCommand(name: string, args?: string[]): Thenable<string> | null {
+	public tryExecuteCommandDirectly(name: string, args?: string[]): Thenable<string> | undefined {
 		const parameters = args ? args.map(parseJSContent) : undefined;
 		const deferToShell = null; //The value executeCommand returns to instruct the caller function to run the same command in the Mongo shell.
 

--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -4,11 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Collection, DeleteWriteOpResultObject, ObjectID, UpdateWriteOpResult } from 'mongodb';
-import * as path from 'path';
 import * as _ from 'underscore';
 import * as vscode from 'vscode';
 import { AzureTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { resourcesPath } from '../../constants';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { getDocumentTreeItemLabel } from '../../utils/vscodeUtils';
 import { IMongoTreeRoot } from './IMongoTreeRoot';
 import { MongoCollectionTreeItem } from './MongoCollectionTreeItem';
@@ -50,10 +49,7 @@ export class MongoDocumentTreeItem extends AzureTreeItem<IMongoTreeRoot> {
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
-        return {
-            light: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Document.svg'),
-            dark: path.join(resourcesPath, 'icons', 'theme-agnostic', 'Document.svg')
-        };
+        return getThemeAgnosticIconPath('Document.svg');
     }
 
     public async deleteTreeItemImpl(): Promise<void> {

--- a/src/table/tree/TableAccountTreeItem.ts
+++ b/src/table/tree/TableAccountTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeItem, GenericTreeItem } from "vscode-azureextensionui";
+import { AzExtTreeItem, AzureTreeItem, GenericTreeItem } from "vscode-azureextensionui";
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
 import { DocDBAccountTreeItemBase } from "../../docdb/tree/DocDBAccountTreeItemBase";
 import { IDocDBTreeRoot } from "../../docdb/tree/IDocDBTreeRoot";
@@ -20,7 +20,7 @@ export class TableAccountTreeItem extends DocDBAccountTreeItemBase {
         throw new Error('Table Accounts are not supported yet.');
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzureTreeItem<IDocDBTreeRoot>[]> {
+    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         return [new GenericTreeItem(this, {
             contextValue: 'tableNotSupported',
             label: 'Table Accounts are not supported yet.'

--- a/src/tree/AzureAccountTreeItemWithAttached.ts
+++ b/src/tree/AzureAccountTreeItemWithAttached.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtTreeItem, AzureAccountTreeItemBase, IActionContext, ISubscriptionContext } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+import { AttachedAccountsTreeItem } from './AttachedAccountsTreeItem';
+import { SubscriptionTreeItem } from './SubscriptionTreeItem';
+
+export class AzureAccountTreeItemWithAttached extends AzureAccountTreeItemBase {
+    public constructor() {
+        super();
+        ext.attachedAccountsNode = new AttachedAccountsTreeItem(this);
+    }
+
+    public createSubscriptionTreeItem(root: ISubscriptionContext): SubscriptionTreeItem {
+        return new SubscriptionTreeItem(this, root);
+    }
+
+    public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
+        const children: AzExtTreeItem[] = await super.loadMoreChildrenImpl(clearCache, context);
+        return children.concat(ext.attachedAccountsNode);
+    }
+
+    public compareChildrenImpl(item1: AzExtTreeItem, item2: AzExtTreeItem): number {
+        if (item1 instanceof AttachedAccountsTreeItem) {
+            return 1;
+        } else if (item2 instanceof AttachedAccountsTreeItem) {
+            return -1;
+        } else {
+            return super.compareChildrenImpl(item1, item2);
+        }
+    }
+}

--- a/src/utils/getCoreNodeModule.ts
+++ b/src/utils/getCoreNodeModule.ts
@@ -3,31 +3,24 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-"use strict";
-
-// Our util/getCoreNodeModule.js file uses a dynamic require that depends on the environment and so has to be excluded
-// from webpack'ing, and we'll just copy it to the distribution folder.
-//
-// Since webpack shouldn't have to depend on npm build to transpile .ts -> .js, we keep this file in .js.
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const vscode = require("vscode");
+import * as vscode from 'vscode';
 
 /**
  * Returns a node module installed with VSCode, or undefined if it fails.
  */
-function getCoreNodeModule(moduleName) {
+export function getCoreNodeModule<T>(moduleName: string): T | undefined {
     try {
         // tslint:disable-next-line:non-literal-require no-unsafe-any
         return require(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`);
+    } catch (err) {
+        // ignore
     }
-    catch (err) { }
+
     try {
         // tslint:disable-next-line:non-literal-require no-unsafe-any
         return require(`${vscode.env.appRoot}/node_modules/${moduleName}`);
+    } catch (err) {
+        // ignore
     }
-    catch (err) { }
     return undefined;
 }
-
-exports.getCoreNodeModule = getCoreNodeModule;

--- a/src/utils/splitArguments.ts
+++ b/src/utils/splitArguments.ts
@@ -1,15 +1,13 @@
-
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DocumentClient } from "documentdb";
-import { ISubscriptionContext } from "vscode-azureextensionui";
+export function splitArguments(args: string | undefined): string[] {
+    if (!args) {
+        return [];
+    }
 
-export interface IDocDBTreeRoot extends ISubscriptionContext {
-    documentEndpoint: string;
-    masterKey: string;
-    isEmulator: boolean;
-    getDocumentClient(): DocumentClient;
+    let matches: RegExpMatchArray | null = args.match(/('[^']+')|("[^']+")|([^\s]+)/g);
+    return matches ? matches : [];
 }

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -7,7 +7,7 @@ import { RetrievedDocument } from 'documentdb';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzureTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem } from 'vscode-azureextensionui';
 import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
 import { ext } from '../extensionVariables';
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
@@ -27,9 +27,9 @@ export function toDisposable(dispose: () => void): IDisposable {
     return { dispose };
 }
 
-export async function showNewFile(data: string, extensionPath: string, fileName: string, fileExtension: string, column?: vscode.ViewColumn): Promise<void> {
+export async function showNewFile(data: string, fileName: string, fileExtension: string, column?: vscode.ViewColumn): Promise<void> {
     let uri: vscode.Uri;
-    const folderPath: string = vscode.workspace.rootPath || extensionPath;
+    const folderPath: string = vscode.workspace.rootPath || ext.context.extensionPath;
     const fullFileName: string | undefined = await getUniqueFileName(folderPath, fileName, fileExtension);
     uri = vscode.Uri.file(path.join(folderPath, fullFileName)).with({ scheme: 'untitled' });
     const textDocument = await vscode.workspace.openTextDocument(uri);
@@ -68,7 +68,7 @@ async function getUniqueFileName(folderPath: string, fileName: string, fileExten
     throw new Error('Could not find unique name for new file.');
 }
 
-export function getNodeEditorLabel(node: AzureTreeItem): string {
+export function getNodeEditorLabel(node: AzExtTreeItem): string {
     let labels = [node.label];
     while (node.parent) {
         node = node.parent;
@@ -80,7 +80,7 @@ export function getNodeEditorLabel(node: AzureTreeItem): string {
     return labels.join('/');
 }
 
-function isAccountTreeItem(treeItem: AzureTreeItem): boolean {
+function isAccountTreeItem(treeItem: AzExtTreeItem): boolean {
     return (treeItem instanceof MongoAccountTreeItem) || (treeItem instanceof DocDBAccountTreeItemBase);
 }
 

--- a/test/mongo.test.ts
+++ b/test/mongo.test.ts
@@ -1,19 +1,19 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// /*---------------------------------------------------------------------------------------------
+//  *  Copyright (c) Microsoft Corporation. All rights reserved.
+//  *  Licensed under the MIT License. See License.txt in the project root for license information.
+//  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert';
-import { ObjectID, ObjectId } from '../extension.bundle';
-import { Position } from 'vscode';
-import { parseError } from 'vscode-azureextensionui';
-import { MongoCommand } from '../extension.bundle';
-import * as cp from "child_process";
-import { getAllCommandsFromText, getCommandFromTextAtLocation } from '../extension.bundle';
+// import * as assert from 'assert';
+// import { ObjectID, ObjectId } from '../extension.bundle';
+// import { Position } from 'vscode';
+// import { parseError } from 'vscode-azureextensionui';
+// import { MongoCommand } from '../extension.bundle';
+// import * as cp from "child_process";
+// import { getAllCommandsFromText, getCommandFromTextAtLocation } from '../extension.bundle';
 
-suite("Mongo shell tests", () => {
-    let child = cp.exec("mongod");
-    child.on("data", (buffer: Buffer) => {
-        console.log(buffer.toString())
-    });
-});
+// suite("Mongo shell tests", () => {
+//     let child = cp.exec("mongod");
+//     child.on("data", (buffer: Buffer) => {
+//         console.log(buffer.toString())
+//     });
+// });

--- a/test/mongo.test.ts
+++ b/test/mongo.test.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ObjectID, ObjectId } from '../extension.bundle';
+import { Position } from 'vscode';
+import { parseError } from 'vscode-azureextensionui';
+import { MongoCommand } from '../extension.bundle';
+import * as cp from "child_process";
+import { getAllCommandsFromText, getCommandFromTextAtLocation } from '../extension.bundle';
+
+suite("Mongo shell tests", () => {
+    let child = cp.exec("mongod");
+    child.on("data", (buffer: Buffer) => {
+        console.log(buffer.toString())
+    });
+});

--- a/test/splitArguments.test.ts
+++ b/test/splitArguments.test.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { splitArguments } from '../extension.bundle';
+
+suite("splitArguments Tests", () => {
+    function testSplitArguments(args: string, expected: string[]): void {
+        test(String(args), () => {
+            let actual = splitArguments(args);
+            assert.deepStrictEqual(actual, expected);
+        });
+    }
+
+    testSplitArguments(undefined, []);
+    testSplitArguments(null, []);
+    testSplitArguments("", []);
+
+    testSplitArguments("a", ["a"]);
+    testSplitArguments("abc", ["abc"]);
+    testSplitArguments("-abc", ["-abc"]);
+    testSplitArguments("--abc", ["--abc"]);
+    testSplitArguments("-abc def ghi", ["-abc", "def", "ghi"]);
+    testSplitArguments("abc def.exe ghi!jkl", ["abc", "def.exe", "ghi!jkl"]);
+
+    testSplitArguments("'-abc' def ghi", ["'-abc'", "def", "ghi"]);
+    testSplitArguments("'-abc def' ghi", ["'-abc def'", "ghi"]);
+    testSplitArguments("-abc 'def ghi'", ["-abc", "'def ghi'"]);
+
+    testSplitArguments('"-abc" def ghi', ['"-abc"', 'def', 'ghi']);
+    testSplitArguments('"-abc def" ghi', ['"-abc def"', 'ghi']);
+    testSplitArguments('-abc "def ghi"', ['-abc', '"def ghi"']);
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ let config = dev.getDefaultWebpackConfig({
         // Fix "module not found" error in node_modules/es6-promise/dist/es6-promise.js
         'vertx': 'commonjs vertx',
 
-        // ./getCoreNodeModule.js (path from keytar.ts) uses a dynamic require which can't be webpacked
+        // ./getCoreNodeModule.js (path from keytar.ts) uses a dynamic require which can't be webpacked		        // ./getCoreNodeModule.js (path from keytar.ts) uses a dynamic require which can't be webpacked
         './getCoreNodeModule': 'commonjs getCoreNodeModule',
     }, // end of externals
 
@@ -120,7 +120,7 @@ let config = dev.getDefaultWebpackConfig({
         // Copy files to dist folder where the runtime can find them
         new CopyWebpackPlugin([
             // getCoreNodeModule.js -> dist/node_modules/getCoreNodeModule.js
-            { from: './src/utils/getCoreNodeModule.js', to: 'node_modules' },
+            { from: './out/src/utils/getCoreNodeModule.js', to: 'node_modules' },
 
             // graphClient.js -> dist, which is used by graphClient.html
             { from: './out/src/graph/client/graphClient.js', to: 'graphClient.js' }


### PR DESCRIPTION
This especially should provide accurate error messages instead of "timed out" when the "use db" command fails.

Fixes #838
Also fixes #1104

Possibly fixes error reporting for:
https://github.com/Microsoft/vscode-cosmosdb/issues/1071
#988
#852
#820 
#794
#1092 

The main part is a near-rewrite of shell.ts.

Testcases in OneNote: 
![image](https://user-images.githubusercontent.com/6913354/57112768-5b3d2800-6cf6-11e9-98dd-616f8af3ccb7.png)
[](url)