### PR TITLE
Don't reveal tree items after creating

### DIFF
--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -22,23 +22,19 @@ export function registerDocDBCommands(): void {
             node = <DocDBAccountTreeItem>await ext.tree.showTreeItemPicker(DocDBAccountTreeItem.contextValue, context);
         }
         const databaseNode: DocDBDatabaseTreeItem = <DocDBDatabaseTreeItem>await node.createChild(context);
-        await ext.treeView.reveal(databaseNode, { focus: false });
-        const collectionNode: DocDBCollectionTreeItem = <DocDBCollectionTreeItem>await databaseNode.createChild(context);
-        await ext.treeView.reveal(collectionNode);
+        await databaseNode.createChild(context);
     });
     registerCommand('cosmosDB.createDocDBCollection', async (context: IActionContext, node?: DocDBDatabaseTreeItem) => {
         if (!node) {
             node = <DocDBDatabaseTreeItem>await ext.tree.showTreeItemPicker(DocDBDatabaseTreeItem.contextValue, context);
         }
-        const collectionNode: DocDBCollectionTreeItem = <DocDBCollectionTreeItem>await node.createChild(context);
-        await ext.treeView.reveal(collectionNode);
+        await node.createChild(context);
     });
     registerCommand('cosmosDB.createDocDBDocument', async (context: IActionContext, node?: DocDBDocumentsTreeItem) => {
         if (!node) {
             node = <DocDBDocumentsTreeItem>await ext.tree.showTreeItemPicker(DocDBDocumentsTreeItem.contextValue, context);
         }
         const documentNode = <DocDBDocumentTreeItem>await node.createChild(context);
-        await ext.treeView.reveal(documentNode);
         await commands.executeCommand("cosmosDB.openDocument", documentNode);
 
     });

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -41,10 +41,7 @@ export function registerMongoCommands(): MongoCodeLensProvider {
             node = <MongoAccountTreeItem>await ext.tree.showTreeItemPicker([MongoAccountTreeItem.contextValue, MongoAccountTreeItem.contextValue + AttachedAccountSuffix], context);
         }
         const databaseNode = <MongoDatabaseTreeItem>await node.createChild(context);
-        // reveal the database treeItem in case user cancels collection creation
-        await ext.treeView.reveal(databaseNode, { focus: false });
-        const collectionNode = <MongoCollectionTreeItem>await databaseNode.createChild(context);
-        await ext.treeView.reveal(collectionNode, { focus: true });
+        await databaseNode.createChild(context);
 
         await vscode.commands.executeCommand('cosmosDB.connectMongoDB', databaseNode);
     });
@@ -53,7 +50,6 @@ export function registerMongoCommands(): MongoCodeLensProvider {
             node = <MongoDatabaseTreeItem>await ext.tree.showTreeItemPicker(MongoDatabaseTreeItem.contextValue, context);
         }
         const collectionNode = await node.createChild(context);
-        await ext.treeView.reveal(collectionNode);
         await vscode.commands.executeCommand('cosmosDB.connectMongoDB', collectionNode.parent);
     });
     registerCommand('cosmosDB.createMongoDocument', async (context: IActionContext, node?: MongoCollectionTreeItem) => {
@@ -61,7 +57,6 @@ export function registerMongoCommands(): MongoCodeLensProvider {
             node = <MongoCollectionTreeItem>await ext.tree.showTreeItemPicker(MongoCollectionTreeItem.contextValue, context);
         }
         const documentNode = await node.createChild(context);
-        await ext.treeView.reveal(documentNode);
         await vscode.commands.executeCommand("cosmosDB.openDocument", documentNode);
     });
     registerCommand('cosmosDB.connectMongoDB', async (context: IActionContext, node?: MongoDatabaseTreeItem) => {


### PR DESCRIPTION
Calling `treeView.reveal` on a newly created tree item would always lead to the error reported in https://github.com/microsoft/vscode-cosmosdb/issues/1368. Loading more on the parent tree item before revealing would solve the problem but that seemed cumbersome. And since revealing tree items didn't seem to be a prevalent design pattern in other extensions I opted to remove it here.

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1368