### PR TITLE
Change linux key binding for azure view

### DIFF
--- a/package.json
+++ b/package.json
@@ -865,7 +865,8 @@
             {
                 "command": "workbench.view.extension.azure",
                 "key": "ctrl+shift+a",
-                "mac": "cmd+shift+a"
+                "mac": "cmd+shift+a",
+                "linux": "shift+alt+a"
             }
         ],
         "configuration": {


### PR DESCRIPTION
"shift+alt" was used in a few other places on Linux, so seemed like a decent pattern.

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1328