### PR TITLE
Use empty string for emptyPartitionKeyValue

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,8 +73,6 @@ export const defaultStoredProcedure =
     if (!isAccepted) throw new Error('The query was not accepted by the server.');
 };` ;
 
-export const emptyPartitionKeyValue: string = '';
-
 export let emulatorPassword = 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==';
 
 // https://docs.mongodb.com/manual/mongo/#working-with-the-mongo-shell

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,7 +73,7 @@ export const defaultStoredProcedure =
     if (!isAccepted) throw new Error('The query was not accepted by the server.');
 };` ;
 
-export const emptyPartitionKeyValue = {};
+export const emptyPartitionKeyValue: string = '';
 
 export let emulatorPassword = 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==';
 

--- a/src/docdb/tree/DocDBDocumentTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentTreeItem.ts
@@ -6,7 +6,7 @@
 import { DocumentClient, RetrievedDocument } from 'documentdb';
 import * as vscode from 'vscode';
 import { AzureTreeItem, DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
-import { emptyPartitionKeyValue, getThemeAgnosticIconPath } from '../../constants';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { getDocumentTreeItemLabel } from '../../utils/vscodeUtils';
 import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
@@ -116,7 +116,7 @@ export class DocDBDocumentTreeItem extends AzureTreeItem<IDocDBTreeRoot> {
         for (const field of fields) {
             value = value ? value[field] : this.document[field];
             if (!value) { //Partition Key exists, but this document doesn't have a value
-                return emptyPartitionKeyValue;
+                return '';
             }
         }
         return value;


### PR DESCRIPTION
Using an empty object as the partition key when one wasn't provided seemed to be causing the issue.

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1434