### PR TITLE
Add ➕ appName to options to support private 🚫 IP 💻

### DIFF
--- a/src/mongo/connectToMongoClient.ts
+++ b/src/mongo/connectToMongoClient.ts
@@ -15,8 +15,6 @@ export async function connectToMongoClient(connectionString: string, appName: st
         useNewUrlParser: true
     };
 
-    options.ssl = true;
-
     try {
         return await MongoClient.connect(connectionString, options);
     } catch (err) {

--- a/src/mongo/connectToMongoClient.ts
+++ b/src/mongo/connectToMongoClient.ts
@@ -6,10 +6,11 @@
 import { MongoClient, MongoClientOptions } from 'mongodb';
 import { Links } from '../constants';
 
-export async function connectToMongoClient(connectionString: string, dbAccountName: string): Promise<MongoClient> {
+export async function connectToMongoClient(connectionString: string, appName: string): Promise<MongoClient> {
     // appname appears to be the correct equivalent to user-agent for mongo
     let options: MongoClientOptions = <MongoClientOptions>{
-        appName: `@${dbAccountName}@`,
+        // appName should be wrapped in '@'s when trying to connect to a Mongo account, this doesn't effect the appendUserAgent string
+        appName: `@${appName}@`,
         // https://github.com/lmammino/mongo-uri-builder/issues/2
         useNewUrlParser: true
     };

--- a/src/mongo/connectToMongoClient.ts
+++ b/src/mongo/connectToMongoClient.ts
@@ -6,15 +6,15 @@
 import { MongoClient, MongoClientOptions } from 'mongodb';
 import { Links } from '../constants';
 
-// Can't call appendExtensionUserAgent() here because languageClient.ts can't take a dependency on vscode-azureextensionui and hence vscode, so have
-//   to pass the user agent string in
-export async function connectToMongoClient(connectionString: string, extensionUserAgent: string): Promise<MongoClient> {
+export async function connectToMongoClient(connectionString: string, dbAccountName: string): Promise<MongoClient> {
     // appname appears to be the correct equivalent to user-agent for mongo
     let options: MongoClientOptions = <MongoClientOptions>{
-        appname: extensionUserAgent,
+        appName: `@${dbAccountName}@`,
         // https://github.com/lmammino/mongo-uri-builder/issues/2
         useNewUrlParser: true
     };
+
+    options.ssl = true;
 
     try {
         return await MongoClient.connect(connectionString, options);

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -57,7 +57,7 @@ export class MongoAccountTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
                 throw new Error('Missing connection string');
             }
 
-            mongoClient = await connectToMongoClient(this.connectionString, appendExtensionUserAgent());
+            mongoClient = await connectToMongoClient(this.connectionString, this.databaseAccount ? this.databaseAccount.name : appendExtensionUserAgent());
 
             let databaseInConnectionString = getDatabaseNameFromConnectionString(this.connectionString);
             if (databaseInConnectionString && !this.root.isEmulator) { // emulator violates the connection string format

--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -57,6 +57,7 @@ export class MongoAccountTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
                 throw new Error('Missing connection string');
             }
 
+            // Azure MongoDB accounts need to have the name passed in for private endpoints
             mongoClient = await connectToMongoClient(this.connectionString, this.databaseAccount ? this.databaseAccount.name : appendExtensionUserAgent());
 
             let databaseInConnectionString = getDatabaseNameFromConnectionString(this.connectionString);


### PR DESCRIPTION
Azure MongoDB accounts need to have the name passed in for private endpoints.  To test this, you have to remote SSH into VS Code in a VM that is in the same VNET as the private IP.