### PR TITLE
Add support for editing & updating Postgres functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "onCommand:cosmosDB.update",
         "onCommand:cosmosDB.openDocument",
         "onCommand:cosmosDB.openStoredProcedure",
+        "onCommand:cosmosDB.openPostgresFunction",
         "onCommand:cosmosDB.openCollection",
         "onCommand:cosmosDB.loadMore",
         "onCommand:cosmosDB.refresh",
@@ -351,6 +352,11 @@
                 "category": "Cosmos DB",
                 "command": "cosmosDB.openStoredProcedure",
                 "title": "Open Stored Procedure"
+            },
+            {
+                "category": "PostgreSQL",
+                "command": "cosmosDB.openPostgresFunction",
+                "title": "Open Function"
             },
             {
                 "category": "PostgreSQL",

--- a/src/CosmosEditorManager.ts
+++ b/src/CosmosEditorManager.ts
@@ -18,6 +18,8 @@ import { MongoCollectionNodeEditor } from './mongo/editors/MongoCollectionNodeEd
 import { MongoDocumentNodeEditor } from './mongo/editors/MongoDocumentNodeEditor';
 import { MongoCollectionTreeItem } from './mongo/tree/MongoCollectionTreeItem';
 import { MongoDocumentTreeItem } from './mongo/tree/MongoDocumentTreeItem';
+import { PostgresFunctionEditor } from './postgres/editors/PostgresFunctionEditor';
+import { PostgresFunctionTreeItem } from './postgres/tree/PostgresFunctionTreeItem';
 import { nonNullValue } from './utils/nonNull';
 import * as vscodeUtils from './utils/vscodeUtils';
 
@@ -159,6 +161,8 @@ export class CosmosEditorManager {
                     editor = new MongoDocumentNodeEditor(editorNode);
                 } else if (editorNode instanceof DocDBStoredProcedureTreeItem) {
                     editor = new DocDBStoredProcedureNodeEditor(editorNode);
+                } else if (editorNode instanceof PostgresFunctionTreeItem) {
+                    editor = new PostgresFunctionEditor(editorNode);
                 } else {
                     throw new Error("Unexpected type of Editor treeItem");
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
 
         registerDocDBCommands(editorManager);
         registerGraphCommands();
-        registerPostgresCommands();
+        registerPostgresCommands(editorManager);
         const codeLensProvider = registerMongoCommands(editorManager);
 
         const cosmosDBTopLevelContextValues: string[] = [GraphAccountTreeItem.contextValue, DocDBAccountTreeItem.contextValue, TableAccountTreeItem.contextValue, MongoAccountTreeItem.contextValue];

--- a/src/postgres/commands/openPostgresFunction.ts
+++ b/src/postgres/commands/openPostgresFunction.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "vscode-azureextensionui";
+import { CosmosEditorManager } from "../../CosmosEditorManager";
+import { ext } from "../../extensionVariables";
+import { PostgresFunctionEditor } from "../editors/PostgresFunctionEditor";
+import { PostgresFunctionTreeItem } from "../tree/PostgresFunctionTreeItem";
+
+export async function openPostgresFunction(editorManager: CosmosEditorManager, context: IActionContext, treeItem?: PostgresFunctionTreeItem): Promise<void> {
+    if (!treeItem) {
+        treeItem = <PostgresFunctionTreeItem>await ext.tree.showTreeItemPicker(PostgresFunctionTreeItem.contextValue, context);
+    }
+
+    const fileName: string = `${treeItem.label} (${treeItem.parent.parent.parent.server.name}.${treeItem.schema}).sql`;
+    await editorManager.showDocument(context, new PostgresFunctionEditor(treeItem), fileName);
+}

--- a/src/postgres/commands/registerPostgresCommands.ts
+++ b/src/postgres/commands/registerPostgresCommands.ts
@@ -3,16 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { registerCommand } from "vscode-azureextensionui";
+import { IActionContext, registerCommand } from "vscode-azureextensionui";
+import { doubleClickDebounceDelay } from "../../constants";
+import { CosmosEditorManager } from "../../CosmosEditorManager";
+import { PostgresFunctionTreeItem } from "../tree/PostgresFunctionTreeItem";
 import { configurePostgresFirewall } from "./configurePostgresFirewall";
 import { deletePostgresDatabase } from "./deletePostgresDatabase";
 import { deletePostgresServer } from "./deletePostgresServer";
 import { enterPostgresCredentials } from "./enterPostgresCredentials";
+import { openPostgresFunction } from "./openPostgresFunction";
 
-export function registerPostgresCommands(): void {
-
+export function registerPostgresCommands(editorManager: CosmosEditorManager): void {
     registerCommand('cosmosDB.deletePostgresServer', deletePostgresServer);
     registerCommand('cosmosDB.enterPostgresCredentials', enterPostgresCredentials);
     registerCommand('cosmosDB.configurePostgresFirewall', configurePostgresFirewall);
     registerCommand('cosmosDB.deletePostgresDatabase', deletePostgresDatabase);
+    registerCommand('cosmosDB.openPostgresFunction', async (context: IActionContext, treeItem?: PostgresFunctionTreeItem) => {
+        await openPostgresFunction(editorManager, context, treeItem);
+        // tslint:disable-next-line:align
+    }, doubleClickDebounceDelay);
 }

--- a/src/postgres/editors/PostgresFunctionEditor.ts
+++ b/src/postgres/editors/PostgresFunctionEditor.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ICosmosEditor } from "../../CosmosEditorManager";
+import { getNodeEditorLabel } from "../../utils/vscodeUtils";
+import { PostgresFunctionTreeItem } from "../tree/PostgresFunctionTreeItem";
+
+export class PostgresFunctionEditor implements ICosmosEditor<string> {
+    private _treeItem: PostgresFunctionTreeItem;
+
+    constructor(treeItem: PostgresFunctionTreeItem) {
+        this._treeItem = treeItem;
+    }
+
+    public get label(): string {
+        return getNodeEditorLabel(this._treeItem);
+    }
+
+    public async getData(): Promise<string> {
+        return this._treeItem.definition;
+    }
+
+    public async update(document: string): Promise<string> {
+        return await this._treeItem.update(document);
+    }
+
+    public get id(): string {
+        return this._treeItem.fullId;
+    }
+
+    public convertFromString(data: string): string {
+        return data;
+    }
+
+    public convertToString(data: string): string {
+        return data;
+    }
+}

--- a/src/postgres/editors/PostgresFunctionEditor.ts
+++ b/src/postgres/editors/PostgresFunctionEditor.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Client } from "pg";
 import { ICosmosEditor } from "../../CosmosEditorManager";
 import { getNodeEditorLabel } from "../../utils/vscodeUtils";
 import { PostgresFunctionTreeItem } from "../tree/PostgresFunctionTreeItem";
@@ -22,8 +23,12 @@ export class PostgresFunctionEditor implements ICosmosEditor<string> {
         return this._treeItem.definition;
     }
 
-    public async update(document: string): Promise<string> {
-        return await this._treeItem.update(document);
+    public async update(newDefinition: string): Promise<string> {
+        this._treeItem.definition = newDefinition;
+        const client = new Client(this._treeItem.parent.clientConfig);
+        await client.connect();
+        await client.query(this._treeItem.definition);
+        return this._treeItem.definition;
     }
 
     public get id(): string {

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -23,7 +23,7 @@ const firewallNotConfiguredErrorType: string = '28000';
 export class PostgresDatabaseTreeItem extends AzureParentTreeItem<ISubscriptionContext> {
     public static contextValue: string = "postgresDatabase";
     public readonly contextValue: string = PostgresDatabaseTreeItem.contextValue;
-    public readonly childTypeLabel: string = "Tables";
+    public readonly childTypeLabel: string = "Resource Type";
     public readonly databaseName: string;
     public readonly parent: PostgresServerTreeItem;
     public autoSelectInTreeItemPicker: boolean = true;

--- a/src/postgres/tree/PostgresFunctionTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionTreeItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Client } from "pg";
 import { AzureTreeItem, ISubscriptionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { getThemeAgnosticIconPath } from "../../constants";
 import { IPostgresFunctionsQueryRow, PostgresFunctionsTreeItem } from "./PostgresFunctionsTreeItem";
@@ -10,6 +11,8 @@ import { IPostgresFunctionsQueryRow, PostgresFunctionsTreeItem } from "./Postgre
 export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext> {
     public static contextValue: string = 'postgresFunction';
     public readonly contextValue: string = PostgresFunctionTreeItem.contextValue;
+    public readonly commandId: string = 'cosmosDB.openPostgresFunction';
+    public readonly parent: PostgresFunctionsTreeItem;
     public readonly schema: string;
     public readonly name: string;
     public readonly id: string;
@@ -35,5 +38,13 @@ export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext
 
     public get iconPath(): TreeItemIconPath {
         return getThemeAgnosticIconPath('Collection.svg');
+    }
+
+    public async update(newDefinition: string): Promise<string> {
+        this.definition = newDefinition;
+        const client = new Client(this.parent.clientConfig);
+        await client.connect();
+        await client.query(this.definition);
+        return this.definition;
     }
 }

--- a/src/postgres/tree/PostgresFunctionTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionTreeItem.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Client } from "pg";
 import { AzureTreeItem, ISubscriptionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { getThemeAgnosticIconPath } from "../../constants";
 import { IPostgresFunctionsQueryRow, PostgresFunctionsTreeItem } from "./PostgresFunctionsTreeItem";
@@ -38,13 +37,5 @@ export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext
 
     public get iconPath(): TreeItemIconPath {
         return getThemeAgnosticIconPath('Collection.svg');
-    }
-
-    public async update(newDefinition: string): Promise<string> {
-        this.definition = newDefinition;
-        const client = new Client(this.parent.clientConfig);
-        await client.connect();
-        await client.query(this.definition);
-        return this.definition;
     }
 }

--- a/src/postgres/tree/PostgresFunctionsTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionsTreeItem.ts
@@ -74,4 +74,8 @@ export class PostgresFunctionsTreeItem extends AzureParentTreeItem<ISubscription
             duplicateNames.has(row.name)
         ));
     }
+
+    public isAncestorOfImpl(contextValue: string): boolean {
+        return contextValue === PostgresFunctionTreeItem.contextValue;
+    }
 }

--- a/src/postgres/tree/PostgresServerTreeItem.ts
+++ b/src/postgres/tree/PostgresServerTreeItem.ts
@@ -14,6 +14,8 @@ import { azureUtils } from '../../utils/azureUtils';
 import { KeyTar, tryGetKeyTar } from '../../utils/keytar';
 import { nonNullProp } from '../../utils/nonNull';
 import { PostgresDatabaseTreeItem } from './PostgresDatabaseTreeItem';
+import { PostgresFunctionsTreeItem } from './PostgresFunctionsTreeItem';
+import { PostgresFunctionTreeItem } from './PostgresFunctionTreeItem';
 import { PostgresTablesTreeItem } from './PostgresTablesTreeItem';
 import { PostgresTableTreeItem } from './PostgresTableTreeItem';
 
@@ -82,6 +84,8 @@ export class PostgresServerTreeItem extends AzureParentTreeItem<ISubscriptionCon
             case PostgresDatabaseTreeItem.contextValue:
             case PostgresTablesTreeItem.contextValue:
             case PostgresTableTreeItem.contextValue:
+            case PostgresFunctionsTreeItem.contextValue:
+            case PostgresFunctionTreeItem.contextValue:
                 return true;
             default:
                 return false;

--- a/src/postgres/tree/PostgresTablesTreeItem.ts
+++ b/src/postgres/tree/PostgresTablesTreeItem.ts
@@ -33,4 +33,8 @@ export class PostgresTablesTreeItem extends AzureParentTreeItem<ISubscriptionCon
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<PostgresTableTreeItem[]> {
         return this.tables.map(table => new PostgresTableTreeItem(this, table));
     }
+
+    public isAncestorOfImpl(contextValue: string): boolean {
+        return contextValue === PostgresTableTreeItem.contextValue;
+    }
 }


### PR DESCRIPTION
<img width="715" alt="Screen Shot 2020-04-13 at 3 19 11 PM" src="https://user-images.githubusercontent.com/22795803/79166495-25277580-7d9a-11ea-8a59-4e67a0f6809b.png">

The filename includes function name, server name, and schema name to uniquely identify functions. Otherwise, you couldn't open two functions named "test" from two different servers/schemas at the same time.

Related to https://github.com/microsoft/vscode-cosmosdb/issues/1407