### PR TITLE
feat: add CosmosDB serverless

### DIFF
--- a/src/docdb/tree/DocDBAccountTreeItemBase.ts
+++ b/src/docdb/tree/DocDBAccountTreeItemBase.ts
@@ -7,6 +7,7 @@ import { DatabaseAccountGetResults } from '@azure/arm-cosmosdb/src/models';
 import { CosmosClient, DatabaseDefinition, DatabaseResponse, FeedOptions, QueryIterator, Resource } from '@azure/cosmos';
 import * as vscode from 'vscode';
 import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
+import { SERVERLESS_CAPABILITY_NAME } from '../../AzureDBExperiences';
 import { deleteCosmosDBAccount } from '../../commands/deleteCosmosDBAccount';
 import { getThemeAgnosticIconPath } from '../../constants';
 import { ext } from '../../extensionVariables';
@@ -50,6 +51,10 @@ export abstract class DocDBAccountTreeItemBase extends DocDBTreeItemBase<Databas
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {
         return getThemeAgnosticIconPath('CosmosDBAccount.svg');
+    }
+
+    public get isServerless(): boolean {
+        return !!this.databaseAccount?.capabilities?.find(cap => cap.name === SERVERLESS_CAPABILITY_NAME);
     }
 
     public getIterator(client: CosmosClient, feedOptions: FeedOptions): QueryIterator<DatabaseDefinition & Resource> {

--- a/src/tree/AzureDBAPIStep.ts
+++ b/src/tree/AzureDBAPIStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, VerifyProvidersStep } from 'vscode-azureextensionui';
-import { API, Experience, getExperienceQuickPicks } from '../AzureDBExperiences';
+import { API, CapacityModelName, Experience, getExperienceQuickPicks } from '../AzureDBExperiences';
 import { ext } from '../extensionVariables';
 import { IPostgresServerWizardContext } from '../postgres/commands/createPostgresServer/IPostgresServerWizardContext';
 import { PostgresServerConfirmPWStep } from '../postgres/commands/createPostgresServer/steps/PostgresServerConfirmPWStep';
@@ -28,6 +28,18 @@ export class AzureDBAPIStep extends AzureWizardPromptStep<IPostgresServerWizardC
         const result: IAzureQuickPickItem<Experience> = await ext.ui.showQuickPick(picks, {
             placeHolder: localize('selectDBServerMsg', 'Select an Azure Database Server.')
         });
+
+        if (result.data?.api !== API.Postgres) {
+            const modelPicks: IAzureQuickPickItem<CapacityModelName>[] = [
+                {label: "Provisioned Throughput", data: "Provisioned"},
+                {label: "Serverless", data: "Serverless"}
+            ];
+            const modelResult: IAzureQuickPickItem<CapacityModelName> = await ext.ui.showQuickPick(modelPicks, {
+                placeHolder: localize('selectDBServerMsg', 'Select a capacity model.')
+            });
+
+            result.data.capacityModel = modelResult.data;
+        }
 
         wizardContext.defaultExperience = result.data;
     }

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountCreateStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountCreateStep.ts
@@ -7,6 +7,7 @@ import { CosmosDBManagementClient } from '@azure/arm-cosmosdb';
 import { DatabaseAccountCreateUpdateParameters, DatabaseAccountsCreateOrUpdateResponse } from '@azure/arm-cosmosdb/src/models';
 import { Progress } from 'vscode';
 import { AzureWizardExecuteStep, createAzureClient } from 'vscode-azureextensionui';
+import { SERVERLESS_CAPABILITY_NAME } from '../../AzureDBExperiences';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
@@ -30,6 +31,7 @@ export class CosmosDBAccountCreateStep extends AzureWizardExecuteStep<ICosmosDBW
             location: locationName,
             locations: [{ locationName: locationName }],
             kind: defaultExperience.kind,
+            capabilities: [],
             // Note: Setting this tag has no functional effect in the portal, but we'll keep doing it to imitate portal behavior
             tags: { defaultExperience: nonNullProp(defaultExperience, 'tag') },
         };
@@ -39,7 +41,11 @@ export class CosmosDBAccountCreateStep extends AzureWizardExecuteStep<ICosmosDBW
         }
 
         if (defaultExperience.capability) {
-            options.capabilities = [{ name: defaultExperience.capability }];
+            options.capabilities?.push({ name: defaultExperience.capability });
+        }
+
+        if (defaultExperience?.capacityModel === "Serverless") {
+            options.capabilities?.push({ name: SERVERLESS_CAPABILITY_NAME});
         }
 
         const response: DatabaseAccountsCreateOrUpdateResponse = await client.databaseAccounts.createOrUpdate(rgName, accountName, options);

--- a/test/nightly/azureResourceSQL.test.ts
+++ b/test/nightly/azureResourceSQL.test.ts
@@ -16,6 +16,7 @@ suite('SQL action', async function (this: Mocha.Suite): Promise<void> {
     this.timeout(20 * 60 * 1000);
     let resourceGroupName: string;
     let accountName: string;
+    let serverlessAccountName: string;
     let databaseName: string;
     let collectionId2: string;
 
@@ -26,6 +27,7 @@ suite('SQL action', async function (this: Mocha.Suite): Promise<void> {
         this.timeout(2 * 60 * 1000);
         resourceGroupName = resourceGroupList[AccountApi.Core];
         accountName = accountList[AccountApi.Core];
+        serverlessAccountName = accountList[AccountApi.Core];
         databaseName = randomUtils.getRandomHexString(12);
         collectionId2 = randomUtils.getRandomHexString(12);
     });
@@ -39,7 +41,13 @@ suite('SQL action', async function (this: Mocha.Suite): Promise<void> {
         const collectionId1: string = randomUtils.getRandomHexString(12);
         // Partition key cannot begin with a digit
         const partitionKey1: string = `f${randomUtils.getRandomHexString(12)}`;
-        const testInputs: (string | RegExp)[] = [testAccount.getSubscriptionContext().subscriptionDisplayName, `${accountName} (SQL)`, databaseName, collectionId1, partitionKey1, '1000'];
+        const testInputs: (string | RegExp)[] = [
+            testAccount.getSubscriptionContext().subscriptionDisplayName,
+            `${accountName} (SQL)`,
+            databaseName,
+            collectionId1,
+            partitionKey1,
+            '1000'];
         await testUserInput.runWithInputs(testInputs, async () => {
             await vscode.commands.executeCommand('cosmosDB.createDocDBDatabase');
         });
@@ -49,7 +57,47 @@ suite('SQL action', async function (this: Mocha.Suite): Promise<void> {
     test('Create SQL collection', async () => {
         // Partition key cannot begin with a digit
         const partitionKey2: string = `f${randomUtils.getRandomHexString(12)}`;
-        const testInputs: (string | RegExp)[] = [testAccount.getSubscriptionContext().subscriptionDisplayName, `${accountName} (SQL)`, databaseName, collectionId2, partitionKey2, '1000'];
+        const testInputs: (string | RegExp)[] = [
+            testAccount.getSubscriptionContext().subscriptionDisplayName,
+            `${accountName} (SQL)`,
+            databaseName,
+            collectionId2,
+            partitionKey2,
+            '1000'];
+        await testUserInput.runWithInputs(testInputs, async () => {
+            await vscode.commands.executeCommand('cosmosDB.createDocDBCollection');
+        });
+        assert.ok(await getDocDBCollectionMeta(accountName, databaseName, collectionId2));
+    });
+
+    // create collection on serverless (w/o throughput)
+    test('Create SQL Database', async () => {
+        const collectionId1: string = randomUtils.getRandomHexString(12);
+        // Partition key cannot begin with a digit
+        const partitionKey1: string = `f${randomUtils.getRandomHexString(12)}`;
+        const testInputs: (string | RegExp)[] = [
+            testAccount.getSubscriptionContext().subscriptionDisplayName,
+            `${serverlessAccountName} (SQL)`,
+            databaseName,
+            collectionId1,
+            partitionKey1
+        ];
+        await testUserInput.runWithInputs(testInputs, async () => {
+            await vscode.commands.executeCommand('cosmosDB.createDocDBDatabase');
+        });
+        assert.ok(await getDatabaseMeta());
+    });
+
+    test('Create SQL collection', async () => {
+        // Partition key cannot begin with a digit
+        const partitionKey2: string = `f${randomUtils.getRandomHexString(12)}`;
+        const testInputs: (string | RegExp)[] = [
+            testAccount.getSubscriptionContext().subscriptionDisplayName,
+            `${serverlessAccountName} (SQL)`,
+            databaseName,
+            collectionId2,
+            partitionKey2
+        ];
         await testUserInput.runWithInputs(testInputs, async () => {
             await vscode.commands.executeCommand('cosmosDB.createDocDBCollection');
         });


### PR DESCRIPTION
Addresses #1682 

## Changes

1. Add capacity model to Cosmos DB API options w/ Provisioned and Serverless
2. Only prompt for RUs on account create for non-serverless accounts

## Contributors
Cosmos DB - @ThomasWeiss, @christopheranderson 
