### PR TITLE
Add a setting to configure the Mongo shell batch size

### DIFF
--- a/package.json
+++ b/package.json
@@ -960,9 +960,9 @@
                     "default": true,
                     "description": "Show warning dialog when uploading a document to the cloud."
                 },
-                "cosmosDB.batchSize": {
+                "azureDatabases.batchSize": {
                     "type": "number",
-                    "description": "The batch size to be used when querying Cosmos DB resources.",
+                    "description": "The batch size to be used when querying Azure Database resources.",
                     "default": 50
                 },
                 "azureDatabases.enableOutputTimestamps": {

--- a/package.json
+++ b/package.json
@@ -935,6 +935,11 @@
                     "description": "The duration allowed (in seconds) for the Mongo shell to execute a command. Default value is 30 seconds.",
                     "default": 30
                 },
+                "mongo.shell.batchSize": {
+                    "type": "number",
+                    "description": "The maximum number of documents to be returned from a query executed in the Mongo shell.",
+                    "default": 20
+                },
                 "azureDatabases.showExplorer": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -935,11 +935,6 @@
                     "description": "The duration allowed (in seconds) for the Mongo shell to execute a command. Default value is 30 seconds.",
                     "default": 30
                 },
-                "mongo.shell.batchSize": {
-                    "type": "number",
-                    "description": "The maximum number of documents to be returned from a query executed in the Mongo shell.",
-                    "default": 20
-                },
                 "azureDatabases.showExplorer": {
                     "type": "boolean",
                     "default": true,
@@ -964,6 +959,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show warning dialog when uploading a document to the cloud."
+                },
+                "cosmosDB.batchSize": {
+                    "type": "number",
+                    "description": "The batch size to be used when querying Cosmos DB resources.",
+                    "default": 50
                 },
                 "azureDatabases.enableOutputTimestamps": {
                     "type": "boolean",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,8 +41,6 @@ export function getResourcesPath(): string {
     return ext.context.asAbsolutePath('resources');
 }
 
-export const defaultBatchSize: number = 50;
-
 export const doubleClickDebounceDelay = 500; //milliseconds
 
 export const defaultStoredProcedure =

--- a/src/docdb/tree/DocDBTreeItemBase.ts
+++ b/src/docdb/tree/DocDBTreeItemBase.ts
@@ -5,7 +5,7 @@
 
 import { DocumentClient, FeedOptions, QueryError, QueryIterator } from 'documentdb';
 import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
-import { defaultBatchSize } from '../../constants';
+import { getBatchSizeSetting } from '../../utils/workspacUtils';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
 
 /**
@@ -19,7 +19,7 @@ export abstract class DocDBTreeItemBase<T> extends AzureParentTreeItem<IDocDBTre
 
     private _hasMoreChildren: boolean = true;
     private _iterator: QueryIterator<T> | undefined;
-    private _batchSize: number = defaultBatchSize;
+    private _batchSize: number = getBatchSizeSetting();
 
     public hasMoreChildrenImpl(): boolean {
         return this._hasMoreChildren;
@@ -33,8 +33,8 @@ export abstract class DocDBTreeItemBase<T> extends AzureParentTreeItem<IDocDBTre
         if (clearCache || this._iterator === undefined) {
             this._hasMoreChildren = true;
             const client = this.root.getDocumentClient();
-            this._iterator = await this.getIterator(client, { maxItemCount: defaultBatchSize });
-            this._batchSize = defaultBatchSize;
+            this._batchSize = getBatchSizeSetting();
+            this._iterator = await this.getIterator(client, { maxItemCount: this._batchSize });
         }
 
         const resources: T[] = [];

--- a/src/docdb/tree/DocDBTreeItemBase.ts
+++ b/src/docdb/tree/DocDBTreeItemBase.ts
@@ -29,11 +29,14 @@ export abstract class DocDBTreeItemBase<T> extends AzureParentTreeItem<IDocDBTre
 
     public abstract getIterator(client: DocumentClient, feedOptions: FeedOptions): Promise<QueryIterator<T>>;
 
+    public async refreshImpl(): Promise<void> {
+        this._batchSize = getBatchSizeSetting();
+    }
+
     public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
         if (clearCache || this._iterator === undefined) {
             this._hasMoreChildren = true;
             const client = this.root.getDocumentClient();
-            this._batchSize = getBatchSizeSetting();
             this._iterator = await this.getIterator(client, { maxItemCount: this._batchSize });
         }
 

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -37,7 +37,7 @@ export namespace ext {
         export const mongoShellArgs = 'mongo.shell.args';
         export const documentLabelFields = 'cosmosDB.documentLabelFields';
         export const mongoShellTimeout = 'mongo.shell.timeout';
-        export const batchSize = 'cosmosDB.batchSize';
+        export const batchSize = 'azureDatabases.batchSize';
 
         export namespace vsCode {
             export const proxyStrictSSL = "http.proxyStrictSSL";

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -37,6 +37,7 @@ export namespace ext {
         export const mongoShellArgs = 'mongo.shell.args';
         export const documentLabelFields = 'cosmosDB.documentLabelFields';
         export const mongoShellTimeout = 'mongo.shell.timeout';
+        export const mongoShellBatchSize = 'mongo.shell.batchSize';
 
         export namespace vsCode {
             export const proxyStrictSSL = "http.proxyStrictSSL";

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -37,7 +37,7 @@ export namespace ext {
         export const mongoShellArgs = 'mongo.shell.args';
         export const documentLabelFields = 'cosmosDB.documentLabelFields';
         export const mongoShellTimeout = 'mongo.shell.timeout';
-        export const mongoShellBatchSize = 'mongo.shell.batchSize';
+        export const batchSize = 'cosmosDB.batchSize';
 
         export namespace vsCode {
             export const proxyStrictSSL = "http.proxyStrictSSL";

--- a/src/mongo/MongoShell.ts
+++ b/src/mongo/MongoShell.ts
@@ -6,10 +6,9 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { parseError } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
 import { InteractiveChildProcess } from '../utils/InteractiveChildProcess';
-import { nonNullValue } from '../utils/nonNull';
 import { randomUtils } from '../utils/randomUtils';
+import { getBatchSizeSetting } from '../utils/workspacUtils';
 import { wrapError } from '../utils/wrapError';
 
 const timeoutMessage = "Timed out trying to execute the Mongo script. To use a longer timeout, modify the VS Code 'mongo.shell.timeout' setting.";
@@ -55,10 +54,8 @@ export class MongoShell extends vscode.Disposable {
             // to catch any errors related to the start-up of the process before trying to write to it.
             await shell.executeScript("");
 
-            // Set the configured shell batch size
-            const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-            const mongoShellBatchSize: number = nonNullValue(config.get<number>(ext.settingsKeys.mongoShellBatchSize), 'mongoShellBatchSize');
-            await shell.executeScript(`DBQuery.shellBatchSize = ${mongoShellBatchSize}`);
+            // Configure the batch size
+            await shell.executeScript(`DBQuery.shellBatchSize = ${getBatchSizeSetting()}`);
 
             return shell;
         } catch (error) {

--- a/src/mongo/MongoShell.ts
+++ b/src/mongo/MongoShell.ts
@@ -6,7 +6,9 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { parseError } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { InteractiveChildProcess } from '../utils/InteractiveChildProcess';
+import { nonNullValue } from '../utils/nonNull';
 import { randomUtils } from '../utils/randomUtils';
 import { wrapError } from '../utils/wrapError';
 
@@ -52,6 +54,11 @@ export class MongoShell extends vscode.Disposable {
             // Try writing an empty script to verify the process is running correctly and allow us
             // to catch any errors related to the start-up of the process before trying to write to it.
             await shell.executeScript("");
+
+            // Set the configured shell batch size
+            const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+            const mongoShellBatchSize: number = nonNullValue(config.get<number>(ext.settingsKeys.mongoShellBatchSize), 'mongoShellBatchSize');
+            await shell.executeScript(`DBQuery.shellBatchSize = ${mongoShellBatchSize}`);
 
             return shell;
         } catch (error) {

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -8,11 +8,12 @@ import { BulkWriteOpResultObject, Collection, CollectionInsertManyOptions, Curso
 import * as _ from 'underscore';
 import * as vscode from 'vscode';
 import { AzExtTreeItem, AzureParentTreeItem, DialogResponses, IActionContext, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
-import { defaultBatchSize, getThemeAgnosticIconPath } from '../../constants';
+import { getThemeAgnosticIconPath } from '../../constants';
 import { IEditableTreeItem } from '../../DatabasesFileSystem';
 import { ext } from '../../extensionVariables';
 import { nonNullValue } from '../../utils/nonNull';
 import { getDocumentTreeItemLabel } from '../../utils/vscodeUtils';
+import { getBatchSizeSetting } from '../../utils/workspacUtils';
 import { MongoCommand } from '../MongoCommand';
 import { IMongoTreeRoot } from './IMongoTreeRoot';
 import { IMongoDocument, MongoDocumentTreeItem } from './MongoDocumentTreeItem';
@@ -40,7 +41,7 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
     private readonly _projection: object | undefined;
     private _cursor: Cursor | undefined;
     private _hasMoreChildren: boolean = true;
-    private _batchSize: number = defaultBatchSize;
+    private _batchSize: number = getBatchSizeSetting();
 
     constructor(parent: AzureParentTreeItem, collection: Collection, findArgs?: {}[]) {
         super(parent);
@@ -126,11 +127,11 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 
     public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
         if (clearCache || this._cursor === undefined) {
-            this._cursor = this.collection.find(this._query).batchSize(defaultBatchSize);
+            this._batchSize = getBatchSizeSetting();
+            this._cursor = this.collection.find(this._query).batchSize(this._batchSize);
             if (this._projection) {
                 this._cursor = this._cursor.project(this._projection);
             }
-            this._batchSize = defaultBatchSize;
         }
 
         const documents: IMongoDocument[] = [];

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -107,6 +107,7 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
     }
 
     public async refreshImpl(): Promise<void> {
+        this._batchSize = getBatchSizeSetting();
         ext.fileSystem.fireChangedEvent(this);
     }
 
@@ -127,7 +128,6 @@ export class MongoCollectionTreeItem extends AzureParentTreeItem<IMongoTreeRoot>
 
     public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
         if (clearCache || this._cursor === undefined) {
-            this._batchSize = getBatchSizeSetting();
             this._cursor = this.collection.find(this._query).batchSize(this._batchSize);
             if (this._projection) {
                 this._cursor = this._cursor.project(this._projection);

--- a/src/utils/workspacUtils.ts
+++ b/src/utils/workspacUtils.ts
@@ -4,9 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { ext } from '../extensionVariables';
+import { nonNullValue } from './nonNull';
 
 // tslint:disable-next-line: export-name
 export function getRootPath(): string | undefined {
     // if this is a multi-root workspace, return undefined
     return vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length === 1 ? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined;
+}
+
+export function getBatchSizeSetting(): number {
+    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+    return nonNullValue(config.get<number>(ext.settingsKeys.batchSize), 'batchSize');
 }


### PR DESCRIPTION
I got the default batch size of 20 from the mongo default (https://docs.mongodb.com/manual/tutorial/configure-mongo-shell/index.html#change-the-mongo-shell-batch-size)

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1073