### PR TITLE
Display mongo command results in a single file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8907,9 +8907,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.33.7",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.33.7.tgz",
-            "integrity": "sha512-KO3aB/N+Mg8aAg++zZuZEUfaLTmqL6jW6wzaSacsWDOu0TqTiyRZEsgLjwLXUr1UlFVKjpeKbMXJlor7qFXCOQ==",
+            "version": "0.33.9",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.33.9.tgz",
+            "integrity": "sha512-AKNMxwdJOTdXA+vh0VARV4OYO+hfK89oPJYaQwca2t9IMWbS12+b99FMEWOp0aqF2GoV/jpz0QT0wBV1nHsp2Q==",
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1042,7 +1042,7 @@
         "public-ip": "^4.0.0",
         "semver": "^7.2.2",
         "underscore": "^1.8.3",
-        "vscode-azureextensionui": "^0.33.8",
+        "vscode-azureextensionui": "^0.33.9",
         "vscode-json-languageservice": "^3.0.8",
         "vscode-languageclient": "^4.4.0",
         "vscode-languageserver": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1037,7 +1037,7 @@
         "public-ip": "^4.0.0",
         "semver": "^7.2.2",
         "underscore": "^1.8.3",
-        "vscode-azureextensionui": "^0.33.7",
+        "vscode-azureextensionui": "^0.33.8",
         "vscode-json-languageservice": "^3.0.8",
         "vscode-languageclient": "^4.4.0",
         "vscode-languageserver": "^4.4.0",

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -29,7 +29,7 @@ import { IMongoDocument, MongoDocumentTreeItem } from './tree/MongoDocumentTreeI
 const EJSON = require("mongodb-extended-json");
 
 const notInScrapbookMessage = "You must have a MongoDB scrapbook (*.mongo) open to run a MongoDB command.";
-const resultMap: Map<string, ReadOnlyContent> = new Map<string, ReadOnlyContent>();
+let defaultReadOnlyContent: ReadOnlyContent | undefined;
 
 export function getAllErrorsFromTextDocument(document: vscode.TextDocument): vscode.Diagnostic[] {
     const commands = getAllCommandsFromTextDocument(document);
@@ -137,9 +137,7 @@ async function executeCommand(context: IActionContext, command: MongoCommand, re
                 await ext.fileSystem.showTextDocument(docNode, { viewColumn: vscode.ViewColumn.Beside });
             } else {
                 const showOptions: vscode.TextDocumentShowOptions = { viewColumn: vscode.ViewColumn.Beside };
-                const label: string = 'Scrapbook-results';
-                const fullId: string = `${database.fullId}/${label}`;
-                readOnlyContent = readOnlyContent || resultMap.get(fullId);
+                readOnlyContent = readOnlyContent || defaultReadOnlyContent;
                 result += `${EOL}${EOL}`;
 
                 if (readOnlyContent) {
@@ -150,8 +148,9 @@ async function executeCommand(context: IActionContext, command: MongoCommand, re
                         await readOnlyContent.show(showOptions);
                     }
                 } else {
-                    readOnlyContent = await openReadOnlyContent({ label, fullId }, result, '.txt', showOptions);
-                    resultMap.set(fullId, readOnlyContent);
+                    const label: string = 'Scrapbook-results';
+                    const fullId: string = `${database.fullId}/${label}`;
+                    defaultReadOnlyContent = await openReadOnlyContent({ label, fullId }, result, '.txt', showOptions);
                 }
 
                 await refreshTreeAfterCommand(database, command, context);

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -140,7 +140,7 @@ async function executeCommand(context: IActionContext, command: MongoCommand, re
                 } else {
                     const label: string = 'Scrapbook-results';
                     const fullId: string = `${database.fullId}/${label}`;
-                    await openReadOnlyContent({ label, fullId }, result, '.txt', { viewColumn: vscode.ViewColumn.Beside });
+                    await openReadOnlyContent({ label, fullId }, result, '.json', { viewColumn: vscode.ViewColumn.Beside });
                 }
 
                 await refreshTreeAfterCommand(database, command, context);

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -132,7 +132,7 @@ async function executeCommand(context: IActionContext, command: MongoCommand): P
                 await ext.fileSystem.showTextDocument(docNode);
             } else {
                 const viewColumn = vscode.window.activeTextEditor?.viewColumn;
-                await vscodeUtil.showNewFile(result, 'result', '.json', viewColumn ? viewColumn + 1 : undefined);
+                await vscodeUtil.createOrAppendToFile(result, 'Scrapbook-results', '.txt', viewColumn ? viewColumn + 1 : undefined);
                 await refreshTreeAfterCommand(database, command, context);
             }
         }

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -10,13 +10,13 @@ import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { TerminalNode } from 'antlr4ts/tree/TerminalNode';
 import { ObjectID } from 'bson';
 import { Collection } from 'mongodb';
+import { EOL } from 'os';
 import * as vscode from 'vscode';
-import { IActionContext, IParsedError, parseError } from 'vscode-azureextensionui';
+import { IActionContext, IParsedError, openReadOnlyContent, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { filterType, findType } from '../utils/array';
 import { localize } from '../utils/localize';
 import { nonNullProp, nonNullValue } from '../utils/nonNull';
-import * as vscodeUtil from './../utils/vscodeUtils';
 import { LexerErrorListener, ParserErrorListener } from './errorListeners';
 import { mongoLexer } from './grammar/mongoLexer';
 import * as mongoParser from './grammar/mongoParser';
@@ -131,8 +131,7 @@ async function executeCommand(context: IActionContext, command: MongoCommand): P
                 const docNode = new MongoDocumentTreeItem(colNode, document);
                 await ext.fileSystem.showTextDocument(docNode, { viewColumn: vscode.ViewColumn.Beside });
             } else {
-                const viewColumn = vscode.window.activeTextEditor?.viewColumn;
-                await vscodeUtil.createOrAppendToFile(result, 'Scrapbook-results', '.txt', viewColumn ? viewColumn + 1 : undefined);
+                await openReadOnlyContent({ label: 'Scrapbook-results', fullId: database.fullId }, result, '.txt', `${EOL}${EOL}`, true);
                 await refreshTreeAfterCommand(database, command, context);
             }
         }

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -5,6 +5,7 @@
 
 import { RetrievedDocument } from 'documentdb';
 import * as fse from 'fs-extra';
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzExtTreeItem } from 'vscode-azureextensionui';
@@ -34,18 +35,36 @@ export async function showNewFile(data: string, fileName: string, fileExtension:
     const fullFileName: string | undefined = await getUniqueFileName(folderPath, fileName, fileExtension);
     uri = vscode.Uri.file(path.join(folderPath, fullFileName)).with({ scheme: 'untitled' });
     const textDocument = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(textDocument, column ? column > vscode.ViewColumn.Three ? vscode.ViewColumn.One : column : undefined, true);
+    const editor = await showTextDocument(textDocument, column);
     await writeToEditor(editor, data);
 }
 
-export async function writeToEditor(editor: vscode.TextEditor, data: string): Promise<void> {
-    await editor.edit((editBuilder: vscode.TextEditorEdit) => {
-        if (editor.document.lineCount > 0) {
-            const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
-            editBuilder.delete(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(lastLine.range.start.line, lastLine.range.end.character)));
-        }
+export async function createOrAppendToFile(data: string, fileName: string, fileExtension: string, column?: vscode.ViewColumn): Promise<void> {
+    const folderPath: string = getRootPath() || ext.context.extensionPath;
+    const fullFileName: string = `${path.join(folderPath, fileName)}${fileExtension}`;
+    await fse.ensureFile(fullFileName);
+    const textDocument: vscode.TextDocument = await vscode.workspace.openTextDocument(fullFileName);
+    const editor: vscode.TextEditor = await showTextDocument(textDocument, column);
+    await writeToEditor(editor, data, false);
+}
 
-        editBuilder.insert(new vscode.Position(0, 0), data);
+async function showTextDocument(textDocument: vscode.TextDocument, column?: vscode.ViewColumn): Promise<vscode.TextEditor> {
+    return await vscode.window.showTextDocument(textDocument, column ? column > vscode.ViewColumn.Three ? vscode.ViewColumn.One : column : undefined, true);
+}
+
+export async function writeToEditor(editor: vscode.TextEditor, data: string, overwrite: boolean = true): Promise<void> {
+    await editor.edit((editBuilder: vscode.TextEditorEdit) => {
+        const lineCount: number = editor.document.lineCount;
+        if (overwrite) {
+            if (lineCount > 0) {
+                const lastLine = editor.document.lineAt(lineCount - 1);
+                editBuilder.delete(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(lastLine.range.start.line, lastLine.range.end.character)));
+            }
+
+            editBuilder.insert(new vscode.Position(0, 0), data);
+        } else {
+            editBuilder.insert(new vscode.Position(lineCount, 0), `${data}${os.EOL}${os.EOL}`);
+        }
     });
 }
 


### PR DESCRIPTION
Instead of creating a "result-x.json" file every time you execute a command, this creates one "Scrapbook-results.txt" file and appends each result to that. The results of `find` and `findOne` will still display in their own files.

I opted to use ".txt" instead of ".json" because the appended results won't always be valid json. 

After running "Execute All":
<img width="538" alt="Screen Shot 2020-06-23 at 6 03 28 PM" src="https://user-images.githubusercontent.com/22795803/85486572-b88ddb80-b57f-11ea-83c1-087678c909de.png">

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/607
Depends on https://github.com/microsoft/vscode-azuretools/pull/758
