### PR TITLE
Move to latest tree that's friendlier to non-Azure scenarios

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
 	},
 	"editor.codeActionsOnSave": {
 		"source.fixAll.tslint": true,
-	}
+	},
+	"typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9878,9 +9878,9 @@
 			}
 		},
 		"vscode-azureextensionui": {
-			"version": "0.23.3",
-			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.23.3.tgz",
-			"integrity": "sha512-d/Y8zWejDBSklrdG82hUJ+KXJKv1d+7ur7Yq3lZitGWfvjM81shqb1kvxgzUlKjbPy3LVsVhWRh1YpCLlWIDjQ==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.24.0.tgz",
+			"integrity": "sha512-IgyQEHMUbzvwy5ZBolZCvK3BpPW6mBAzcMPxWkiT9IcYAM1D8JSg546xCvzCYMDR0o1T/iJ8t7Ki9H4MjHfSYQ==",
 			"requires": {
 				"azure-arm-resource": "^3.0.0-preview",
 				"azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -920,7 +920,7 @@
 		"socket.io": "^1.7.3",
 		"socket.io-client": "^1.7.3",
 		"underscore": "^1.8.3",
-		"vscode-azureextensionui": "^0.23.2",
+		"vscode-azureextensionui": "^0.24.0",
 		"vscode-json-languageservice": "^3.0.8",
 		"vscode-languageclient": "^4.4.0",
 		"vscode-languageserver": "^4.4.0",

--- a/src/commands/api/findTreeItem.ts
+++ b/src/commands/api/findTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem } from 'vscode-azureextensionui';
 import { parseDocDBConnectionString } from '../../docdb/docDBConnectionStrings';
 import { DocDBAccountTreeItemBase } from '../../docdb/tree/DocDBAccountTreeItemBase';
 import { DocDBDatabaseTreeItemBase } from '../../docdb/tree/DocDBDatabaseTreeItemBase';
@@ -66,7 +66,7 @@ export async function findTreeItem(query: TreeItemQuery): Promise<DatabaseAccoun
     return result;
 }
 
-async function searchDbAccounts(dbAccounts: AzureTreeItem[], expected: ParsedConnectionString, maxTime: number): Promise<DatabaseAccountTreeItem | DatabaseTreeItem | undefined> {
+async function searchDbAccounts(dbAccounts: AzExtTreeItem[], expected: ParsedConnectionString, maxTime: number): Promise<DatabaseAccountTreeItem | DatabaseTreeItem | undefined> {
     for (const dbAccount of dbAccounts) {
         if (Date.now() > maxTime) {
             return undefined;

--- a/src/commands/api/findTreeItem.ts
+++ b/src/commands/api/findTreeItem.ts
@@ -12,7 +12,7 @@ import { parseMongoConnectionString } from '../../mongo/mongoConnectionStrings';
 import { MongoAccountTreeItem } from '../../mongo/tree/MongoAccountTreeItem';
 import { MongoDatabaseTreeItem } from '../../mongo/tree/MongoDatabaseTreeItem';
 import { ParsedConnectionString } from '../../ParsedConnectionString';
-import { CosmosDBAccountProvider } from '../../tree/CosmosDBAccountProvider';
+import { SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 import { DatabaseAccountTreeItem, DatabaseTreeItem, TreeItemQuery } from '../../vscode-cosmosdb.api';
 import { cacheTreeItem, tryGetTreeItemFromCache } from './apiCache';
 import { DatabaseAccountTreeItemInternal } from './DatabaseAccountTreeItemInternal';
@@ -46,7 +46,7 @@ export async function findTreeItem(query: TreeItemQuery): Promise<DatabaseAccoun
                 break;
             }
 
-            if (rootNode instanceof CosmosDBAccountProvider) {
+            if (rootNode instanceof SubscriptionTreeItem) {
                 const dbAccounts = await rootNode.getCachedChildren();
                 result = await searchDbAccounts(dbAccounts, parsedCS, maxTime);
                 if (result) {

--- a/src/docdb/tree/DocDBCollectionTreeItem.ts
+++ b/src/docdb/tree/DocDBCollectionTreeItem.ts
@@ -75,18 +75,19 @@ export class DocDBCollectionTreeItem extends AzureParentTreeItem<IDocDBTreeRoot>
         return false;
     }
 
-    public pickTreeItemImpl(expectedContextValue: string): AzureTreeItem<IDocDBTreeRoot> | undefined {
-        switch (expectedContextValue) {
-            case DocDBDocumentsTreeItem.contextValue:
-            case DocDBDocumentTreeItem.contextValue:
-                return this.documentsTreeItem;
-
-            case DocDBStoredProceduresTreeItem.contextValue:
-            case DocDBStoredProcedureTreeItem.contextValue:
-                return this._storedProceduresTreeItem;
-
-            default:
-                return undefined;
+    public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): AzureTreeItem<IDocDBTreeRoot> | undefined {
+        for (const expectedContextValue of expectedContextValues) {
+            switch (expectedContextValue) {
+                case DocDBDocumentsTreeItem.contextValue:
+                case DocDBDocumentTreeItem.contextValue:
+                    return this.documentsTreeItem;
+                case DocDBStoredProceduresTreeItem.contextValue:
+                case DocDBStoredProcedureTreeItem.contextValue:
+                    return this._storedProceduresTreeItem;
+                default:
+            }
         }
+
+        return undefined;
     }
 }

--- a/src/docdb/tree/DocDBTreeItemBase.ts
+++ b/src/docdb/tree/DocDBTreeItemBase.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentClient, FeedOptions, QueryError, QueryIterator } from 'documentdb';
-import { AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
 import { defaultBatchSize } from '../../constants';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
 
@@ -29,7 +29,7 @@ export abstract class DocDBTreeItemBase<T> extends AzureParentTreeItem<IDocDBTre
 
     public abstract getIterator(client: DocumentClient, feedOptions: FeedOptions): Promise<QueryIterator<T>>;
 
-    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzureTreeItem<IDocDBTreeRoot>[]> {
+    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
         if (clearCache || this._iterator === undefined) {
             this._hasMoreChildren = true;
             const client = this.root.getDocumentClient();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { AzExtTreeDataProvider, AzExtTreeItem, AzureTreeItem, AzureUserInput, callWithTelemetryAndErrorHandling, createApiProvider, createTelemetryReporter, IActionContext, registerCommand, registerEvent, registerUIExtensionVariables, SubscriptionTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeDataProvider, AzExtTreeItem, AzureTreeItem, AzureUserInput, callWithTelemetryAndErrorHandling, createApiProvider, createTelemetryReporter, IActionContext, registerCommand, registerEvent, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { findTreeItem } from './commands/api/findTreeItem';
 import { pickTreeItem } from './commands/api/pickTreeItem';
@@ -30,6 +30,7 @@ import { MongoDocumentTreeItem } from './mongo/tree/MongoDocumentTreeItem';
 import { TableAccountTreeItem } from './table/tree/TableAccountTreeItem';
 import { AttachedAccountSuffix } from './tree/AttachedAccountsTreeItem';
 import { AzureAccountTreeItemWithAttached } from './tree/AzureAccountTreeItemWithAttached';
+import { SubscriptionTreeItem } from './tree/SubscriptionTreeItem';
 
 export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number, loadEndTime: number }): Promise<AzureExtensionApiProvider> {
     ext.context = context;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { AzureTreeDataProvider, AzureTreeItem, AzureUserInput, callWithTelemetryAndErrorHandling, createApiProvider, createTelemetryReporter, IActionContext, registerCommand, registerEvent, registerUIExtensionVariables, SubscriptionTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeDataProvider, AzExtTreeItem, AzureTreeItem, AzureUserInput, callWithTelemetryAndErrorHandling, createApiProvider, createTelemetryReporter, IActionContext, registerCommand, registerEvent, registerUIExtensionVariables, SubscriptionTreeItem } from 'vscode-azureextensionui';
 import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { findTreeItem } from './commands/api/findTreeItem';
 import { pickTreeItem } from './commands/api/pickTreeItem';
@@ -28,8 +28,8 @@ import { MongoAccountTreeItem } from './mongo/tree/MongoAccountTreeItem';
 import { MongoCollectionTreeItem } from './mongo/tree/MongoCollectionTreeItem';
 import { MongoDocumentTreeItem } from './mongo/tree/MongoDocumentTreeItem';
 import { TableAccountTreeItem } from './table/tree/TableAccountTreeItem';
-import { AttachedAccountsTreeItem, AttachedAccountSuffix } from './tree/AttachedAccountsTreeItem';
-import { CosmosDBAccountProvider } from './tree/CosmosDBAccountProvider';
+import { AttachedAccountSuffix } from './tree/AttachedAccountsTreeItem';
+import { AzureAccountTreeItemWithAttached } from './tree/AzureAccountTreeItemWithAttached';
 
 export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number, loadEndTime: number }): Promise<AzureExtensionApiProvider> {
     ext.context = context;
@@ -43,10 +43,9 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         this.properties.isActivationEvent = 'true';
         this.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
 
-        const attachedAccountsNode: AttachedAccountsTreeItem = new AttachedAccountsTreeItem(context.globalState);
-        ext.attachedAccountsNode = attachedAccountsNode;
-        const tree: AzureTreeDataProvider = new AzureTreeDataProvider(CosmosDBAccountProvider, 'cosmosDB.loadMore', [attachedAccountsNode]);
-        context.subscriptions.push(tree);
+        const azureAccountNode: AzureAccountTreeItemWithAttached = new AzureAccountTreeItemWithAttached();
+        context.subscriptions.push(azureAccountNode);
+        const tree: AzExtTreeDataProvider = new AzExtTreeDataProvider(azureAccountNode, 'cosmosDB.loadMore');
         ext.tree = tree;
         context.subscriptions.push(vscode.window.registerTreeDataProvider('cosmosDBExplorer', tree));
 
@@ -79,21 +78,21 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         });
 
         registerCommand('cosmosDB.attachDatabaseAccount', async () => {
-            await attachedAccountsNode.attachNewAccount();
-            await tree.refresh(attachedAccountsNode);
+            await ext.attachedAccountsNode.attachNewAccount();
+            await tree.refresh(ext.attachedAccountsNode);
         });
         registerCommand('cosmosDB.attachEmulator', async () => {
-            await attachedAccountsNode.attachEmulator();
-            await tree.refresh(attachedAccountsNode);
+            await ext.attachedAccountsNode.attachEmulator();
+            await tree.refresh(ext.attachedAccountsNode);
         });
-        registerCommand('cosmosDB.refresh', async (node?: AzureTreeItem) => await tree.refresh(node));
+        registerCommand('cosmosDB.refresh', async (node?: AzExtTreeItem) => await tree.refresh(node));
         registerCommand('cosmosDB.detachDatabaseAccount', async (node?: AzureTreeItem) => {
             if (!node) {
-                node = await tree.showTreeItemPicker(accountContextValues.map((val: string) => val += AttachedAccountSuffix), attachedAccountsNode);
+                node = await tree.showTreeItemPicker(accountContextValues.map((val: string) => val += AttachedAccountSuffix), ext.attachedAccountsNode);
             }
 
-            await attachedAccountsNode.detach(node);
-            await tree.refresh(attachedAccountsNode);
+            await ext.attachedAccountsNode.detach(node);
+            await tree.refresh(ext.attachedAccountsNode);
         });
         registerCommand('cosmosDB.importDocument', async (selectedNode: vscode.Uri | MongoCollectionTreeItem | DocDBCollectionTreeItem, uris: vscode.Uri[]) => //ignore first pass
         {
@@ -132,7 +131,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             // tslint:disable-next-line:align
         }, doubleClickDebounceDelay);
         registerCommand('cosmosDB.update', (filePath: vscode.Uri) => editorManager.updateMatchingNode(filePath));
-        registerCommand('cosmosDB.loadMore', (node?: AzureTreeItem) => tree.loadMore(node));
+        registerCommand('cosmosDB.loadMore', (node?: AzExtTreeItem) => tree.loadMore(node));
         registerEvent('cosmosDB.CosmosEditorManager.onDidSaveTextDocument', vscode.workspace.onDidSaveTextDocument, async function (
             this: IActionContext, doc: vscode.TextDocument): Promise<void> {
             await editorManager.onDidSaveTextDocument(this, doc);

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext, OutputChannel, TreeView } from "vscode";
-import { AzureTreeDataProvider, AzureTreeItem, IAzureUserInput, ISubscriptionRoot, ITelemetryReporter } from "vscode-azureextensionui";
+import { AzExtTreeDataProvider, AzExtTreeItem, IAzureUserInput, ITelemetryReporter } from "vscode-azureextensionui";
 import { MongoDatabaseTreeItem } from "./mongo/tree/MongoDatabaseTreeItem";
 import { AttachedAccountsTreeItem } from "./tree/AttachedAccountsTreeItem";
 
@@ -17,8 +17,8 @@ export namespace ext {
     export let context: ExtensionContext;
     export let outputChannel: OutputChannel;
     export let reporter: ITelemetryReporter;
-    export let tree: AzureTreeDataProvider;
-    export let treeView: TreeView<AzureTreeItem<ISubscriptionRoot>>;
+    export let tree: AzExtTreeDataProvider;
+    export let treeView: TreeView<AzExtTreeItem>;
     export let attachedAccountsNode: AttachedAccountsTreeItem;
 
     export namespace settingsKeys {

--- a/src/graph/tree/GraphCollectionTreeItem.ts
+++ b/src/graph/tree/GraphCollectionTreeItem.ts
@@ -71,17 +71,19 @@ export class GraphCollectionTreeItem extends AzureParentTreeItem<IDocDBTreeRoot>
         }
     }
 
-    public pickTreeItemImpl(expectedContextValue: string): AzureTreeItem<IDocDBTreeRoot> | undefined {
-        switch (expectedContextValue) {
-            case GraphTreeItem.contextValue:
-                return this._graphTreeItem;
+    public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): AzureTreeItem<IDocDBTreeRoot> | undefined {
+        for (const expectedContextValue of expectedContextValues) {
+            switch (expectedContextValue) {
+                case GraphTreeItem.contextValue:
+                    return this._graphTreeItem;
+                case DocDBStoredProceduresTreeItem.contextValue:
+                case DocDBStoredProcedureTreeItem.contextValue:
+                    return this._storedProceduresTreeItem;
 
-            case DocDBStoredProceduresTreeItem.contextValue:
-            case DocDBStoredProcedureTreeItem.contextValue:
-                return this._storedProceduresTreeItem;
-
-            default:
-                return undefined;
+                default:
+            }
         }
+
+        return undefined;
     }
 }

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { AzureTreeItem, callWithTelemetryAndErrorHandling, IActionContext, registerCommand, registerEvent } from "vscode-azureextensionui";
 import { CosmosEditorManager } from "../CosmosEditorManager";
 import { ext } from "../extensionVariables";
+import { AttachedAccountSuffix } from '../tree/AttachedAccountsTreeItem';
 import * as vscodeUtil from '../utils/vscodeUtils';
 import { MongoCollectionNodeEditor } from "./editors/MongoCollectionNodeEditor";
 import { MongoDBLanguageClient } from "./languageClient";
@@ -35,7 +36,7 @@ export function registerMongoCommands(context: vscode.ExtensionContext, editorMa
 
     registerCommand('cosmosDB.createMongoDatabase', async (node?: MongoAccountTreeItem) => {
         if (!node) {
-            node = <MongoAccountTreeItem>await ext.tree.showTreeItemPicker(MongoAccountTreeItem.contextValue);
+            node = <MongoAccountTreeItem>await ext.tree.showTreeItemPicker([MongoAccountTreeItem.contextValue, MongoAccountTreeItem.contextValue + AttachedAccountSuffix]);
         }
         const databaseNode = <MongoDatabaseTreeItem>await node.createChild();
         // reveal the database treeItem in case user cancels collection creation

--- a/src/table/tree/TableAccountTreeItem.ts
+++ b/src/table/tree/TableAccountTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeItem, GenericTreeItem } from "vscode-azureextensionui";
+import { AzExtTreeItem, AzureTreeItem, GenericTreeItem } from "vscode-azureextensionui";
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
 import { DocDBAccountTreeItemBase } from "../../docdb/tree/DocDBAccountTreeItemBase";
 import { IDocDBTreeRoot } from "../../docdb/tree/IDocDBTreeRoot";
@@ -20,7 +20,7 @@ export class TableAccountTreeItem extends DocDBAccountTreeItemBase {
         throw new Error('Table Accounts are not supported yet.');
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzureTreeItem<IDocDBTreeRoot>[]> {
+    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         return [new GenericTreeItem(this, {
             contextValue: 'tableNotSupported',
             label: 'Table Accounts are not supported yet.'

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -7,13 +7,14 @@ import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { appendExtensionUserAgent, AzureTreeItem, GenericTreeItem, ISubscriptionRoot, RootTreeItem, SubscriptionTreeItem, UserCancelledError } from 'vscode-azureextensionui';
+import { appendExtensionUserAgent, AzExtParentTreeItem, AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, GenericTreeItem, ISubscriptionRoot, SubscriptionTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { removeTreeItemFromCache } from '../commands/api/apiCache';
 import { emulatorPassword, resourcesPath } from '../constants';
 import { parseDocDBConnectionString } from '../docdb/docDBConnectionStrings';
 import { DocDBAccountTreeItem } from '../docdb/tree/DocDBAccountTreeItem';
 import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
 import { API, getExperienceFromApi, getExperienceQuickPick, getExperienceQuickPicks } from '../experiences';
+import { ext } from '../extensionVariables';
 import { GraphAccountTreeItem } from '../graph/tree/GraphAccountTreeItem';
 import { connectToMongoClient } from '../mongo/connectToMongoClient';
 import { parseMongoConnectionString } from '../mongo/mongoConnectionStrings';
@@ -33,7 +34,7 @@ export const MONGO_CONNECTION_EXPECTED: string = 'Connection string must start w
 
 const localMongoConnectionString: string = 'mongodb://127.0.0.1:27017';
 
-export class AttachedAccountsTreeItem extends RootTreeItem<ISubscriptionRoot> {
+export class AttachedAccountsTreeItem extends AzureParentTreeItem {
     public static contextValue: string = 'cosmosDBAttachedAccounts' + (process.platform === 'win32' ? 'WithEmulator' : 'WithoutEmulator');
     public readonly contextValue: string = AttachedAccountsTreeItem.contextValue;
     public readonly id: string = 'cosmosDBAttachedAccounts';
@@ -44,12 +45,18 @@ export class AttachedAccountsTreeItem extends RootTreeItem<ISubscriptionRoot> {
     private _attachedAccounts: AzureTreeItem[] | undefined;
     private _keytar: KeyTar;
 
+    private _root: ISubscriptionRoot;
     private _loadPersistedAccountsTask: Promise<AzureTreeItem[]>;
 
-    constructor(private readonly _globalState: vscode.Memento) {
-        super(new AttachedAccountRoot());
+    constructor(parent: AzExtParentTreeItem) {
+        super(parent);
         this._keytar = tryGetKeyTar();
+        this._root = new AttachedAccountRoot();
         this._loadPersistedAccountsTask = this.loadPersistedAccounts();
+    }
+
+    public get root(): ISubscriptionRoot {
+        return this._root;
     }
 
     private async getAttachedAccounts(): Promise<AzureTreeItem[]> {
@@ -76,7 +83,7 @@ export class AttachedAccountsTreeItem extends RootTreeItem<ISubscriptionRoot> {
         return false;
     }
 
-    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzureTreeItem[]> {
+    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
         if (clearCache) {
             this._attachedAccounts = undefined;
             this._loadPersistedAccountsTask = this.loadPersistedAccounts();
@@ -87,7 +94,8 @@ export class AttachedAccountsTreeItem extends RootTreeItem<ISubscriptionRoot> {
         return attachedAccounts.length > 0 ? attachedAccounts : [new GenericTreeItem(this, {
             contextValue: 'cosmosDBAttachDatabaseAccount',
             label: 'Attach Database Account...',
-            commandId: 'cosmosDB.attachDatabaseAccount'
+            commandId: 'cosmosDB.attachDatabaseAccount',
+            includeInTreeItemPicker: true
         })];
     }
 
@@ -233,7 +241,7 @@ export class AttachedAccountsTreeItem extends RootTreeItem<ISubscriptionRoot> {
 
     private async loadPersistedAccounts(): Promise<AzureTreeItem[]> {
         const persistedAccounts: AzureTreeItem[] = [];
-        const value: string | undefined = this._globalState.get(this._serviceName);
+        const value: string | undefined = ext.context.globalState.get(this._serviceName);
         if (value && this._keytar) {
             const accounts: (string | IPersistedAccount)[] = JSON.parse(value);
             await Promise.all(accounts.map(async account => {
@@ -316,7 +324,7 @@ export class AttachedAccountsTreeItem extends RootTreeItem<ISubscriptionRoot> {
             }
             return { id: node.id, defaultExperience: api, isEmulator: isEmulator };
         });
-        await this._globalState.update(this._serviceName, JSON.stringify(value));
+        await ext.context.globalState.update(this._serviceName, JSON.stringify(value));
     }
 
     static validateMongoConnectionString(value: string): string | undefined {

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -7,7 +7,7 @@ import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { appendExtensionUserAgent, AzExtParentTreeItem, AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, GenericTreeItem, ISubscriptionRoot, SubscriptionTreeItem, UserCancelledError } from 'vscode-azureextensionui';
+import { appendExtensionUserAgent, AzExtParentTreeItem, AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, GenericTreeItem, ISubscriptionRoot, UserCancelledError } from 'vscode-azureextensionui';
 import { removeTreeItemFromCache } from '../commands/api/apiCache';
 import { emulatorPassword, resourcesPath } from '../constants';
 import { parseDocDBConnectionString } from '../docdb/docDBConnectionStrings';
@@ -21,6 +21,7 @@ import { parseMongoConnectionString } from '../mongo/mongoConnectionStrings';
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
 import { TableAccountTreeItem } from '../table/tree/TableAccountTreeItem';
 import { KeyTar, tryGetKeyTar } from '../utils/keytar';
+import { SubscriptionTreeItem } from './SubscriptionTreeItem';
 
 interface IPersistedAccount {
     id: string;

--- a/src/tree/AzureAccountTreeItemWithAttached.ts
+++ b/src/tree/AzureAccountTreeItemWithAttached.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtTreeItem, AzureAccountTreeItem } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+import { AttachedAccountsTreeItem } from './AttachedAccountsTreeItem';
+import { CosmosDBAccountProvider } from './CosmosDBAccountProvider';
+
+export class AzureAccountTreeItemWithAttached extends AzureAccountTreeItem {
+    public constructor() {
+        super(undefined, CosmosDBAccountProvider);
+        ext.attachedAccountsNode = new AttachedAccountsTreeItem(this);
+    }
+
+    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
+        const children: AzExtTreeItem[] = await super.loadMoreChildrenImpl(clearCache);
+        return children.concat(ext.attachedAccountsNode);
+    }
+
+    public compareChildrenImpl(item1: AzExtTreeItem, item2: AzExtTreeItem): number {
+        if (item1 instanceof AttachedAccountsTreeItem) {
+            return 1;
+        } else if (item2 instanceof AttachedAccountsTreeItem) {
+            return -1;
+        } else {
+            return super.compareChildrenImpl(item1, item2);
+        }
+    }
+}

--- a/src/tree/AzureAccountTreeItemWithAttached.ts
+++ b/src/tree/AzureAccountTreeItemWithAttached.ts
@@ -3,15 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeItem, AzureAccountTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureAccountTreeItemBase, ISubscriptionRoot } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { AttachedAccountsTreeItem } from './AttachedAccountsTreeItem';
-import { CosmosDBAccountProvider } from './CosmosDBAccountProvider';
+import { SubscriptionTreeItem } from './SubscriptionTreeItem';
 
-export class AzureAccountTreeItemWithAttached extends AzureAccountTreeItem {
+export class AzureAccountTreeItemWithAttached extends AzureAccountTreeItemBase {
     public constructor() {
-        super(undefined, CosmosDBAccountProvider);
+        super();
         ext.attachedAccountsNode = new AttachedAccountsTreeItem(this);
+    }
+
+    public createSubscriptionTreeItem(root: ISubscriptionRoot): SubscriptionTreeItem {
+        return new SubscriptionTreeItem(this, root);
     }
 
     public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {

--- a/src/tree/CosmosDBAccountProvider.ts
+++ b/src/tree/CosmosDBAccountProvider.ts
@@ -6,7 +6,7 @@
 import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { DatabaseAccount, DatabaseAccountListKeysResult, DatabaseAccountsListResult } from 'azure-arm-cosmosdb/lib/models';
 import * as vscode from 'vscode';
-import { AzureTreeItem, AzureWizard, createAzureClient, createTreeItemsWithErrorHandling, IActionContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureTreeItem, AzureWizard, createAzureClient, IActionContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItem } from 'vscode-azureextensionui';
 import { DocDBAccountTreeItem } from "../docdb/tree/DocDBAccountTreeItem";
 import { getExperienceLabel, tryGetExperience } from '../experiences';
 import { TryGetGremlinEndpointFromAzure } from '../graph/gremlinEndpoints';
@@ -26,11 +26,10 @@ export class CosmosDBAccountProvider extends SubscriptionTreeItem {
         return false;
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzureTreeItem[]> {
+    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         const client: CosmosDBManagementClient = createAzureClient(this.root, CosmosDBManagementClient);
         const accounts: DatabaseAccountsListResult = await client.databaseAccounts.list();
-        return await createTreeItemsWithErrorHandling(
-            this,
+        return await this.createTreeItemsWithErrorHandling(
             accounts,
             'invalidCosmosDBAccount',
             async (db: DatabaseAccount) => await this.initChild(client, db),
@@ -96,5 +95,9 @@ export class CosmosDBAccountProvider extends SubscriptionTreeItem {
 
             }
         }
+    }
+
+    public isAncestorOfImpl(contextValue: string | RegExp): boolean {
+        return typeof contextValue !== 'string' || !/attached/i.test(contextValue);
     }
 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -6,7 +6,7 @@
 import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { DatabaseAccount, DatabaseAccountListKeysResult, DatabaseAccountsListResult } from 'azure-arm-cosmosdb/lib/models';
 import * as vscode from 'vscode';
-import { AzExtTreeItem, AzureTreeItem, AzureWizard, createAzureClient, IActionContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureTreeItem, AzureWizard, createAzureClient, IActionContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
 import { DocDBAccountTreeItem } from "../docdb/tree/DocDBAccountTreeItem";
 import { getExperienceLabel, tryGetExperience } from '../experiences';
 import { TryGetGremlinEndpointFromAzure } from '../graph/gremlinEndpoints';
@@ -19,7 +19,7 @@ import { CosmosDBAccountCreateStep } from './CosmosDBAccountWizard/CosmosDBAccou
 import { CosmosDBAccountNameStep } from './CosmosDBAccountWizard/CosmosDBAccountNameStep';
 import { ICosmosDBWizardContext } from './CosmosDBAccountWizard/ICosmosDBWizardContext';
 
-export class CosmosDBAccountProvider extends SubscriptionTreeItem {
+export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     public childTypeLabel: string = 'Account';
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -7,7 +7,7 @@ import { RetrievedDocument } from 'documentdb';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzureTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem } from 'vscode-azureextensionui';
 import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
 import { ext } from '../extensionVariables';
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
@@ -68,7 +68,7 @@ async function getUniqueFileName(folderPath: string, fileName: string, fileExten
     throw new Error('Could not find unique name for new file.');
 }
 
-export function getNodeEditorLabel(node: AzureTreeItem): string {
+export function getNodeEditorLabel(node: AzExtTreeItem): string {
     let labels = [node.label];
     while (node.parent) {
         node = node.parent;
@@ -80,7 +80,7 @@ export function getNodeEditorLabel(node: AzureTreeItem): string {
     return labels.join('/');
 }
 
-function isAccountTreeItem(treeItem: AzureTreeItem): boolean {
+function isAccountTreeItem(treeItem: AzExtTreeItem): boolean {
     return (treeItem instanceof MongoAccountTreeItem) || (treeItem instanceof DocDBAccountTreeItemBase);
 }
 


### PR DESCRIPTION
I used Cosmos DB as a trial for https://github.com/microsoft/vscode-azuretools/pull/499. See that PR for more info on why this change is happening.