### PR TITLE
Add a confirmation message for copy connection string

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,11 +112,13 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             await node.openInPortal();
         });
         registerCommand('cosmosDB.copyConnectionString', async (actionContext: IActionContext, node?: MongoAccountTreeItem | DocDBAccountTreeItemBase) => {
+            const message = 'The connection string has been copied to the clipboard';
             if (!node) {
                 node = await ext.tree.showTreeItemPicker(accountContextValues, actionContext);
             }
 
             await copyConnectionString(node);
+            await vscode.window.showInformationMessage(message);
         });
         registerCommand('cosmosDB.openDocument', async (actionContext: IActionContext, node?: MongoDocumentTreeItem | DocDBDocumentTreeItem) => {
             if (!node) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             }
 
             await copyConnectionString(node);
-            await vscode.window.showInformationMessage(message);
+            vscode.window.showInformationMessage(message);
         });
         registerCommand('cosmosDB.openDocument', async (actionContext: IActionContext, node?: MongoDocumentTreeItem | DocDBDocumentTreeItem) => {
             if (!node) {


### PR DESCRIPTION
When executing the "Copy Connection String" command from the Command Palette, there is no feedback that the operation succeeded. This is a little awkward as the developer isn't sure if anything has happened.

This is less of an issue on the right-click since we are accustomed to right-click actions being successful by virtue of the right click occurring without error. Since we don't distinguish between when a the connection string copy occurs via right-click vs command palette, I suggest that we always show a notification that the connection string copy has occurred successfully.