### PR TITLE
Detect null values in schemas

### DIFF
--- a/src/mongo/services/schemaService.ts
+++ b/src/mongo/services/schemaService.ts
@@ -104,9 +104,13 @@ export class SchemaService {
 		});
 	}
 
+
+	private getMongoDocumentType(document: any) {
+		return Array.isArray(document) ? 'array' : (document === null ? 'null' : typeof document);
+	}
+
 	private setSchemaForDocument(parent: string, document: any, schema: JSONSchema): void {
-		const type = Array.isArray(document) ? 'array' : typeof document;
-		if (type === 'object') {
+		if (this.getMongoDocumentType(document) === 'object') {
 			for (const property of Object.keys(document)) {
 				if (!parent &&
 					['_id'].indexOf(property) !== -1) {
@@ -120,7 +124,7 @@ export class SchemaService {
 	private setSchemaForDocumentProperty(parent: string, property: string, document: any, schema: JSONSchema): void {
 		const scopedProperty = parent ? `${parent}.${property}` : property;
 		const value = document[property];
-		const type = Array.isArray(value) ? 'array' : typeof value;
+		const type = this.getMongoDocumentType(value);
 
 		const propertySchema: JSONSchema = {
 			type: [type, 'object']


### PR DESCRIPTION
In src/mongo/services/schemaService.ts:
---------------------------------------
private functions `setSchemaForDocument` and `setSchemaForDocumentProperty` both
make decisions based on the type of the passed value/document
being an object.

Unfortunately, in javascript,
```javascript
typeof null === 'object'
```
As a result, if a property or an array value has a value of `null`,
`setSchemaForDocument` will throw an error when calling `Object.keys(document)`