### PR TITLE
Fix connecting to databases from the explorer context menu

### DIFF
--- a/src/postgres/commands/connectPostgresDatabase.ts
+++ b/src/postgres/commands/connectPostgresDatabase.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, window, workspace } from 'vscode';
+import { Uri, window } from 'vscode';
 import { AzureTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
@@ -12,7 +12,7 @@ import { connectedPostgresKey } from "./registerPostgresCommands";
 export async function connectPostgresDatabase(context: IActionContext, treeItem?: Uri | PostgresDatabaseTreeItem): Promise<void> {
     if (!treeItem || treeItem instanceof Uri) {
         if (treeItem) {
-            window.showTextDocument(await workspace.openTextDocument(treeItem));
+            window.showTextDocument(treeItem);
         }
 
         treeItem = <PostgresDatabaseTreeItem>await ext.tree.showTreeItemPicker(PostgresDatabaseTreeItem.contextValue, context);

--- a/src/postgres/commands/connectPostgresDatabase.ts
+++ b/src/postgres/commands/connectPostgresDatabase.ts
@@ -3,13 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Uri, window, workspace } from 'vscode';
 import { AzureTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
 import { connectedPostgresKey } from "./registerPostgresCommands";
 
-export async function connectPostgresDatabase(context: IActionContext, treeItem?: PostgresDatabaseTreeItem): Promise<void> {
-    if (!treeItem) {
+export async function connectPostgresDatabase(context: IActionContext, treeItem?: Uri | PostgresDatabaseTreeItem): Promise<void> {
+    if (!treeItem || treeItem instanceof Uri) {
+        if (treeItem) {
+            window.showTextDocument(await workspace.openTextDocument(treeItem));
+        }
+
         treeItem = <PostgresDatabaseTreeItem>await ext.tree.showTreeItemPicker(PostgresDatabaseTreeItem.contextValue, context);
     }
 


### PR DESCRIPTION
This fixes the "treeItem.refresh is not a function" error.

Also it made sense to me to open the file you connect to db from