### PR TITLE
Don't prevent Lexer errors from executing mongo scrapbook queries

### DIFF
--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -109,7 +109,8 @@ async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDa
 		if (command.errors && command.errors.length > 0) {
 			//Currently, we take the first error pushed. Tests correlate that the parser visits errors in left-to-right, top-to-bottom.
 			const err = command.errors[0];
-			throw new Error(`Error near line ${err.range.start.line}, column ${err.range.start.character}: '${err.message}'. Please check syntax.`);
+			// don't await intentionally
+			ext.ui.showWarningMessage(`Error near line ${err.range.start.line}, column ${err.range.start.character}: '${err.message}'. Please check syntax.`);
 		}
 
 		if (command.name === 'find') {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1193, https://github.com/microsoft/vscode-cosmosdb/issues/981

Today the lexer is throwing an error for valid mongo commands.  Updating the mongo.g4 file (where the lexer is pulling the grammar) is not a trivial task that I think will take me a lot of investigating to do.

However, if we don't block users from executing commands that the lexer considers invalid, users can still workaround it.

I don't think this is quite a proper fix, perse, but at least it will unblock the users who have run into the above errors.

It looks like this if a mongo command _actually_ fails:
![image](https://user-images.githubusercontent.com/5290572/68628716-5a036980-0496-11ea-82e4-a22b8febee7f.png)

