### PR TITLE
Encode mongo connection strings as needed

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -26,7 +26,7 @@ export { activateInternal, deactivateInternal } from './src/extension';
 export { ext } from './src/extensionVariables';
 export { connectToMongoClient } from './src/mongo/connectToMongoClient';
 export { MongoCommand } from './src/mongo/MongoCommand';
-export { addDatabaseToAccountConnectionString, getDatabaseNameFromConnectionString } from './src/mongo/mongoConnectionStrings';
+export { addDatabaseToAccountConnectionString, encodeMongoConnectionString, getDatabaseNameFromConnectionString } from './src/mongo/mongoConnectionStrings';
 export { findCommandAtPosition, getAllCommandsFromText } from './src/mongo/MongoScrapbook';
 export { MongoShell } from './src/mongo/MongoShell';
 export { IDatabaseInfo } from './src/mongo/tree/MongoAccountTreeItem';

--- a/src/mongo/mongoConnectionStrings.ts
+++ b/src/mongo/mongoConnectionStrings.ts
@@ -49,24 +49,20 @@ export async function parseMongoConnectionString(connectionString: string): Prom
     let host: string;
     let port: string;
 
+    let mongoClient: MongoClient;
     try {
-        // Attempt to connect to determine if the username/password need to be encoded
-        await connectToMongoClient(connectionString, appendExtensionUserAgent());
+        mongoClient = await connectToMongoClient(connectionString, appendExtensionUserAgent());
     } catch (error) {
         const parsedError: IParsedError = parseError(error);
         if (parsedError.message.match(/unescaped/i)) {
-            const matches: RegExpMatchArray | null = connectionString.match(/^(.*):\/\/(.*):(.*)@(.*)/);
-            if (matches) {
-                const prefix: string = matches[1];
-                const username: string = matches[2];
-                const password: string = matches[3];
-                const hostAndQuery: string = matches[4];
-                connectionString = `${prefix}://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${hostAndQuery}`;
-            }
+            // Prevents https://github.com/microsoft/vscode-cosmosdb/issues/1209
+            connectionString = encodeMongoConnectionString(connectionString);
+            mongoClient = await connectToMongoClient(connectionString, appendExtensionUserAgent());
+        } else {
+            throw error;
         }
     }
 
-    const mongoClient: MongoClient = await connectToMongoClient(connectionString, appendExtensionUserAgent());
     const serverConfig: Server | ReplSet | Mongos = mongoClient.db(testDb).serverConfig;
     // Azure CosmosDB comes back as a ReplSet
     if (serverConfig instanceof ReplSet) {
@@ -97,4 +93,20 @@ export class ParsedMongoConnectionString extends ParsedConnectionString {
         this.hostName = hostName;
         this.port = port;
     }
+}
+
+/**
+ * Encodes the username and password in the given Mongo DB connection string.
+ */
+export function encodeMongoConnectionString(connectionString: string): string {
+    const matches: RegExpMatchArray | null = connectionString.match(/^(.*):\/\/(.*):(.*)@(.*)/);
+    if (matches) {
+        const prefix: string = matches[1];
+        const username: string = matches[2];
+        const password: string = matches[3];
+        const hostAndQuery: string = matches[4];
+        connectionString = `${prefix}://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${hostAndQuery}`;
+    }
+
+    return connectionString;
 }

--- a/test/mongoConnectionStrings.test.ts
+++ b/test/mongoConnectionStrings.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { addDatabaseToAccountConnectionString, emulatorPassword, getDatabaseNameFromConnectionString } from '../extension.bundle';
+import { addDatabaseToAccountConnectionString, emulatorPassword, encodeMongoConnectionString, getDatabaseNameFromConnectionString } from '../extension.bundle';
 
 function testDatabaseToAccountConnectionString(connectionString: string, databaseName: string, expectedConnectionString: string | undefined): void {
     const databaseConnectionString = addDatabaseToAccountConnectionString(connectionString, databaseName);
@@ -14,6 +14,11 @@ function testDatabaseToAccountConnectionString(connectionString: string, databas
 function testDatabaseNameFromConectionString(connectionString: string, expectedDatabaseName: string | undefined): void {
     const databaseName = getDatabaseNameFromConnectionString(connectionString);
     assert.equal(databaseName, expectedDatabaseName);
+}
+
+function testEncodeMongoConnectionString(connectionString: string, expectedConnectionString: string): void {
+    connectionString = encodeMongoConnectionString(connectionString);
+    assert.equal(connectionString, expectedConnectionString);
 }
 
 suite(`mongoCollectionStrings`, () => {
@@ -106,5 +111,16 @@ suite(`mongoCollectionStrings`, () => {
         testDatabaseToAccountConnectionString(`mongodb://localhost:${encodeURIComponent(emulatorPassword)}@localhost:10255/?ssl=true`, 'admin/level1/level2', `mongodb://localhost:${encodeURIComponent(emulatorPassword)}@localhost:10255/admin/level1/level2?ssl=true`);
         testDatabaseToAccountConnectionString(`mongodb://localhost:${encodeURIComponent(emulatorPassword)}@localhost:10255/?ssl=true`, 'admin-master', `mongodb://localhost:${encodeURIComponent(emulatorPassword)}@localhost:10255/admin-master?ssl=true`);
         testDatabaseToAccountConnectionString(`mongodb://localhost:${encodeURIComponent(emulatorPassword)}@localhost:10255/?ssl=true`, 'admin!@#%^*()-_,[]', `mongodb://localhost:${encodeURIComponent(emulatorPassword)}@localhost:10255/admin!@#%^*()-_,[]?ssl=true`);
+    });
+
+    test('encodeMongoConnectionString', () => {
+        testEncodeMongoConnectionString(`mongodb://my-mongo:ayO83FFfUoHE97Jm7WbfnpNCqiF0Yq0za2YmvuLAKYJKf7h7hQaRKWfZfsv8Ux41H66Gls7lVPEKlKm0ueSozg==@your-mongo.documents.azure.com:10255/?ssl=true&replicaSet=globaldb`, `mongodb://my-mongo:ayO83FFfUoHE97Jm7WbfnpNCqiF0Yq0za2YmvuLAKYJKf7h7hQaRKWfZfsv8Ux41H66Gls7lVPEKlKm0ueSozg%3D%3D@your-mongo.documents.azure.com:10255/?ssl=true&replicaSet=globaldb`);
+        testEncodeMongoConnectionString(`mongodb://dbuser:dbpassword@dbname.mlab.com:14118`, `mongodb://dbuser:dbpassword@dbname.mlab.com:14118`);
+        testEncodeMongoConnectionString(`mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test`, `mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test`);
+        testEncodeMongoConnectionString(`mongodb+srv://server.example.com/?connectTimeoutMS=300000&authSource=aDifferentAuthDB?`, `mongodb+srv://server.example.com/?connectTimeoutMS=300000&authSource=aDifferentAuthDB?`);
+        testEncodeMongoConnectionString(`mongodb://localhost`, `mongodb://localhost`);
+        testEncodeMongoConnectionString(`mongodb://localhost:${encodeURIComponent(emulatorPassword)}@localhost:10255/?ssl=true`, `mongodb://localhost:${encodeURIComponent(encodeURIComponent(emulatorPassword))}@localhost:10255/?ssl=true`);
+        testEncodeMongoConnectionString(`mongodb://username@example.com:password@localhost/`, `mongodb://username%40example.com:password@localhost/`);
+        testEncodeMongoConnectionString(`mongodb://crazy@:/%username:even@crazier%/password@localhost/`, `mongodb://crazy%40%3A%2F%25username:even%40crazier%25%2Fpassword@localhost/`);
     });
 });


### PR DESCRIPTION
I didn't want to always encode connection strings just in case they're already encoded. So this only encodes if an encoding-related error is thrown first.

Fixes https://github.com/microsoft/vscode-cosmosdb/issues/1209