### PR TITLE
Fix Postgres client connection with connection string

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -30,6 +30,7 @@ export { addDatabaseToAccountConnectionString, encodeMongoConnectionString, getD
 export { findCommandAtPosition, getAllCommandsFromText } from './src/mongo/MongoScrapbook';
 export { MongoShell } from './src/mongo/MongoShell';
 export { IDatabaseInfo } from './src/mongo/tree/MongoAccountTreeItem';
+export { addDatabaseToConnectionString } from './src/postgres/postgresConnectionStrings';
 export { AttachedAccountsTreeItem, MONGO_CONNECTION_EXPECTED } from './src/tree/AttachedAccountsTreeItem';
 export { AzureAccountTreeItemWithAttached } from './src/tree/AzureAccountTreeItemWithAttached';
 export { improveError } from './src/utils/improveError';

--- a/src/postgres/commands/copyConnectionString.ts
+++ b/src/postgres/commands/copyConnectionString.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
-import { createPostgresConnectionString } from '../postgresConnectionStrings';
+import { addDatabaseToConnectionString, createPostgresConnectionString } from '../postgresConnectionStrings';
 import { PostgresDatabaseTreeItem } from '../tree/PostgresDatabaseTreeItem';
 import { checkAuthentication } from './checkAuthentication';
 
@@ -23,7 +23,7 @@ export async function copyConnectionString(context: IActionContext, node: Postgr
         const parsedCS = await node.parent.getFullConnectionString();
         connectionString = createPostgresConnectionString(parsedCS.hostName, parsedCS.port, parsedCS.username, parsedCS.password, node.databaseName);
     } else {
-        connectionString = parsedConnectionString.connectionString;
+        connectionString = addDatabaseToConnectionString(parsedConnectionString.connectionString, node.databaseName);
     }
 
     await vscode.env.clipboard.writeText(connectionString);

--- a/src/postgres/getClientConfig.ts
+++ b/src/postgres/getClientConfig.ts
@@ -8,6 +8,7 @@ import { ConnectionOptions } from "tls";
 import { postgresDefaultPort } from "../constants";
 import { localize } from "../utils/localize";
 import { nonNullProp } from "../utils/nonNull";
+import { addDatabaseToConnectionString } from "./postgresConnectionStrings";
 import { invalidCredentialsErrorType } from "./tree/PostgresDatabaseTreeItem";
 import { PostgresServerTreeItem } from "./tree/PostgresServerTreeItem";
 
@@ -36,7 +37,7 @@ export async function getClientConfig(treeItem: PostgresServerTreeItem, database
     } else {
         let connectionString = parsedCS.connectionString;
         if (!parsedCS.databaseName) {
-            connectionString += databaseName;
+            connectionString = addDatabaseToConnectionString(connectionString, databaseName);
         }
         clientConfig = { connectionString: connectionString };
     }

--- a/src/postgres/postgresConnectionStrings.ts
+++ b/src/postgres/postgresConnectionStrings.ts
@@ -13,6 +13,12 @@ export function parsePostgresConnectionString(connectionString: string): ParsedP
     return new ParsedPostgresConnectionString(connectionString, config);
 }
 
+export function addDatabaseToConnectionString(connectionString: string, databaseName: string): string {
+    const url = new URL(connectionString);
+    url.pathname = encodeURIComponent(databaseName);
+    return url.toString();
+}
+
 export function createPostgresConnectionString(hostName: string, port: string = postgresDefaultPort, username?: string | undefined, password?: string | undefined, databaseName?: string | undefined): string {
     let connectionString: string = `postgres://`;
     if (username) {

--- a/test/postgresConnectionStrings.test.ts
+++ b/test/postgresConnectionStrings.test.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { addDatabaseToConnectionString } from '../src/postgres/postgresConnectionStrings';
+
+function testAddDatabaseToConectionString(connectionString: string, databaseName: string, expectedConnectionString: string | undefined): void {
+    const modifiedConnectionString = addDatabaseToConnectionString(connectionString, databaseName);
+    assert.equal(modifiedConnectionString, expectedConnectionString);
+}
+
+suite(`postgresCollectionStrings`, () => {
+    test(`addDatabaseToConnectionString`, () => {
+        // Connection strings follow the following format (https://www.postgresql.org/docs/12/libpq-connect.html):
+        // postgres://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+        testAddDatabaseToConectionString(`postgres://user:password@test:5432/`, 'testdb', 'postgres://user:password@test:5432/testdb');
+        testAddDatabaseToConectionString(`postgres://user:password@test:5432/testdb`, 'testdb2', `postgres://user:password@test:5432/testdb2`);
+
+        testAddDatabaseToConectionString(`postgres://user:password@test:5432`, 'testdb', 'postgres://user:password@test:5432/testdb');
+        testAddDatabaseToConectionString(`postgres://user:password@test:5432/?ssl=true&sslmode=require`, 'testdb', `postgres://user:password@test:5432/testdb?ssl=true&sslmode=require`);
+
+        testAddDatabaseToConectionString(`postgres://user:password@test:5432/testdb?ssl=true&sslmode=require`, 'testdb2', `postgres://user:password@test:5432/testdb2?ssl=true&sslmode=require`);
+
+        testAddDatabaseToConectionString(`postgres://user:password@test:5432/`, `test%20`, `postgres://user:password@test:5432/test%2520`);
+
+    });
+});

--- a/test/postgresConnectionStrings.test.ts
+++ b/test/postgresConnectionStrings.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { addDatabaseToConnectionString } from '../src/postgres/postgresConnectionStrings';
+import { addDatabaseToConnectionString } from '../extension.bundle';
 
 function testAddDatabaseToConectionString(connectionString: string, databaseName: string, expectedConnectionString: string | undefined): void {
     const modifiedConnectionString = addDatabaseToConnectionString(connectionString, databaseName);
     assert.equal(modifiedConnectionString, expectedConnectionString);
 }
 
-suite(`postgresCollectionStrings`, () => {
+suite(`postgresConnectionStrings`, () => {
     test(`addDatabaseToConnectionString`, () => {
         // Connection strings follow the following format (https://www.postgresql.org/docs/12/libpq-connect.html):
         // postgres://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]


### PR DESCRIPTION
Fixes #1696 
To fix missing databaseName value for Client connections with connectionString. 