### PR TITLE
Display Postgres query output as CSV

### DIFF
--- a/src/postgres/commands/executePostgresQuery.ts
+++ b/src/postgres/commands/executePostgresQuery.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { EOL } from 'os';
 import * as path from 'path';
 import { Client, ClientConfig, QueryResult } from 'pg';
 import * as vscode from 'vscode';
@@ -52,8 +53,6 @@ export async function executePostgresQuery(context: IActionContext): Promise<voi
     await client.connect();
     const query: string | undefined = activeEditor.document.getText();
     const queryResult: QueryResult = await client.query(query);
-
-    ext.outputChannel.show();
     ext.outputChannel.appendLine(localize('executedQuery', 'Successfully executed "{0}" query.', queryResult.command));
 
     if (queryResult.rowCount) {
@@ -62,14 +61,14 @@ export async function executePostgresQuery(context: IActionContext): Promise<voi
         const outputFileName: string = `${queryFileName}-output`;
 
         const fields: string[] = queryResult.fields.map(f => f.name);
-        let csvData: string = `${fields.join(',')}\n`;
+        let csvData: string = `${fields.join(',')}${EOL}`;
 
         for (const row of queryResult.rows) {
             const fieldValues: string[] = [];
             for (const field of fields) {
                 fieldValues.push(row[field]);
             }
-            csvData += `${fieldValues.join(',')}\n`;
+            csvData += `${fieldValues.join(',')}${EOL}`;
         }
 
         await vscodeUtil.showNewFile(csvData, outputFileName, '.csv');


### PR DESCRIPTION
The CSV is opened as a new, unsaved file. Here's an example of executing a create query followed by a select query:

<img width="764" alt="Screen Shot 2020-05-14 at 4 36 08 PM" src="https://user-images.githubusercontent.com/22795803/81996089-06b6d300-9601-11ea-82b9-d56053c24dfe.png">
