### PR TITLE
Create Collections 📚 supports options in Mongo scrapbooks 📔

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/bluebird": {
+			"version": "3.5.29",
+			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
+			"integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
+			"dev": true
+		},
 		"@types/bson": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.0.tgz",
@@ -12,6 +18,12 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/caseless": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+			"dev": true
 		},
 		"@types/d3": {
 			"version": "5.0.0",
@@ -348,6 +360,41 @@
 			"integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==",
 			"dev": true
 		},
+		"@types/request": {
+			"version": "2.48.3",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
+			"integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
+			"dev": true,
+			"requires": {
+				"@types/caseless": "*",
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"form-data": "^2.5.0"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+					"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+					"dev": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				}
+			}
+		},
+		"@types/request-promise": {
+			"version": "4.1.44",
+			"resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.44.tgz",
+			"integrity": "sha512-RId7eFsUKxfal1LirDDIcOp9u3MM3NXFDBcC3sqIMcmu7f4U6DsCEMD8RbLZtnPrQlN5Jc79di/WPsIEDO4keg==",
+			"dev": true,
+			"requires": {
+				"@types/bluebird": "*",
+				"@types/request": "*"
+			}
+		},
 		"@types/socket.io": {
 			"version": "1.4.40",
 			"resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-1.4.40.tgz",
@@ -361,6 +408,12 @@
 			"version": "1.4.32",
 			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.32.tgz",
 			"integrity": "sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg==",
+			"dev": true
+		},
+		"@types/tough-cookie": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+			"integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -7343,6 +7396,27 @@
 				"uuid": "^3.3.2"
 			}
 		},
+		"request-promise": {
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+			"integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.5.0",
+				"request-promise-core": "1.1.3",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8023,6 +8097,12 @@
 					}
 				}
 			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
 		},
 		"stream-browserify": {
 			"version": "2.0.1",

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -112,7 +112,7 @@ export class MongoDatabaseTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
 
 		if (command.name === 'createCollection') {
 			// arguments are always string (ie collection name) whereas arguementObjects will be an Object (where as in arguments, it's a JSON string)
-			return withProgress(this.createCollection(command.arguments[0], command.argumentObjects[1]).then(() => JSON.stringify({ 'Created': 'Ok' })), 'Creating collection');
+			return withProgress(this.createCollection(stripQuotes(command.arguments[0]), command.argumentObjects[1]).then(() => JSON.stringify({ 'Created': 'Ok' })), 'Creating collection');
 		} else {
 			return withProgress(this.executeCommandInShell(command, context), executingInShellMsg);
 		}
@@ -120,7 +120,7 @@ export class MongoDatabaseTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
 
 	public async createCollection(collectionName: string, options?: DbCollectionOptions): Promise<MongoCollectionTreeItem> {
 		const db: Db = await this.connectToDb();
-		const newCollection: Collection = db.collection(collectionName, options);
+		const newCollection: Collection = await db.createCollection(collectionName, options);
 		// db.createCollection() doesn't create empty collections for some reason
 		// However, we can 'insert' and then 'delete' a document, which has the side-effect of creating an empty collection
 		const result = await newCollection.insertOne({});

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -111,7 +111,7 @@ export class MongoDatabaseTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
 		}
 
 		if (command.name === 'createCollection') {
-			// arguments are always string (ie collection name) whereas arguementObjects will be an Object (where as in arguments, it's a JSON string)
+			// arguments  are all strings so DbCollectionOptions is represented as a JSON string which is why we pass argumentObjects instead
 			return withProgress(this.createCollection(stripQuotes(command.arguments[0]), command.argumentObjects[1]).then(() => JSON.stringify({ 'Created': 'Ok' })), 'Creating collection');
 		} else {
 			return withProgress(this.executeCommandInShell(command, context), executingInShellMsg);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1222

Today, createCollection takes all arguments and stringifies them.  That leads to this valid Mongo query:

``` 
db.createCollection("teste", {
    validator: {
        jsonSchema: {
            bsonType: "object",
            required: ["teste1", "teste2"],
            properties: {
                teste1: {
                    bsonType: "string",
                    description: "Deve ser uma string"
                },
                teste2: {
                    bsonType: "string",
                    description: "Deve ser uma string"
                },
            }
        }
    }
})
```

Being inserted like this:
![image](https://user-images.githubusercontent.com/5290572/68703642-e322ab00-053f-11ea-9f2a-2ad7d1832bad.png)

With my changes, it is inserted normally:
![image](https://user-images.githubusercontent.com/5290572/68703660-ef0e6d00-053f-11ea-8f0f-4a197bb31138.png)

I don't think Azure supports validators yet: 
![image](https://user-images.githubusercontent.com/5290572/68715176-428bb580-0556-11ea-95f4-55bf5674b8ff.png)

But it does work for a local database:
`db.getCollectionInfos({name: 'teste3'})`

![image](https://user-images.githubusercontent.com/5290572/68714992-d9a43d80-0555-11ea-9c35-629473167af2.png)
