### PR TITLE
Fix error "Language client is not ready yet"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "azure-cosmosdb" extension will be documented in this file.
 
+## 0.12.2 - 2020-03-10
+### Fixed
+- Language client is not ready yet [#1334](https://github.com/microsoft/vscode-cosmosdb/issues/1334)
+
 ## 0.12.1 - 2020-01-22
 ### Fixed
 - When updating a Mongo document, the operation would fail with the following error: `update operation document must contain atomic operators.` [#1298](https://github.com/microsoft/vscode-cosmosdb/issues/1298)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cosmosdb",
-	"version": "0.12.1",
+	"version": "0.12.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cosmosdb",
-	"version": "0.12.1",
+	"version": "0.12.2",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-azuretools",
 	"displayName": "Azure Cosmos DB",

--- a/src/mongo/languageClient.ts
+++ b/src/mongo/languageClient.ts
@@ -20,12 +20,12 @@ export class MongoDBLanguageClient {
 			ext.context.asAbsolutePath(path.join('out', 'src', 'mongo', 'languageServer.js')) :
 			ext.context.asAbsolutePath(path.join('dist', 'mongo-languageServer.bundle.js'));
 		// The debug options for the server
-		let debugOptions = { execArgv: ['--nolazy', '--debug=6005', '--inspect'] };
+		const debugOptions = { execArgv: ['--nolazy', '--inspect=6005'] };
 
 		// If the extension is launch in debug mode the debug server options are use
 		// Otherwise the run options are used
-		let serverOptions: ServerOptions = {
-			run: { module: serverModule, transport: TransportKind.ipc, options: debugOptions },
+		const serverOptions: ServerOptions = {
+			run: { module: serverModule, transport: TransportKind.ipc },
 			debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
 		};
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1334, with much help from @dbaeumer

> Couple of things:
> 
> - the --debug option is since a long time deprecated in Node and since VS Code moved to a new Electron version I guess it is not supported anymore.
> - never pass any debug options when in run mode. You basically always started the server in debug mode. If you would only do this when you actually run in debug the extension would still have worked when installed from the marketplace.