### PR TITLE
Fix some remaining mongo shell issues

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
 			},
 			"isBackground": true,
 			"presentation": {
-				"reveal": "silent"
+				"reveal": "never"
 			},
 			"problemMatcher": "$tsc-watch"
 		},

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Browse and query your MongoDB databases both locally and in the cloud using [_sc
 ### Run Mongo Commands with Rich Intellisense
 
 - View your MongoDB database account by [signing in to Azure](#managing-azure-subscriptions) or using "Attach Database Account" to connect via a connection string
-- Optionally configure the setting `mongo.shell.path` if your mongo executable is not already on your system's PATH (many of the common commands have built-in support and do not require the Mongo shell to be installed - see [Prerequisites](#prerequisites))
+- Optionally configure the settings `mongo.shell.path` and `mongo.shell.args` if your mongo executable is not already on your system's PATH (many of the common commands have built-in support and do not require the Mongo shell to be installed - see [Prerequisites](#prerequisites))
 - Click on "New Mongo Scrapbook" in the tree title bar
 - Click on "Connect to a database" to indicate which database to run the commands against
 - Enter your commands and/or comments, eg: `db.<collectionName>.find()`

--- a/package.json
+++ b/package.json
@@ -756,7 +756,7 @@
 				"mongo.shell.timeout": {
 					"type": "number",
 					"description": "The duration allowed (in seconds) for the Mongo shell to execute a command. Default value is 5 seconds",
-					"default": 5
+					"default": 30
 				},
 				"cosmosDB.showExplorer": {
 					"type": "boolean",

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -134,7 +134,8 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 			if (parameters.length > descriptor.maxHandledArgs) { //this function won't handle these arguments, but the shell will
 				return { deferToShell: true, result: undefined };
 			}
-			return await reportProgress(descriptor.mongoFunction.apply(this, parameters), descriptor.text);
+			let result = await reportProgress<string>(descriptor.mongoFunction.apply(this, parameters), descriptor.text);
+			return { deferToShell: false, result };
 		}
 		return { deferToShell: true, result: undefined };
 	}

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -157,7 +157,7 @@ export class MongoDatabaseTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
 		return MongoShell.create(shellPath, shellArgs, this.connectionString, this.root.isEmulator, ext.outputChannel, timeout);
 	}
 
-	private async _determineShellPathOrCmd(shellPathSetting: string): Promise<string> {
+	private async _determineShellPathOrCmd(shellPathSetting: string): Promise<string | undefined> {
 		if (!shellPathSetting) {
 			// User hasn't specified the path
 			if (await cpUtils.commandSucceeds('mongo', '--version')) {

--- a/src/utils/InteractiveChildProcess.ts
+++ b/src/utils/InteractiveChildProcess.ts
@@ -14,7 +14,7 @@ import { improveError } from './improveError';
 // We add these when we display to the output window
 const stdInPrefix = '> ';
 const stdErrPrefix = 'ERR> ';
-const errorPrefix = 'Error: ';
+const errorPrefix = 'Error running process: ';
 
 const processStartupTimeout = 60;
 

--- a/src/utils/getWorkspaceConfiguration.ts
+++ b/src/utils/getWorkspaceConfiguration.ts
@@ -6,9 +6,19 @@
 import { isArray } from 'util';
 import * as vscode from 'vscode';
 
+/**
+ * Retrieve a string setting, and throw an error if the value is not a string
+ */
 export function getWorkspaceConfiguration<T extends string>(key: string, expectedTypeOf: 'string', defaultValue?: T): T | typeof defaultValue;
+
+/**
+ * Retrieve a numeric setting, and throw an error if the value is not a number
+ */
 export function getWorkspaceConfiguration<T extends number>(key: string, expectedTypeOf: 'number', defaultValue?: 'number'): T | typeof defaultValue;
 
+/**
+ * Retrieve a string setting, and throw an error if the value is not a string
+ */
 export function getWorkspaceConfiguration<T>(key: string, expectedTypeOf: string, defaultValue?: unknown): unknown | undefined {
     let anyValue: unknown = vscode.workspace.getConfiguration().get<T>(key);
     if (typeof anyValue === expectedTypeOf) {
@@ -22,7 +32,14 @@ export function getWorkspaceConfiguration<T>(key: string, expectedTypeOf: string
     throw new Error(`Unexpected value for configuration setting '${key}'. Expecting value of type '${expectedTypeOf}', but found: ${String(anyValue)}`);
 }
 
+/**
+ * Retrieve a numeric array setting, and throw an error if the value is not an array of numbers
+ */
 export function getWorkspaceArrayConfiguration<T extends number>(key: string, expectedElementTypeOf?: 'number', defaultValue?: (T | undefined)[]): T | typeof defaultValue;
+
+/**
+ * Retrieve a string array setting, and throw an error if the value is not an array of strings
+ */
 export function getWorkspaceArrayConfiguration<T extends string>(key: string, expectedElementTypeOf: 'string', defaultValue?: T[]): (T | undefined)[] | typeof defaultValue;
 
 export function getWorkspaceArrayConfiguration<T>(key: string, expectedElementTypeOf: string, defaultValue?: T[]): unknown[] | undefined {

--- a/src/utils/getWorkspaceConfiguration.ts
+++ b/src/utils/getWorkspaceConfiguration.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isArray } from 'util';
+import * as vscode from 'vscode';
+
+export function getWorkspaceConfiguration<T extends string>(key: string, expectedTypeOf: 'string', defaultValue?: T): T | typeof defaultValue;
+export function getWorkspaceConfiguration<T extends number>(key: string, expectedTypeOf: 'number', defaultValue?: 'number'): T | typeof defaultValue;
+
+export function getWorkspaceConfiguration<T>(key: string, expectedTypeOf: string, defaultValue?: unknown): unknown | undefined {
+    let anyValue: unknown = vscode.workspace.getConfiguration().get<T>(key);
+    if (typeof anyValue === expectedTypeOf) {
+        return <T>anyValue;
+    }
+
+    if (anyValue === undefined || anyValue === null) {
+        return defaultValue;
+    }
+
+    throw new Error(`Unexpected value for configuration setting '${key}'. Expecting value of type '${expectedTypeOf}', but found: ${String(anyValue)}`);
+}
+
+export function getWorkspaceArrayConfiguration<T extends number>(key: string, expectedElementTypeOf?: 'number', defaultValue?: (T | undefined)[]): T | typeof defaultValue;
+export function getWorkspaceArrayConfiguration<T extends string>(key: string, expectedElementTypeOf: 'string', defaultValue?: T[]): (T | undefined)[] | typeof defaultValue;
+
+export function getWorkspaceArrayConfiguration<T>(key: string, expectedElementTypeOf: string, defaultValue?: T[]): unknown[] | undefined {
+    let anyValue: unknown = vscode.workspace.getConfiguration().get<T[]>(key);
+    if (anyValue === undefined || anyValue === null) {
+        return defaultValue;
+    }
+
+    if (isArray(anyValue)) {
+        let anyArray = <unknown[]>anyValue;
+        if (!anyArray.length) {
+            // Array is empty
+            return [];
+        }
+
+        // Check type of each element
+        for (let element of anyArray) {
+            if (element === undefined || element === null || typeof element !== expectedElementTypeOf) {
+                throw new Error(`Unexpected value for configuration setting '${key}'.  One of the array elements was not of the expected type: ${String(element)}`);
+            }
+        }
+
+        return anyArray;
+    } else {
+        throw new Error(`Unexpected value for configuration setting '${key}'.  Expected an array, but found: ${String(anyValue)}`);
+    }
+}


### PR DESCRIPTION
Fixes #1176 (not correctly capturing results from some queries)
Fixes #1149 (probably already fixed, but also testcase had bad mongo.shell.args setting)
Fixes #1115 (Increase default timeout)
Add mongo.shell.args to README
Don't choke on bad mongo.shell.{path,args} settings (these utilities can be used to fix all our settings, but I'm not doing it here)
Immediately after browsing to mongo.exe, the query would fail because we're using correctly path from determineShellPathOrCmd)
