### PR TITLE
Prevent codelens from appearing in all '.sql' files

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,3 +79,7 @@ export let emulatorPassword = 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDu
 
 // https://docs.mongodb.com/manual/mongo/#working-with-the-mongo-shell
 export const testDb: string = 'test';
+
+export const connectedPostgresKey: string = 'ms-azuretools.vscode-azuredatabases.connectedPostgresDB';
+export const sqlFileExtension: string = '.sql';
+export const postgresBaseFileName: string = 'pg-query';

--- a/src/postgres/commands/connectPostgresDatabase.ts
+++ b/src/postgres/commands/connectPostgresDatabase.ts
@@ -5,9 +5,9 @@
 
 import { Uri, window } from 'vscode';
 import { AzureTreeItem, IActionContext } from "vscode-azureextensionui";
+import { connectedPostgresKey } from '../../constants';
 import { ext } from "../../extensionVariables";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
-import { connectedPostgresKey } from "./registerPostgresCommands";
 
 export async function connectPostgresDatabase(context: IActionContext, treeItem?: Uri | PostgresDatabaseTreeItem): Promise<void> {
     if (!treeItem || treeItem instanceof Uri) {

--- a/src/postgres/commands/createPostgresFunctionQuery.ts
+++ b/src/postgres/commands/createPostgresFunctionQuery.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, IActionContext } from "vscode-azureextensionui";
+import { postgresBaseFileName, sqlFileExtension } from "../../constants";
 import { nonNullProp } from "../../utils/nonNull";
 import * as vscodeUtil from '../../utils/vscodeUtils';
 import { PostgresFunctionsTreeItem } from "../tree/PostgresFunctionsTreeItem";
@@ -12,7 +13,6 @@ import { FunctionQueryCreateStep } from "./FunctionQueryWizard/FunctionQueryCrea
 import { FunctionQueryNameStep } from "./FunctionQueryWizard/FunctionQueryNameStep";
 import { FunctionQueryReturnTypeStep } from "./FunctionQueryWizard/FunctionQueryReturnTypeStep";
 import { IPostgresFunctionQueryWizardContext } from "./FunctionQueryWizard/IPostgresFunctionQueryWizardContext";
-import { postgresBaseFileName, postgresFileExtension } from "./registerPostgresCommands";
 
 export async function createPostgresFunctionQuery(context: IActionContext, treeItem?: PostgresFunctionsTreeItem): Promise<void> {
     const wizardContext: IPostgresFunctionQueryWizardContext = context;
@@ -24,7 +24,7 @@ export async function createPostgresFunctionQuery(context: IActionContext, treeI
 
     await wizard.prompt();
     await wizard.execute();
-    await vscodeUtil.showNewFile(nonNullProp(wizardContext, 'query'), postgresBaseFileName, postgresFileExtension);
+    await vscodeUtil.showNewFile(nonNullProp(wizardContext, 'query'), postgresBaseFileName, sqlFileExtension);
 
     if (treeItem) {
         await connectPostgresDatabase(wizardContext, treeItem.parent);

--- a/src/postgres/commands/createPostgresFunctionQuery.ts
+++ b/src/postgres/commands/createPostgresFunctionQuery.ts
@@ -12,6 +12,7 @@ import { FunctionQueryCreateStep } from "./FunctionQueryWizard/FunctionQueryCrea
 import { FunctionQueryNameStep } from "./FunctionQueryWizard/FunctionQueryNameStep";
 import { FunctionQueryReturnTypeStep } from "./FunctionQueryWizard/FunctionQueryReturnTypeStep";
 import { IPostgresFunctionQueryWizardContext } from "./FunctionQueryWizard/IPostgresFunctionQueryWizardContext";
+import { postgresBaseFileName, postgresFileExtension } from "./registerPostgresCommands";
 
 export async function createPostgresFunctionQuery(context: IActionContext, treeItem?: PostgresFunctionsTreeItem): Promise<void> {
     const wizardContext: IPostgresFunctionQueryWizardContext = context;
@@ -23,7 +24,7 @@ export async function createPostgresFunctionQuery(context: IActionContext, treeI
 
     await wizard.prompt();
     await wizard.execute();
-    await vscodeUtil.showNewFile(nonNullProp(wizardContext, 'query'), 'query', '.sql');
+    await vscodeUtil.showNewFile(nonNullProp(wizardContext, 'query'), postgresBaseFileName, postgresFileExtension);
 
     if (treeItem) {
         await connectPostgresDatabase(wizardContext, treeItem.parent);

--- a/src/postgres/commands/openPostgresFunction.ts
+++ b/src/postgres/commands/openPostgresFunction.ts
@@ -7,12 +7,13 @@ import { IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import * as vscodeUtil from '../../utils/vscodeUtils';
 import { PostgresFunctionTreeItem } from "../tree/PostgresFunctionTreeItem";
+import { postgresBaseFileName, postgresFileExtension } from "./registerPostgresCommands";
 
 export async function openPostgresFunction(context: IActionContext, treeItem?: PostgresFunctionTreeItem): Promise<void> {
     if (!treeItem) {
         treeItem = <PostgresFunctionTreeItem>await ext.tree.showTreeItemPicker(PostgresFunctionTreeItem.contextValue, context);
     }
 
-    const fileName: string = `${treeItem.label} (${treeItem.parent.parent.parent.server.name}.${treeItem.schema})`;
-    await vscodeUtil.showNewFile(treeItem.definition, fileName, '.sql');
+    const fileName: string = `${treeItem.label}-${postgresBaseFileName}`;
+    await vscodeUtil.showNewFile(treeItem.definition, fileName, postgresFileExtension);
 }

--- a/src/postgres/commands/openPostgresFunction.ts
+++ b/src/postgres/commands/openPostgresFunction.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "vscode-azureextensionui";
+import { postgresBaseFileName, sqlFileExtension } from "../../constants";
 import { ext } from "../../extensionVariables";
 import * as vscodeUtil from '../../utils/vscodeUtils';
 import { PostgresFunctionTreeItem } from "../tree/PostgresFunctionTreeItem";
-import { postgresBaseFileName, postgresFileExtension } from "./registerPostgresCommands";
 
 export async function openPostgresFunction(context: IActionContext, treeItem?: PostgresFunctionTreeItem): Promise<void> {
     if (!treeItem) {
@@ -15,5 +15,5 @@ export async function openPostgresFunction(context: IActionContext, treeItem?: P
     }
 
     const fileName: string = `${treeItem.label}-${postgresBaseFileName}`;
-    await vscodeUtil.showNewFile(treeItem.definition, fileName, postgresFileExtension);
+    await vscodeUtil.showNewFile(treeItem.definition, fileName, sqlFileExtension);
 }

--- a/src/postgres/commands/registerPostgresCommands.ts
+++ b/src/postgres/commands/registerPostgresCommands.ts
@@ -5,7 +5,7 @@
 
 import { languages } from "vscode";
 import { callWithTelemetryAndErrorHandling, IActionContext, registerCommand } from "vscode-azureextensionui";
-import { doubleClickDebounceDelay } from "../../constants";
+import { connectedPostgresKey, doubleClickDebounceDelay, postgresBaseFileName, sqlFileExtension } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { PostgresCodeLensProvider } from "../services/PostgresCodeLensProvider";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
@@ -22,13 +22,9 @@ import { enterPostgresCredentials } from "./enterPostgresCredentials";
 import { executePostgresQuery } from "./executePostgresQuery";
 import { openPostgresFunction } from "./openPostgresFunction";
 
-export const connectedPostgresKey: string = 'ms-azuretools.vscode-azuredatabases.connectedPostgresDB';
-export const postgresFileExtension: string = '.sql';
-export const postgresBaseFileName: string = 'pg-query';
-
 export function registerPostgresCommands(): void {
     ext.postgresCodeLensProvider = new PostgresCodeLensProvider();
-    ext.context.subscriptions.push(languages.registerCodeLensProvider({ pattern: `{**/,}*${postgresBaseFileName}*${postgresFileExtension}` }, ext.postgresCodeLensProvider));
+    ext.context.subscriptions.push(languages.registerCodeLensProvider({ pattern: `{**/,}*${postgresBaseFileName}*${sqlFileExtension}` }, ext.postgresCodeLensProvider));
 
     // tslint:disable-next-line: no-floating-promises
     loadPersistedPostgresDatabase();

--- a/src/postgres/commands/registerPostgresCommands.ts
+++ b/src/postgres/commands/registerPostgresCommands.ts
@@ -23,11 +23,12 @@ import { executePostgresQuery } from "./executePostgresQuery";
 import { openPostgresFunction } from "./openPostgresFunction";
 
 export const connectedPostgresKey: string = 'ms-azuretools.vscode-azuredatabases.connectedPostgresDB';
-const postgresLanguageId: string = 'sql';
+export const postgresFileExtension: string = '.sql';
+export const postgresBaseFileName: string = 'pg-query';
 
 export function registerPostgresCommands(): void {
     ext.postgresCodeLensProvider = new PostgresCodeLensProvider();
-    ext.context.subscriptions.push(languages.registerCodeLensProvider(postgresLanguageId, ext.postgresCodeLensProvider));
+    ext.context.subscriptions.push(languages.registerCodeLensProvider({ pattern: `{**/,}*${postgresBaseFileName}*${postgresFileExtension}` }, ext.postgresCodeLensProvider));
 
     // tslint:disable-next-line: no-floating-promises
     loadPersistedPostgresDatabase();


### PR DESCRIPTION
This changes the default query file name to "pg-query" and applies the codelens only to files with names that contain "pg-query" and end with ".sql" 
("pg-query" seemed like a more Postgres specific option than just "query")

I also changed the file name format for function queries opened via the tree view. It looked too busy to show the server name, schema, and "pg-query"

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1455