### PR TITLE
Fix for importing documents without partition key 

### DIFF
--- a/src/docdb/tree/DocDBDocumentsTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentsTreeItem.ts
@@ -85,7 +85,7 @@ export class DocDBDocumentsTreeItem extends DocDBTreeItemBase<ItemDefinition> {
         }
         const keyPath = partitionKey.split('/');
         let i: number;
-        for (i = 0; i < keyPath.length - 1; i++) {
+        for (i = 0; i <= keyPath.length - 1; i++) {
             if (interim.hasOwnProperty(keyPath[i])) {
                 interim = interim[keyPath[i]];
             } else {

--- a/src/docdb/tree/DocDBDocumentsTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentsTreeItem.ts
@@ -83,11 +83,11 @@ export class DocDBDocumentsTreeItem extends DocDBTreeItemBase<ItemDefinition> {
         if (partitionKey[0] === '/') {
             partitionKey = partitionKey.slice(1);
         }
-        const keyPath = partitionKey.split('/');
-        let i: number;
-        for (i = 0; i <= keyPath.length - 1; i++) {
-            if (interim.hasOwnProperty(keyPath[i])) {
-                interim = interim[keyPath[i]];
+        const partitionKeyPath = partitionKey.split('/');
+
+        for (const prop of partitionKeyPath) {
+            if (interim.hasOwnProperty(prop)) {
+                interim = interim[prop];
             } else {
                 return false;
             }


### PR DESCRIPTION
The existing release already accounts for importing documents without partition key. An error is thrown with specific partition key information when a document doesn't contain the required partition key. 

The only issue is with scenarios where the partition key paths array has only 1 element, such as "/a". 