### PR TITLE
Add "Tables" tree item for Postgres

### DIFF
--- a/src/postgres/tree/PostgresSchemaTreeItem.ts
+++ b/src/postgres/tree/PostgresSchemaTreeItem.ts
@@ -13,6 +13,7 @@ export class PostgresSchemaTreeItem extends AzureParentTreeItem<ISubscriptionCon
     public static contextValue: string = "postgresSchema";
     public readonly contextValue: string = PostgresSchemaTreeItem.contextValue;
     public readonly schema: Schema;
+    public autoSelectInTreeItemPicker: boolean = true;
 
     private _tablesTreeItem: PostgresTablesTreeItem;
 

--- a/src/postgres/tree/PostgresSchemaTreeItem.ts
+++ b/src/postgres/tree/PostgresSchemaTreeItem.ts
@@ -3,22 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Schema, Table } from 'pg-structure';
-import * as _ from 'underscore';
+import { Schema } from 'pg-structure';
 import * as vscode from 'vscode';
 import { AzureParentTreeItem, ISubscriptionContext } from 'vscode-azureextensionui';
 import { getThemeAgnosticIconPath } from '../../constants';
-import { PostgresTableTreeItem } from './PostgresTableTreeItem';
+import { PostgresTablesTreeItem } from './PostgresTablesTreeItem';
 
 export class PostgresSchemaTreeItem extends AzureParentTreeItem<ISubscriptionContext> {
     public static contextValue: string = "postgresSchema";
     public readonly contextValue: string = PostgresSchemaTreeItem.contextValue;
-    public readonly childTypeLabel: string = "Table";
     public readonly schema: Schema;
+
+    private _tablesTreeItem: PostgresTablesTreeItem;
 
     constructor(parent: AzureParentTreeItem, schema: Schema) {
         super(parent);
         this.schema = schema;
+        this._tablesTreeItem = new PostgresTablesTreeItem(this);
     }
 
     public get id(): string {
@@ -37,8 +38,7 @@ export class PostgresSchemaTreeItem extends AzureParentTreeItem<ISubscriptionCon
         return false;
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<PostgresTableTreeItem[]> {
-        const tables: Table[] = this.schema.tables;
-        return tables.map(table => new PostgresTableTreeItem(this, table));
+    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<PostgresTablesTreeItem[]> {
+        return [this._tablesTreeItem];
     }
 }

--- a/src/postgres/tree/PostgresTableTreeItem.ts
+++ b/src/postgres/tree/PostgresTableTreeItem.ts
@@ -7,15 +7,15 @@ import { Table } from 'pg-structure';
 import * as vscode from 'vscode';
 import { AzureTreeItem, ISubscriptionContext } from 'vscode-azureextensionui';
 import { getThemeAgnosticIconPath } from '../../constants';
-import { PostgresSchemaTreeItem } from './PostgresSchemaTreeItem';
+import { PostgresTablesTreeItem } from './PostgresTablesTreeItem';
 
 export class PostgresTableTreeItem extends AzureTreeItem<ISubscriptionContext> {
     public static contextValue: string = "postgresTable";
     public readonly contextValue: string = PostgresTableTreeItem.contextValue;
     public readonly table: Table;
-    public readonly parent: PostgresSchemaTreeItem;
+    public readonly parent: PostgresTablesTreeItem;
 
-    constructor(parent: PostgresSchemaTreeItem, table: Table) {
+    constructor(parent: PostgresTablesTreeItem, table: Table) {
         super(parent);
         this.table = table;
     }

--- a/src/postgres/tree/PostgresTablesTreeItem.ts
+++ b/src/postgres/tree/PostgresTablesTreeItem.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Table } from "pg-structure";
+import { Uri } from 'vscode';
+import { AzureParentTreeItem, ISubscriptionContext } from "vscode-azureextensionui";
+import { getThemeAgnosticIconPath } from "../../constants";
+import { PostgresSchemaTreeItem } from "./PostgresSchemaTreeItem";
+import { PostgresTableTreeItem } from "./PostgresTableTreeItem";
+
+export class PostgresTablesTreeItem extends AzureParentTreeItem<ISubscriptionContext> {
+    public static contextValue: string = "postgresTables";
+    public readonly contextValue: string = PostgresTablesTreeItem.contextValue;
+    public readonly childTypeLabel: string = "Table";
+    public readonly label: string = 'Tables';
+    public readonly parent: PostgresSchemaTreeItem;
+
+    constructor(parent: PostgresSchemaTreeItem) {
+        super(parent);
+    }
+
+    public get iconPath(): string | Uri | { light: string | Uri; dark: string | Uri } {
+        return getThemeAgnosticIconPath('Collection.svg');
+    }
+
+    public hasMoreChildrenImpl(): boolean {
+        return false;
+    }
+
+    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<PostgresTableTreeItem[]> {
+        const tables: Table[] = this.parent.schema.tables;
+        return tables.map(table => new PostgresTableTreeItem(this, table));
+    }
+}


### PR DESCRIPTION
Adding this so we can support functions & stored procs too (related: https://github.com/microsoft/vscode-cosmosdb/issues/1407)

I had trouble finding good icons for the tables group and for individual tables so I left them generic for now.

Before ➡️After
<img width="161" alt="Screen Shot 2020-04-07 at 12 47 41 PM" src="https://user-images.githubusercontent.com/22795803/78712769-fe66cc00-78cd-11ea-8c6b-c5d1c3b51a32.png"><img width="161" alt="Screen Shot 2020-04-07 at 12 42 50 PM" src="https://user-images.githubusercontent.com/22795803/78712558-a039e900-78cd-11ea-9542-5b9e2e526061.png">