### PR TITLE
Add arguments when deleting Postgres functions

### DIFF
--- a/src/postgres/IPostgresProceduresQueryRow.ts
+++ b/src/postgres/IPostgresProceduresQueryRow.ts
@@ -7,5 +7,6 @@ export interface IPostgresProceduresQueryRow {
     schema: string;
     name: string;
     oid: number;
+    args: string;
     definition: string;
 }

--- a/src/postgres/tree/PostgresFunctionTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionTreeItem.ts
@@ -17,6 +17,7 @@ export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext
     public readonly schema: string;
     public readonly name: string;
     public readonly id: string;
+    public readonly args: string;
     public readonly isDuplicate: boolean;
     public definition: string;
 
@@ -25,6 +26,7 @@ export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext
         this.schema = row.schema;
         this.name = row.name;
         this.id = String(row.oid);
+        this.args = row.args;
         this.definition = row.definition;
         this.isDuplicate = isDuplicate;
     }
@@ -45,7 +47,7 @@ export class PostgresFunctionTreeItem extends AzureTreeItem<ISubscriptionContext
         const client = new Client(this.parent.clientConfig);
         try {
             await client.connect();
-            await client.query(`DROP FUNCTION ${this.schema}.${this.name};`);
+            await client.query(`DROP FUNCTION ${this.schema}.${this.name}(${this.args});`);
         } finally {
             await client.end();
         }

--- a/src/postgres/tree/PostgresFunctionsTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionsTreeItem.ts
@@ -39,6 +39,7 @@ export class PostgresFunctionsTreeItem extends AzureParentTreeItem<ISubscription
         const functionsQuery: string = `select n.nspname as schema,
             p.proname as name,
             p.oid as oid,
+            pg_get_function_arguments(p.oid) as args,
             case when l.lanname = 'internal' then p.prosrc
                 else pg_get_functiondef(p.oid)
                 end as definition


### PR DESCRIPTION
An error was happening because the syntax we were using to delete functions didn't always work. Parenthesis need to be included after the function name. And if the function has arguments, those need to be included as well

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1494