### PR TITLE
Add arguments to Postgres function label

### DIFF
--- a/src/postgres/IPostgresProceduresQueryRow.ts
+++ b/src/postgres/IPostgresProceduresQueryRow.ts
@@ -6,6 +6,7 @@
 export interface IPostgresProceduresQueryRow {
     schema: string;
     name: string;
+    args: string;
     oid: number;
     definition: string;
 }

--- a/src/postgres/tree/PostgresFunctionTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionTreeItem.ts
@@ -16,6 +16,7 @@ export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext
     public readonly parent: PostgresFunctionsTreeItem;
     public readonly schema: string;
     public readonly name: string;
+    public readonly args: string;
     public readonly id: string;
     public readonly isDuplicate: boolean;
     public definition: string;
@@ -24,13 +25,14 @@ export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext
         super(parent);
         this.schema = row.schema;
         this.name = row.name;
+        this.args = row.args;
         this.id = String(row.oid);
         this.definition = row.definition;
         this.isDuplicate = isDuplicate;
     }
 
     public get label(): string {
-        return this.name;
+        return `${this.name}(${this.args})`;
     }
 
     public get description(): string | undefined {

--- a/src/postgres/tree/PostgresFunctionsTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionsTreeItem.ts
@@ -38,6 +38,7 @@ export class PostgresFunctionsTreeItem extends AzureParentTreeItem<ISubscription
         // Adapted from https://aka.ms/AA83fg8
         const functionsQuery: string = `select n.nspname as schema,
             p.proname as name,
+            pg_get_function_arguments(p.oid) as args,
             p.oid as oid,
             case when l.lanname = 'internal' then p.prosrc
                 else pg_get_functiondef(p.oid)


### PR DESCRIPTION
It's possible to have multiple functions with the same name in a schema, each with different arguments. This accounts for that but it does look a little funky with the description in parenthesis too:

<img width="238" alt="Screen Shot 2020-04-21 at 2 12 53 PM" src="https://user-images.githubusercontent.com/22795803/79915372-b40c4180-83db-11ea-8247-d062bd61aa92.png">
