### PR TITLE
updateOne to replaceOne

### DIFF
--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -46,7 +46,7 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 	public async update(documents: IMongoDocument[]): Promise<IMongoDocument[]> {
 		const operations = documents.map((document) => {
 			return {
-				updateOne: {
+				replaceOne: {
 					filter: { _id: document._id },
 					update: _.omit(document, '_id'),
 					upsert: false

--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -75,7 +75,7 @@ export class MongoDocumentTreeItem extends AzureTreeItem<IMongoTreeRoot> {
             throw new Error(`The "_id" field is required to update a document.`);
         }
         const filter: object = { _id: newDocument._id };
-        const result: UpdateWriteOpResult = await collection.updateOne(filter, _.omit(newDocument, '_id'));
+        const result: UpdateWriteOpResult = await collection.replaceOne(filter, _.omit(newDocument, '_id'));
         if (result.modifiedCount !== 1) {
             throw new Error(`Failed to update document with _id '${newDocument._id}'.`);
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1298

After updating Mongodb in package.json, updateOne doesn't support overwriting anymore.  On a save, the action that we are actually performing is `replaceOne` where we update the document as we upload the entire document (rather than just updating the documents with new properties).