### PR TITLE
Iterate over parsedIds 🆔 as objects 📦 rather than array 

### DIFF
--- a/src/commands/importDocuments.ts
+++ b/src/commands/importDocuments.ts
@@ -139,8 +139,8 @@ function processMongoResults(result: string): string {
     let parsed = JSON.parse(result);
     if (parsed.result && parsed.result.ok) {
         output = `Import into mongo successful. Inserted ${parsed.insertedCount} document(s). See output for more details.`;
-        for (let inserted of parsed.insertedIds) {
-            ext.outputChannel.appendLine(`Inserted document: ${inserted}`);
+        for (let key of Object.keys(parsed.insertedIds)) {
+            ext.outputChannel.appendLine(`Inserted document: ${parsed.insertedIds[key]}`);
         }
     }
     return output;

--- a/src/commands/importDocuments.ts
+++ b/src/commands/importDocuments.ts
@@ -139,8 +139,8 @@ function processMongoResults(result: string): string {
     let parsed = JSON.parse(result);
     if (parsed.result && parsed.result.ok) {
         output = `Import into mongo successful. Inserted ${parsed.insertedCount} document(s). See output for more details.`;
-        for (let key of Object.keys(parsed.insertedIds)) {
-            ext.outputChannel.appendLine(`Inserted document: ${parsed.insertedIds[key]}`);
+        for (let inserted of Object.values(parsed.insertedIds)) {
+            ext.outputChannel.appendLine(`Inserted document: ${inserted}`);
         }
     }
     return output;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1307

Despite the [documentation](https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/)

```
The operation returns the following document:

{
   "acknowledged" : true,
   "insertedIds" : [
      ObjectId("562a94d381cb9f1cd6eb0e1a"),
      ObjectId("562a94d381cb9f1cd6eb0e1b"),
      ObjectId("562a94d381cb9f1cd6eb0e1c")
   ]
``` 

`insertMany` returns a `Promise<InsertWriteOpResult>` which according to [THIS documentation](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#~insertWriteOpResult) says `insertedIds` is an Object (which explains the error).  The type files in the library agree with this. 

Most likely this came from updating the mongoDrivers and should be included in the patch release.