### PR TITLE
Check chained ⛓ property when executing command

### DIFF
--- a/src/commands/importDocuments.ts
+++ b/src/commands/importDocuments.ts
@@ -45,7 +45,7 @@ export async function importDocuments(actionContext: IActionContext, uris: vscod
             const documents = await parseDocuments(uris);
             progress.report({ increment: 30, message: "Parsed documents. Importing" });
             if (collectionNode instanceof MongoCollectionTreeItem) {
-                let { deferToShell, result: tryExecuteResult } = await collectionNode.tryExecuteCommandDirectly('insertMany', [JSON.stringify(documents)]);
+                let { deferToShell, result: tryExecuteResult } = await collectionNode.tryExecuteCommandDirectly({ name: 'insertMany', arguments: [JSON.stringify(documents)] });
                 assert(!deferToShell, "This command should not need to be sent to the shell");
                 result = processMongoResults(tryExecuteResult);
             } else {

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -112,7 +112,7 @@ async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDa
 			throw new Error(`Error near line ${err.range.start.line}, column ${err.range.start.character}: '${err.message}'. Please check syntax.`);
 		}
 
-		if (command.name === 'find') {
+		if (command.name === 'find' && !command.chained) {
 			await editorManager.showDocument(context, new MongoFindResultEditor(database, command), 'cosmos-result.json', { showInNextColumn: true });
 		} else {
 			const result = await database.executeCommand(command, context);

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { AzureParentTreeItem, DialogResponses, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
 import { defaultBatchSize, getThemeAgnosticIconPath } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { MongoCommand } from '../MongoCommand';
 import { IMongoTreeRoot } from './IMongoTreeRoot';
 import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';
 // tslint:disable:no-var-requires
@@ -107,8 +108,9 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 		return new MongoDocumentTreeItem(this, newDocument);
 	}
 
-	public async tryExecuteCommandDirectly(name: string, args?: string[]): Promise<{ deferToShell: true; result: undefined } | { deferToShell: false; result: string }> {
-		const parameters = args ? args.map(parseJSContent) : undefined;
+	public async tryExecuteCommandDirectly(command: Partial<MongoCommand>): Promise<{ deferToShell: true; result: undefined } | { deferToShell: false; result: string }> {
+		// range and text are not neccessary properties for this function so partial should suffice
+		const parameters = command.arguments ? command.arguments.map(parseJSContent) : undefined;
 
 		const functions = {
 			drop: new FunctionDescriptor(this.drop, 'Dropping collection', 0, 0, 0),
@@ -122,14 +124,19 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 			remove: new FunctionDescriptor(this.remove, 'Deleting document(s)', 1, 2, 1)
 		};
 
-		if (functions.hasOwnProperty(name)) {
-			let descriptor: FunctionDescriptor = functions[name];
+		if (functions.hasOwnProperty(command.name)) {
+
+			// we don't know how to handle chained commands so just defer to the shell right away
+			if (command.chained) {
+				return { deferToShell: true, result: undefined };
+			}
+			let descriptor: FunctionDescriptor = functions[command.name];
 
 			if (parameters.length < descriptor.minShellArgs) {
-				throw new Error(`Too few arguments passed to command ${name}.`);
+				throw new Error(`Too few arguments passed to command ${command.name}.`);
 			}
 			if (parameters.length > descriptor.maxShellArgs) {
-				throw new Error(`Too many arguments passed to command ${name}`);
+				throw new Error(`Too many arguments passed to command ${command.name}`);
 			}
 			if (parameters.length > descriptor.maxHandledArgs) { //this function won't handle these arguments, but the shell will
 				return { deferToShell: true, result: undefined };

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -126,7 +126,7 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 
 		if (functions.hasOwnProperty(command.name)) {
 
-			// we don't know how to handle chained commands so just defer to the shell right away
+			// currently no logic to handle chained commands so just defer to the shell right away
 			if (command.chained) {
 				return { deferToShell: true, result: undefined };
 			}

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -101,7 +101,7 @@ export class MongoDatabaseTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
 			const collection = db.collection(command.collection);
 			if (collection) {
 				const collectionTreeItem = new MongoCollectionTreeItem(this, collection, command.arguments);
-				const result = await collectionTreeItem.tryExecuteCommandDirectly(command.name, command.arguments);
+				const result = await collectionTreeItem.tryExecuteCommandDirectly(command);
 				if (!result.deferToShell) {
 					return result.result;
 				}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/981
Partially fixes https://github.com/microsoft/vscode-cosmosdb/issues/1193

There was an issue when trying to run `db.getCollection('my-collection').find({})`.  The MongoCommand parser was detecting the chained command, but there was no check on that property.  If a command is being chained, then we should just defer to the shell since we don't have chaining logic.

I want to refactor how we `executeCommand` at one point, but I couldn't think of a better way to fix this than to simply check the `chained` property when the `command.name === 'find'`