### PR TITLE
Update tests for 'azureDatabases.createServer' (not including Postgres)

### DIFF
--- a/test/nightly/azureResourceGraph.test.ts
+++ b/test/nightly/azureResourceGraph.test.ts
@@ -31,9 +31,9 @@ suite('Graph action', async function (this: Mocha.Suite): Promise<void> {
     });
 
     test('Create graph account', async () => {
-        const testInputs: (string | RegExp)[] = [accountName, /graph/, '$(plus) Create new resource group', resourceGroupName, 'West US'];
+        const testInputs: (string | RegExp)[] = [/graph/, accountName, '$(plus) Create new resource group', resourceGroupName, 'West US'];
         await testUserInput.runWithInputs(testInputs, async () => {
-            await vscode.commands.executeCommand('cosmosDB.createAccount');
+            await vscode.commands.executeCommand('azureDatabases.createServer');
         });
         const getAccount: CosmosDBManagementModels.DatabaseAccount | undefined = await client.databaseAccounts.get(resourceGroupName, accountName);
         assert.ok(getAccount);

--- a/test/nightly/azureResourceMongoDB.test.ts
+++ b/test/nightly/azureResourceMongoDB.test.ts
@@ -35,9 +35,9 @@ suite('MongoDB action', async function (this: Mocha.Suite): Promise<void> {
     });
 
     test('Create MongoDB account', async () => {
-        const testInputs: (string | RegExp)[] = [accountName, /MongoDB/, '$(plus) Create new resource group', resourceGroupName, 'West US'];
+        const testInputs: (string | RegExp)[] = [/MongoDB/, accountName, '$(plus) Create new resource group', resourceGroupName, 'West US'];
         await testUserInput.runWithInputs(testInputs, async () => {
-            await vscode.commands.executeCommand('cosmosDB.createAccount');
+            await vscode.commands.executeCommand('azureDatabases.createServer');
         });
         const createAccount: CosmosDBManagementModels.DatabaseAccount | undefined = await client.databaseAccounts.get(resourceGroupName, accountName);
         assert.ok(createAccount);

--- a/test/nightly/azureResourceSQL.test.ts
+++ b/test/nightly/azureResourceSQL.test.ts
@@ -33,9 +33,9 @@ suite('SQL action', async function (this: Mocha.Suite): Promise<void> {
     });
 
     test('Create SQL account', async () => {
-        const testInputs: (string | RegExp)[] = [accountName, /SQL/, '$(plus) Create new resource group', resourceGroupName, 'West US'];
+        const testInputs: (string | RegExp)[] = [/SQL/, accountName, '$(plus) Create new resource group', resourceGroupName, 'West US'];
         await testUserInput.runWithInputs(testInputs, async () => {
-            await vscode.commands.executeCommand('cosmosDB.createAccount');
+            await vscode.commands.executeCommand('azureDatabases.createServer');
         });
         const getAccount: CosmosDBManagementModels.DatabaseAccount | undefined = await client.databaseAccounts.get(resourceGroupName, accountName);
         assert.ok(getAccount);


### PR DESCRIPTION
Forgot to update the nightly tests when we merged 'cosmosDB.createAccount' into 'azureDatabases.createServer'