### PR TITLE
Update Postgres icons 🐘👀

### DIFF
--- a/resources/icons/dark/list-unordered.svg
+++ b/resources/icons/dark/list-unordered.svg
@@ -1,3 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M2 3H1V4H2V3ZM2 6H1V7H2V6ZM1 9H2V10H1V9ZM2 12H1V13H2V12ZM4 3H15V4H4V3ZM15 6H4V7H15V6ZM4 9H15V10H4V9ZM15 12H4V13H15V12Z" fill="#C5C5C5"/>
-</svg>

--- a/resources/icons/light/list-unordered.svg
+++ b/resources/icons/light/list-unordered.svg
@@ -1,3 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M2 3H1V4H2V3ZM2 6H1V7H2V6ZM1 9H2V10H1V9ZM2 12H1V13H2V12ZM4 3H15V4H4V3ZM15 6H4V7H15V6ZM4 9H15V10H4V9ZM15 12H4V13H15V12Z" fill="#424242"/>
-</svg>

--- a/src/postgres/tree/PostgresFunctionsTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionsTreeItem.ts
@@ -23,7 +23,7 @@ export class PostgresFunctionsTreeItem extends PostgresResourcesTreeItemBase {
     }
 
     public get iconPath(): TreeItemIconPath {
-        return getThemedIconPath('list-unordered.svg');
+        return getThemedIconPath('function.svg');
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/postgres/tree/PostgresStoredProceduresTreeItem.ts
+++ b/src/postgres/tree/PostgresStoredProceduresTreeItem.ts
@@ -23,7 +23,7 @@ export class PostgresStoredProceduresTreeItem extends PostgresResourcesTreeItemB
     }
 
     public get iconPath(): TreeItemIconPath {
-        return getThemedIconPath('list-unordered.svg');
+        return getThemedIconPath('Process_16x.svg');
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/postgres/tree/PostgresTablesTreeItem.ts
+++ b/src/postgres/tree/PostgresTablesTreeItem.ts
@@ -23,7 +23,7 @@ export class PostgresTablesTreeItem extends PostgresResourcesTreeItemBase {
     }
 
     public get iconPath(): string | Uri | { light: string | Uri; dark: string | Uri } {
-        return getThemedIconPath('list-unordered.svg');
+        return getThemedIconPath('window.svg');
     }
 
     public hasMoreChildrenImpl(): boolean {


### PR DESCRIPTION
I thought I would hate this but I kinda don't...

| old | new |
| - | - |
| <img width="155" alt="Screen Shot 2020-06-24 at 11 21 36 AM" src="https://user-images.githubusercontent.com/22795803/85611918-3946e900-b60d-11ea-86d9-db23f82ebf03.png"> | <img width="155" alt="Screen Shot 2020-06-24 at 11 20 26 AM" src="https://user-images.githubusercontent.com/22795803/85611942-3fd56080-b60d-11ea-9723-26b1a5e011c6.png"> |

The UI peeps suggested to reuse the elephant icon for the database node but I like the plain one better.

They also suggested to use this icon for columns <img width="46" alt="Screen Shot 2020-06-24 at 11 32 35 AM" src="https://user-images.githubusercontent.com/22795803/85613127-6942bc00-b60e-11ea-84af-bb0520a8c41c.png"> but I like what we already have.


Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1431

