### PR TITLE
Add query param retrywrite=false

### DIFF
--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -109,7 +109,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             // for any Mongo connectionString, append this query param because the Cosmos Mongo API v3.6 doesn't support retrywrites
             // but the newer node.js drivers started breaking this
             const searchParam: string = 'retrywrites';
-            if (!connectionString.searchParams.get(searchParam)) {
+            if (!connectionString.searchParams.has(searchParam)) {
                 connectionString.searchParams.set(searchParam, 'false');
             }
 

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -108,7 +108,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             const connectionString: URL = new URL(nonNullProp(nonNullProp(result, 'connectionStrings')[0], 'connectionString'));
             // for any Mongo connectionString, append this query param because the Cosmos Mongo API v3.6 doesn't support retrywrites
             // but the newer node.js drivers started breaking this
-            const searchParam: string = 'retywrites';
+            const searchParam: string = 'retrywrites';
             if (!connectionString.searchParams.get(searchParam)) {
                 connectionString.searchParams.set(searchParam, 'false');
             }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -105,7 +105,10 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
         if (experience && experience.api === "MongoDB") {
             const result = await client.databaseAccounts.listConnectionStrings(resourceGroup, name);
-            const connectionString = nonNullProp(nonNullProp(result, 'connectionStrings')[0], 'connectionString');
+            let connectionString = nonNullProp(nonNullProp(result, 'connectionStrings')[0], 'connectionString');
+            // for any Mongo connectionString, append this query param because the Mongo API doesn't support retrywrites
+            // but the newer Mongo enables it by default
+            connectionString += '&retrywrites=false';
             // Use the default connection string
             return new MongoAccountTreeItem(this, id, label, connectionString, isEmulator, databaseAccount);
         } else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1343

Technically this issue only reproduces with Azure Cosmos MongoDB v3.6, which our extension does not create by default (it creates v3.2, we should probably look into that 😂)

But I didn't notice any adverse effects appending the query param to older MongoDB accounts, so I assume that this is easier solution because I didn't see any obvious indicators if the account is 3.2 or 3.6.  (CosmosAccountType: Non-Production for 3.6, but that property didn't exist on the 3.2 accounts)