### PR TITLE
Include ISODate 📆 for constructorCall 👷‍♀️📞 and handle appropriately

### DIFF
--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -373,9 +373,11 @@ class FindMongoCommandsVisitor extends MongoVisitor<MongoCommand[]> {
 			try {
 				tokenText = stripQuotes(tokenText);
 
-				// if the tokenText was an isodate, it needs a Z suffix for indication
+				// if the tokenText was an isodate, the last char must be Z
 				if (isIsodate) {
-					tokenText += 'Z';
+					if (tokenText[tokenText.length - 1] !== 'Z') {
+						tokenText += 'Z';
+					}
 				}
 
 				constructedObject = new Date(tokenText);

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -370,22 +370,23 @@ class FindMongoCommandsVisitor extends MongoVisitor<MongoCommand[]> {
 		}
 	}
 
-	private dateToObject(ctx: mongoParser.ArgumentContext | mongoParser.PropertyValueContext, tokenText?: string): { $date: Date | {} } {
-		let stringDate: Date | {} = this.tryToConstructDate(ctx, tokenText);
-		if (stringDate instanceof Date) {
-			return { $date: stringDate.toISOString() };
+	private dateToObject(ctx: mongoParser.ArgumentContext | mongoParser.PropertyValueContext, tokenText?: string): { $date: string } | {} {
+		let date: Date | {} = this.tryToConstructDate(ctx, tokenText);
+		if (date instanceof Date) {
+			return { $date: date.toString() };
+		} else {
+			return date;
 		}
-
-		return { $date: stringDate };
 	}
 
-	private isodateToObject(ctx: mongoParser.ArgumentContext | mongoParser.PropertyValueContext, tokenText?: string): { $date: Date | {} } {
-		let stringDate: Date | {} = this.tryToConstructDate(ctx, tokenText, true);
-		if (stringDate instanceof Date) {
-			return { $date: stringDate.toISOString() };
-		}
+	private isodateToObject(ctx: mongoParser.ArgumentContext | mongoParser.PropertyValueContext, tokenText?: string): { $date: string } | {} {
+		let date: Date | {} = this.tryToConstructDate(ctx, tokenText, true);
 
-		return { $date: stringDate };
+		if (date instanceof Date) {
+			return { $date: date.toISOString() };
+		} else {
+			return date;
+		}
 	}
 
 	private tryToConstructDate(ctx: mongoParser.ArgumentContext | mongoParser.PropertyValueContext, tokenText?: string, isIsodate: boolean = false): Date | {} {

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -176,7 +176,9 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 		if (!document) {
 			throw new Error("The insert command requires at least one argument");
 		}
-		const insertResult = await this.collection.insert(document);
+
+		// insert is deprecated, so use insertOne instead
+		const insertResult = await this.collection.insertOne(document);
 		return this.stringify(insertResult);
 	}
 

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -184,8 +184,7 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 			throw new Error("The insert command requires at least one argument");
 		}
 
-		// insert is deprecated, so use insertOne instead
-		const insertResult = await this.collection.insertOne(document);
+		const insertResult = await this.collection.insert(document);
 		return this.stringify(insertResult);
 	}
 

--- a/test/mongoGetCommand.test.ts
+++ b/test/mongoGetCommand.test.ts
@@ -459,7 +459,7 @@ suite("scrapbook parsing Tests", () => {
         });
     });
 
-    test("ISODate", () => {
+    test("ISODate with standard date string", () => {
         testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00Z") });', {
             collection: "c1",
             name: "insertOne",
@@ -477,7 +477,7 @@ suite("scrapbook parsing Tests", () => {
         });
     });
 
-    test("ISODate 2", () => {
+    test("ISODate without Z in date string", () => {
         testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00") });', {
             collection: "c1",
             name: "insertOne",
@@ -495,7 +495,7 @@ suite("scrapbook parsing Tests", () => {
         });
     });
 
-    test("ISODate 3", () => {
+    test("Invalid ISODate", () => {
         testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00z") });', {
             collection: "c1",
             name: "insertOne",
@@ -503,6 +503,26 @@ suite("scrapbook parsing Tests", () => {
             firstErrorText: "Invalid time value"
         });
     });
+
+    test("Date", () => {
+        const date: Date = new Date("2018-05-01T00:00:00");
+        testParse(`db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": Date("${date.toUTCString()}") });`, {
+            collection: "c1",
+            name: "insertOne",
+            args: [
+                {
+                    "_id": {
+                        "$oid": "5aecf1a63d8af732f07e4275"
+                    },
+                    "date": {
+                        "$date": date.toISOString()
+                    },
+                    "name": "Stephen"
+                }
+            ]
+        });
+    });
+
 
     test("Keys with periods", () => {
         testParse(`db.timesheets.update( {

--- a/test/mongoGetCommand.test.ts
+++ b/test/mongoGetCommand.test.ts
@@ -459,14 +459,50 @@ suite("scrapbook parsing Tests", () => {
         });
     });
 
-    // test("ISODate", () => {
-    //     testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00Z") });', {
-    //         collection: "c1",
-    //         name: "insertOne",
-    //         args: [],
-    //         firstErrorText: "Unexpected token O in JSON at position 7"
-    //     });
-    // });
+    test("ISODate", () => {
+        testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00Z") });', {
+            collection: "c1",
+            name: "insertOne",
+            args: [
+                {
+                    "_id": {
+                        "$oid": "5aecf1a63d8af732f07e4275"
+                    },
+                    "date": {
+                        "$date": "2018-05-01T00:00:00.000Z"
+                    },
+                    "name": "Stephen"
+                }
+            ]
+        });
+    });
+
+    test("ISODate 2", () => {
+        testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00") });', {
+            collection: "c1",
+            name: "insertOne",
+            args: [
+                {
+                    "_id": {
+                        "$oid": "5aecf1a63d8af732f07e4275"
+                    },
+                    "date": {
+                        "$date": "2018-05-01T00:00:00.000Z"
+                    },
+                    "name": "Stephen"
+                }
+            ]
+        });
+    });
+
+    test("ISODate 3", () => {
+        testParse('db.c1.insertOne({ "_id": ObjectId("5aecf1a63d8af732f07e4275"), "name": "Stephen", "date": ISODate("2018-05-01T00:00:00z") });', {
+            collection: "c1",
+            name: "insertOne",
+            args: [],
+            firstErrorText: "Invalid time value"
+        });
+    });
 
     test("Keys with periods", () => {
         testParse(`db.timesheets.update( {
@@ -478,20 +514,20 @@ suite("scrapbook parsing Tests", () => {
             }
             });
         `, {
-                collection: "timesheets",
-                name: "update",
-                args: [
-                    {
-                        year: 2018,
-                        month: "06"
-                    },
-                    {
-                        "$set": {
-                            "workers.0.days.0.something": "yupy!"
-                        }
+            collection: "timesheets",
+            name: "update",
+            args: [
+                {
+                    year: 2018,
+                    month: "06"
+                },
+                {
+                    "$set": {
+                        "workers.0.days.0.something": "yupy!"
                     }
-                ]
-            });
+                }
+            ]
+        });
     });
 
     test("nested objects", () => {
@@ -502,21 +538,21 @@ suite("scrapbook parsing Tests", () => {
             }
             }
             })`, {
-                collection: "users",
-                name: "update",
-                args: [
-                    {},
-                    {
-                        "$pull": {
-                            proposals: {
-                                "$elemMatch": {
-                                    _id: "4qsBHLDCb755c3vPH"
-                                }
+            collection: "users",
+            name: "update",
+            args: [
+                {},
+                {
+                    "$pull": {
+                        proposals: {
+                            "$elemMatch": {
+                                _id: "4qsBHLDCb755c3vPH"
                             }
                         }
                     }
-                ]
-            });
+                }
+            ]
+        });
     });
     test("test function call with and without quotes", () => {
         for (let q = 0; q <= 2; q++) {
@@ -1020,4 +1056,3 @@ suite("scrapbook parsing Tests", () => {
         }
     });
 });
-

--- a/test/mongoGetCommand.test.ts
+++ b/test/mongoGetCommand.test.ts
@@ -515,7 +515,7 @@ suite("scrapbook parsing Tests", () => {
                         "$oid": "5aecf1a63d8af732f07e4275"
                     },
                     "date": {
-                        "$date": date.toISOString()
+                        "$date": date.toString()
                     },
                     "name": "Stephen"
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1096

The error was happening because ISODate was being handled the same as a Date object.  The string representation for a Date is `1975-07-23T04:10:00.000` as opposed to ISODate's `1975-07-23T04:10:00.000Z`.  So when Mongo inserted the date, it just assumed the timezone was whatever the computer's local timezone was set to.

Edit: Both `db.test.insert({ 'datetime': ISODate('1975-07-23T04:10:00') })` and `db.test.insert({ 'datetime': ISODate('1975-07-23T04:10:00Z') })` are valid timestrings.