### PR TITLE
Check for chaining before executing command

### DIFF
--- a/src/commands/importDocuments.ts
+++ b/src/commands/importDocuments.ts
@@ -45,7 +45,7 @@ export async function importDocuments(actionContext: IActionContext, uris: vscod
             const documents = await parseDocuments(uris);
             progress.report({ increment: 30, message: "Parsed documents. Importing" });
             if (collectionNode instanceof MongoCollectionTreeItem) {
-                let { deferToShell, result: tryExecuteResult } = await collectionNode.tryExecuteCommandDirectly('insertMany', [JSON.stringify(documents)]);
+                let { deferToShell, result: tryExecuteResult } = await collectionNode.tryExecuteCommandDirectly({ name: 'insertMany', arguments: [JSON.stringify(documents)] });
                 assert(!deferToShell, "This command should not need to be sent to the shell");
                 result = processMongoResults(tryExecuteResult);
             } else {

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -112,7 +112,7 @@ async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDa
 			throw new Error(`Error near line ${err.range.start.line}, column ${err.range.start.character}: '${err.message}'. Please check syntax.`);
 		}
 
-		if (command.name === 'find') {
+		if (command.name === 'find' && !command.chained) {
 			await editorManager.showDocument(context, new MongoFindResultEditor(database, command), 'cosmos-result.json', { showInNextColumn: true });
 		} else {
 			const result = await database.executeCommand(command, context);

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -112,6 +112,7 @@ async function executeCommand(activeEditor: vscode.TextEditor, database: MongoDa
 			throw new Error(`Error near line ${err.range.start.line}, column ${err.range.start.character}: '${err.message}'. Please check syntax.`);
 		}
 
+		// we don't handle chained commands so we can only handle "find" if isn't chained
 		if (command.name === 'find' && !command.chained) {
 			await editorManager.showDocument(context, new MongoFindResultEditor(database, command), 'cosmos-result.json', { showInNextColumn: true });
 		} else {

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { AzureParentTreeItem, DialogResponses, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
 import { defaultBatchSize, getThemeAgnosticIconPath } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { MongoCommand } from '../MongoCommand';
 import { IMongoTreeRoot } from './IMongoTreeRoot';
 import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';
 // tslint:disable:no-var-requires
@@ -107,8 +108,9 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 		return new MongoDocumentTreeItem(this, newDocument);
 	}
 
-	public async tryExecuteCommandDirectly(name: string, args?: string[]): Promise<{ deferToShell: true; result: undefined } | { deferToShell: false; result: string }> {
-		const parameters = args ? args.map(parseJSContent) : undefined;
+	public async tryExecuteCommandDirectly(command: Partial<MongoCommand>): Promise<{ deferToShell: true; result: undefined } | { deferToShell: false; result: string }> {
+		// range and text are not neccessary properties for this function so partial should suffice
+		const parameters = command.arguments ? command.arguments.map(parseJSContent) : undefined;
 
 		const functions = {
 			drop: new FunctionDescriptor(this.drop, 'Dropping collection', 0, 0, 0),
@@ -122,14 +124,19 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 			remove: new FunctionDescriptor(this.remove, 'Deleting document(s)', 1, 2, 1)
 		};
 
-		if (functions.hasOwnProperty(name)) {
-			let descriptor: FunctionDescriptor = functions[name];
+		if (functions.hasOwnProperty(command.name)) {
+
+			// we don't know how to handle chained commands so just defer to the shell right away
+			if (command.chained) {
+				return { deferToShell: true, result: undefined };
+			}
+			let descriptor: FunctionDescriptor = functions[command.name];
 
 			if (parameters.length < descriptor.minShellArgs) {
-				throw new Error(`Too few arguments passed to command ${name}.`);
+				throw new Error(`Too few arguments passed to command ${command.name}.`);
 			}
 			if (parameters.length > descriptor.maxShellArgs) {
-				throw new Error(`Too many arguments passed to command ${name}`);
+				throw new Error(`Too many arguments passed to command ${command.name}`);
 			}
 			if (parameters.length > descriptor.maxHandledArgs) { //this function won't handle these arguments, but the shell will
 				return { deferToShell: true, result: undefined };

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -126,7 +126,7 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 
 		if (functions.hasOwnProperty(command.name)) {
 
-			// we don't know how to handle chained commands so just defer to the shell right away
+			// currently no logic to handle chained commands so just defer to the shell right away
 			if (command.chained) {
 				return { deferToShell: true, result: undefined };
 			}

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -101,7 +101,7 @@ export class MongoDatabaseTreeItem extends AzureParentTreeItem<IMongoTreeRoot> {
 			const collection = db.collection(command.collection);
 			if (collection) {
 				const collectionTreeItem = new MongoCollectionTreeItem(this, collection, command.arguments);
-				const result = await collectionTreeItem.tryExecuteCommandDirectly(command.name, command.arguments);
+				const result = await collectionTreeItem.tryExecuteCommandDirectly(command);
 				if (!result.deferToShell) {
 					return result.result;
 				}

--- a/test/mongoGetCommand.test.ts
+++ b/test/mongoGetCommand.test.ts
@@ -459,15 +459,6 @@ suite("scrapbook parsing Tests", () => {
         });
     });
 
-    test("test chained command: chain command ends with find", () => {
-
-        testParse('db.getCollection("timesheets").find();', {
-            collection: "",
-            name: "find",
-            args: ['timesheets']
-        });
-    });
-
     // test("ISODate", () => {
     //     testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00Z") });', {
     //         collection: "c1",

--- a/test/mongoGetCommand.test.ts
+++ b/test/mongoGetCommand.test.ts
@@ -459,6 +459,15 @@ suite("scrapbook parsing Tests", () => {
         });
     });
 
+    test("test chained command: chain command ends with find", () => {
+
+        testParse('db.getCollection("timesheets").find();', {
+            collection: "",
+            name: "find",
+            args: ['timesheets']
+        });
+    });
+
     // test("ISODate", () => {
     //     testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00Z") });', {
     //         collection: "c1",
@@ -478,20 +487,20 @@ suite("scrapbook parsing Tests", () => {
             }
             });
         `, {
-                collection: "timesheets",
-                name: "update",
-                args: [
-                    {
-                        year: 2018,
-                        month: "06"
-                    },
-                    {
-                        "$set": {
-                            "workers.0.days.0.something": "yupy!"
-                        }
+            collection: "timesheets",
+            name: "update",
+            args: [
+                {
+                    year: 2018,
+                    month: "06"
+                },
+                {
+                    "$set": {
+                        "workers.0.days.0.something": "yupy!"
                     }
-                ]
-            });
+                }
+            ]
+        });
     });
 
     test("nested objects", () => {
@@ -502,21 +511,21 @@ suite("scrapbook parsing Tests", () => {
             }
             }
             })`, {
-                collection: "users",
-                name: "update",
-                args: [
-                    {},
-                    {
-                        "$pull": {
-                            proposals: {
-                                "$elemMatch": {
-                                    _id: "4qsBHLDCb755c3vPH"
-                                }
+            collection: "users",
+            name: "update",
+            args: [
+                {},
+                {
+                    "$pull": {
+                        proposals: {
+                            "$elemMatch": {
+                                _id: "4qsBHLDCb755c3vPH"
                             }
                         }
                     }
-                ]
-            });
+                }
+            ]
+        });
     });
     test("test function call with and without quotes", () => {
         for (let q = 0; q <= 2; q++) {
@@ -1020,4 +1029,3 @@ suite("scrapbook parsing Tests", () => {
         }
     });
 });
-


### PR DESCRIPTION
A workaround for this issue https://github.com/microsoft/vscode-cosmosdb/issues/1193

You can now use `getCollection` to retrieve collections with odd naming conventions.  The real solution is to edit the grammar file to understand [] notation.

`getCollection` doesn't work today because `getCollection().find()` was parsed with the command.name as find, and would enter that part of the conditional rather than attempting to execute the command.