### PR TITLE
Extend Create Server for Postgres wizard to select SKU

### DIFF
--- a/src/postgres/commands/createPostgresServer/IPostgresServerWizardContext.ts
+++ b/src/postgres/commands/createPostgresServer/IPostgresServerWizardContext.ts
@@ -8,19 +8,19 @@ import { Server } from "@azure/arm-postgresql/src/models";
 import { IAzureDBWizardContext } from "../../../tree/IAzureDBWizardContext";
 
 export interface IPostgresServerWizardContext extends IAzureDBWizardContext {
-  /**
-   * Username without server, i.e. "user1"
-   */
-  shortUserName?: string;
-  /**
-   * Username with server, i.e. "user1@server1"
-   */
-  longUserName?: string;
-  adminPassword?: string;
+    /**
+     * Username without server, i.e. "user1"
+     */
+    shortUserName?: string;
+    /**
+     * Username with server, i.e. "user1@server1"
+     */
+    longUserName?: string;
+    adminPassword?: string;
 
-  addFirewall?: boolean;
-  publicIp?: string;
+    addFirewall?: boolean;
+    publicIp?: string;
 
-  server?: Server;
-  sku?: Sku;
+    server?: Server;
+    sku?: Sku;
 }

--- a/src/postgres/commands/createPostgresServer/IPostgresServerWizardContext.ts
+++ b/src/postgres/commands/createPostgresServer/IPostgresServerWizardContext.ts
@@ -3,24 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Sku } from "@azure/arm-postgresql/esm/models";
 import { Server } from "@azure/arm-postgresql/src/models";
 import { IAzureDBWizardContext } from "../../../tree/IAzureDBWizardContext";
 
 export interface IPostgresServerWizardContext extends IAzureDBWizardContext {
+  /**
+   * Username without server, i.e. "user1"
+   */
+  shortUserName?: string;
+  /**
+   * Username with server, i.e. "user1@server1"
+   */
+  longUserName?: string;
+  adminPassword?: string;
 
-    /**
-     * Username without server, i.e. "user1"
-     */
-    shortUserName?: string;
-    /**
-     * Username with server, i.e. "user1@server1"
-     */
-    longUserName?: string;
-    adminPassword?: string;
+  addFirewall?: boolean;
+  publicIp?: string;
 
-    addFirewall?: boolean;
-    publicIp?: string;
-
-    server?: Server;
-
+  server?: Server;
+  sku?: Sku;
 }

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerCreateStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerCreateStep.ts
@@ -13,12 +13,12 @@ import { IPostgresServerWizardContext } from '../IPostgresServerWizardContext';
 
 export class PostgresServerCreateStep extends AzureWizardExecuteStep<IPostgresServerWizardContext> {
     public priority: number = 150;
-    public postgresDefaultStorageSizeMB: number = 51200;
 
     public async execute(wizardContext: IPostgresServerWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
 
         const locationName = nonNullProp(nonNullProp(wizardContext, 'location'), 'name');
         const rgName: string = nonNullProp(nonNullProp(wizardContext, 'resourceGroup'), 'name');
+        const storageMB: string = nonNullProp(nonNullProp(wizardContext, 'sku'), 'size');
         const newServerName = nonNullProp(wizardContext, 'newServerName');
         const password: string = nonNullProp(wizardContext, 'adminPassword');
 
@@ -30,13 +30,7 @@ export class PostgresServerCreateStep extends AzureWizardExecuteStep<IPostgresSe
                 progress.report({ message: createMessage });
                 const options: ServerForCreate = {
                     location: locationName,
-                    sku: {
-                        name: "B_Gen5_1",
-                        tier: "Basic",
-                        capacity: 1,
-                        family: "Gen5",
-                        size: `${this.postgresDefaultStorageSizeMB}`
-                    },
+                    sku: nonNullProp(wizardContext, 'sku'),
                     properties: {
                         administratorLogin: nonNullProp(wizardContext, 'shortUserName'),
                         administratorLoginPassword: password,
@@ -44,7 +38,7 @@ export class PostgresServerCreateStep extends AzureWizardExecuteStep<IPostgresSe
                         createMode: "Default",
                         version: "10",
                         storageProfile: {
-                            storageMB: this.postgresDefaultStorageSizeMB
+                            storageMB: parseInt(storageMB)
                         }
                     },
                 };

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -12,7 +12,7 @@ import { IPostgresServerWizardContext } from '../IPostgresServerWizardContext';
 
 interface ISkuOption {
     label: string
-    detail: string
+    description: string
     sku: Sku
 }
 
@@ -29,7 +29,7 @@ export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServer
     public async getPicks(): Promise<IAzureQuickPickItem<Sku>[]> {
         const options: IAzureQuickPickItem<Sku>[] = [];
         availableSkus.forEach(option => {
-            options.push({ label: option.label, description: localize(nonNullProp(option.sku, 'name'), option.detail), data: option.sku });
+            options.push({ label: option.label, description: localize(nonNullProp(option.sku, 'name'), option.description), data: option.sku });
         });
         return options;
     }
@@ -38,7 +38,7 @@ export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServer
 const availableSkus: ISkuOption[] = [
     {
         label: "B1",
-        detail: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
+        description: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
         sku: {
             name: "B_Gen5_1",
             tier: "Basic",
@@ -49,7 +49,7 @@ const availableSkus: ISkuOption[] = [
     },
     {
         label: "B2",
-        detail: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
+        description: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
         sku: {
             name: "B_Gen5_2",
             tier: "Basic",
@@ -60,7 +60,7 @@ const availableSkus: ISkuOption[] = [
     },
     {
         label: "GP2",
-        detail: "General Purpose, 2 vCores, 10GiB Memory, 50GB storage",
+        description: "General Purpose, 2 vCores, 10GiB Memory, 50GB storage",
         sku: {
             name: "GP_Gen5_2",
             tier: "GeneralPurpose",
@@ -71,7 +71,7 @@ const availableSkus: ISkuOption[] = [
     },
     {
         label: "GP4",
-        detail: "General Purpose, 4 vCores, 20GiB Memory, 50GB storage",
+        description: "General Purpose, 4 vCores, 20GiB Memory, 50GB storage",
         sku: {
             name: "GP_Gen5_4",
             tier: "GeneralPurpose",
@@ -82,7 +82,7 @@ const availableSkus: ISkuOption[] = [
     },
     {
         label: "GP8",
-        detail: "General Purpose, 8 vCores, 40GiB Memory, 200GB storage",
+        description: "General Purpose, 8 vCores, 40GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_8",
             tier: "GeneralPurpose",
@@ -93,7 +93,7 @@ const availableSkus: ISkuOption[] = [
     },
     {
         label: "GP16",
-        detail: "General Purpose, 16 vCores, 80GiB Memory, 200GB storage",
+        description: "General Purpose, 16 vCores, 80GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_16",
             tier: "GeneralPurpose",
@@ -104,7 +104,7 @@ const availableSkus: ISkuOption[] = [
     },
     {
         label: "GP32",
-        detail: "General Purpose, 32 vCores, 160GiB Memory, 200GB storage",
+        description: "General Purpose, 32 vCores, 160GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_32",
             tier: "GeneralPurpose",
@@ -115,7 +115,7 @@ const availableSkus: ISkuOption[] = [
     },
     {
         label: "GP64",
-        detail: "General Purpose, 64 vCores, 320GiB Memory, 200GB storage",
+        description: "General Purpose, 64 vCores, 320GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_64",
             tier: "GeneralPurpose",

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -48,7 +48,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "Basic",
             capacity: 1,
             family: "Gen5",
-            size: "5000"
+            size: "5120"
         }
     },
     {
@@ -58,7 +58,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "Basic",
             capacity: 2,
             family: "Gen5",
-            size: "50000"
+            size: "51200"
         }
     },
     {
@@ -68,7 +68,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "GeneralPurpose",
             capacity: 2,
             family: "Gen5",
-            size: "50000"
+            size: "51200"
         }
     },
     {
@@ -78,7 +78,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "GeneralPurpose",
             capacity: 4,
             family: "Gen5",
-            size: "50000"
+            size: "51200"
         }
     },
     {
@@ -88,7 +88,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "GeneralPurpose",
             capacity: 8,
             family: "Gen5",
-            size: "200000"
+            size: "204800"
         }
     },
     {
@@ -98,7 +98,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "GeneralPurpose",
             capacity: 16,
             family: "Gen5",
-            size: "200000"
+            size: "204800"
         }
     },
     {
@@ -108,7 +108,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "GeneralPurpose",
             capacity: 32,
             family: "Gen5",
-            size: "200000"
+            size: "204800"
         }
     },
     {
@@ -118,7 +118,7 @@ const availableSkus: Array<SkuOption> = [
             tier: "GeneralPurpose",
             capacity: 64,
             family: "Gen5",
-            size: "200000"
+            size: "204800"
         }
     }
 ];

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -56,7 +56,7 @@ const availableSkus: Array<SkuOption> = [
         sku: {
             name: "B_Gen5_2",
             tier: "Basic",
-            capacity: 1,
+            capacity: 2,
             family: "Gen5",
             size: "50000"
         }
@@ -66,7 +66,7 @@ const availableSkus: Array<SkuOption> = [
         sku: {
             name: "GP_Gen5_2",
             tier: "GeneralPurpose",
-            capacity: 1,
+            capacity: 2,
             family: "Gen5",
             size: "50000"
         }
@@ -76,7 +76,7 @@ const availableSkus: Array<SkuOption> = [
         sku: {
             name: "GP_Gen5_4",
             tier: "GeneralPurpose",
-            capacity: 1,
+            capacity: 4,
             family: "Gen5",
             size: "50000"
         }
@@ -86,7 +86,7 @@ const availableSkus: Array<SkuOption> = [
         sku: {
             name: "GP_Gen5_8",
             tier: "GeneralPurpose",
-            capacity: 1,
+            capacity: 8,
             family: "Gen5",
             size: "200000"
         }
@@ -96,7 +96,7 @@ const availableSkus: Array<SkuOption> = [
         sku: {
             name: "GP_Gen5_16",
             tier: "GeneralPurpose",
-            capacity: 1,
+            capacity: 16,
             family: "Gen5",
             size: "200000"
         }
@@ -106,7 +106,7 @@ const availableSkus: Array<SkuOption> = [
         sku: {
             name: "GP_Gen5_32",
             tier: "GeneralPurpose",
-            capacity: 1,
+            capacity: 32,
             family: "Gen5",
             size: "200000"
         }
@@ -116,7 +116,7 @@ const availableSkus: Array<SkuOption> = [
         sku: {
             name: "GP_Gen5_64",
             tier: "GeneralPurpose",
-            capacity: 1,
+            capacity: 64,
             family: "Gen5",
             size: "200000"
         }

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -10,21 +10,15 @@ import { localize } from '../../../../utils/localize';
 import { nonNullProp } from '../../../../utils/nonNull';
 import { IPostgresServerWizardContext } from '../IPostgresServerWizardContext';
 
-class SkuOption {
+interface ISkuOption {
     label: string
     sku: Sku
 }
 
 export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServerWizardContext> {
-    public postgresDefaultStorageSizeMB: number = 51200;
-
-
     public async prompt(wizardContext: IPostgresServerWizardContext): Promise<void> {
-
         const placeHolder: string = localize('selectPostgresSku', 'Select the Postgres SKU and options.');
-
         wizardContext.sku = (await ext.ui.showQuickPick(this.getPicks(), { placeHolder })).data;
-
     }
 
     public shouldPrompt(wizardContext: IPostgresServerWizardContext): boolean {

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -12,6 +12,7 @@ import { IPostgresServerWizardContext } from '../IPostgresServerWizardContext';
 
 interface ISkuOption {
     label: string
+    detail: string
     sku: Sku
 }
 
@@ -28,7 +29,7 @@ export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServer
     public async getPicks(): Promise<IAzureQuickPickItem<Sku>[]> {
         const options: IAzureQuickPickItem<Sku>[] = [];
         availableSkus.forEach(option => {
-            options.push({ label: localize(nonNullProp(option.sku, 'name'), option.label), data: option.sku });
+            options.push({ label: option.label, description: localize(nonNullProp(option.sku, 'name'), option.detail), data: option.sku });
         });
         return options;
     }
@@ -36,7 +37,8 @@ export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServer
 
 const availableSkus: ISkuOption[] = [
     {
-        label: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
+        label: "B1",
+        detail: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
         sku: {
             name: "B_Gen5_1",
             tier: "Basic",
@@ -46,7 +48,8 @@ const availableSkus: ISkuOption[] = [
         }
     },
     {
-        label: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
+        label: "B2",
+        detail: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
         sku: {
             name: "B_Gen5_2",
             tier: "Basic",
@@ -56,7 +59,8 @@ const availableSkus: ISkuOption[] = [
         }
     },
     {
-        label: "General, 2 vCores, 10GiB Memory, 50GB storage",
+        label: "GP2",
+        detail: "General Purpose, 2 vCores, 10GiB Memory, 50GB storage",
         sku: {
             name: "GP_Gen5_2",
             tier: "GeneralPurpose",
@@ -66,7 +70,8 @@ const availableSkus: ISkuOption[] = [
         }
     },
     {
-        label: "General, 4 vCores, 20GiB Memory, 50GB storage",
+        label: "GP4",
+        detail: "General Purpose, 4 vCores, 20GiB Memory, 50GB storage",
         sku: {
             name: "GP_Gen5_4",
             tier: "GeneralPurpose",
@@ -76,7 +81,8 @@ const availableSkus: ISkuOption[] = [
         }
     },
     {
-        label: "General, 8 vCores, 40GiB Memory, 200GB storage",
+        label: "GP8",
+        detail: "General Purpose, 8 vCores, 40GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_8",
             tier: "GeneralPurpose",
@@ -86,7 +92,8 @@ const availableSkus: ISkuOption[] = [
         }
     },
     {
-        label: "General, 16 vCores, 80GiB Memory, 200GB storage",
+        label: "GP16",
+        detail: "General Purpose, 16 vCores, 80GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_16",
             tier: "GeneralPurpose",
@@ -96,7 +103,8 @@ const availableSkus: ISkuOption[] = [
         }
     },
     {
-        label: "General, 32 vCores, 160GiB Memory, 200GB storage",
+        label: "GP32",
+        detail: "General Purpose, 32 vCores, 160GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_32",
             tier: "GeneralPurpose",
@@ -106,7 +114,8 @@ const availableSkus: ISkuOption[] = [
         }
     },
     {
-        label: "General, 64 vCores, 320GiB Memory, 200GB storage",
+        label: "GP64",
+        detail: "General Purpose, 64 vCores, 320GiB Memory, 200GB storage",
         sku: {
             name: "GP_Gen5_64",
             tier: "GeneralPurpose",

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -14,131 +14,131 @@ import { nonNullProp } from "../../../../utils/nonNull";
 import { IPostgresServerWizardContext } from "../IPostgresServerWizardContext";
 
 interface ISkuOption {
-  label: string;
-  description: string;
-  sku: Sku;
+    label: string;
+    description: string;
+    sku: Sku;
 }
 
 export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServerWizardContext> {
-  public async prompt(
-    wizardContext: IPostgresServerWizardContext
-  ): Promise<void> {
-    const placeHolder: string = localize(
-      "selectPostgresSku",
-      "Select the Postgres SKU and options."
-    );
-    wizardContext.sku = (
-      await ext.ui.showQuickPick(this.getPicks(), { placeHolder })
-    ).data;
-  }
+    public async prompt(
+        wizardContext: IPostgresServerWizardContext
+    ): Promise<void> {
+        const placeHolder: string = localize(
+            "selectPostgresSku",
+            "Select the Postgres SKU and options."
+        );
+        wizardContext.sku = (
+            await ext.ui.showQuickPick(this.getPicks(), { placeHolder })
+        ).data;
+    }
 
-  public shouldPrompt(wizardContext: IPostgresServerWizardContext): boolean {
-    return wizardContext.sku === undefined;
-  }
+    public shouldPrompt(wizardContext: IPostgresServerWizardContext): boolean {
+        return wizardContext.sku === undefined;
+    }
 
-  public async getPicks(): Promise<IAzureQuickPickItem<Sku>[]> {
-    const options: IAzureQuickPickItem<Sku>[] = [];
-    availableSkus.forEach((option) => {
-      options.push({
-        label: option.label,
-        description: localize(
-          nonNullProp(option.sku, "name"),
-          option.description
-        ),
-        data: option.sku,
-      });
-    });
-    return options;
-  }
+    public async getPicks(): Promise<IAzureQuickPickItem<Sku>[]> {
+        const options: IAzureQuickPickItem<Sku>[] = [];
+        availableSkus.forEach((option) => {
+            options.push({
+                label: option.label,
+                description: localize(
+                    nonNullProp(option.sku, "name"),
+                    option.description
+                ),
+                data: option.sku,
+            });
+        });
+        return options;
+    }
 }
 
 const availableSkus: ISkuOption[] = [
-  {
-    label: "B1",
-    description: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
-    sku: {
-      name: "B_Gen5_1",
-      tier: "Basic",
-      capacity: 1,
-      family: "Gen5",
-      size: "5120",
+    {
+        label: "B1",
+        description: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
+        sku: {
+            name: "B_Gen5_1",
+            tier: "Basic",
+            capacity: 1,
+            family: "Gen5",
+            size: "5120",
+        },
     },
-  },
-  {
-    label: "B2",
-    description: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
-    sku: {
-      name: "B_Gen5_2",
-      tier: "Basic",
-      capacity: 2,
-      family: "Gen5",
-      size: "51200",
+    {
+        label: "B2",
+        description: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
+        sku: {
+            name: "B_Gen5_2",
+            tier: "Basic",
+            capacity: 2,
+            family: "Gen5",
+            size: "51200",
+        },
     },
-  },
-  {
-    label: "GP2",
-    description: "General Purpose, 2 vCores, 10GiB Memory, 50GB storage",
-    sku: {
-      name: "GP_Gen5_2",
-      tier: "GeneralPurpose",
-      capacity: 2,
-      family: "Gen5",
-      size: "51200",
+    {
+        label: "GP2",
+        description: "General Purpose, 2 vCores, 10GiB Memory, 50GB storage",
+        sku: {
+            name: "GP_Gen5_2",
+            tier: "GeneralPurpose",
+            capacity: 2,
+            family: "Gen5",
+            size: "51200",
+        },
     },
-  },
-  {
-    label: "GP4",
-    description: "General Purpose, 4 vCores, 20GiB Memory, 50GB storage",
-    sku: {
-      name: "GP_Gen5_4",
-      tier: "GeneralPurpose",
-      capacity: 4,
-      family: "Gen5",
-      size: "51200",
+    {
+        label: "GP4",
+        description: "General Purpose, 4 vCores, 20GiB Memory, 50GB storage",
+        sku: {
+            name: "GP_Gen5_4",
+            tier: "GeneralPurpose",
+            capacity: 4,
+            family: "Gen5",
+            size: "51200",
+        },
     },
-  },
-  {
-    label: "GP8",
-    description: "General Purpose, 8 vCores, 40GiB Memory, 200GB storage",
-    sku: {
-      name: "GP_Gen5_8",
-      tier: "GeneralPurpose",
-      capacity: 8,
-      family: "Gen5",
-      size: "204800",
+    {
+        label: "GP8",
+        description: "General Purpose, 8 vCores, 40GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_8",
+            tier: "GeneralPurpose",
+            capacity: 8,
+            family: "Gen5",
+            size: "204800",
+        },
     },
-  },
-  {
-    label: "GP16",
-    description: "General Purpose, 16 vCores, 80GiB Memory, 200GB storage",
-    sku: {
-      name: "GP_Gen5_16",
-      tier: "GeneralPurpose",
-      capacity: 16,
-      family: "Gen5",
-      size: "204800",
+    {
+        label: "GP16",
+        description: "General Purpose, 16 vCores, 80GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_16",
+            tier: "GeneralPurpose",
+            capacity: 16,
+            family: "Gen5",
+            size: "204800",
+        },
     },
-  },
-  {
-    label: "GP32",
-    description: "General Purpose, 32 vCores, 160GiB Memory, 200GB storage",
-    sku: {
-      name: "GP_Gen5_32",
-      tier: "GeneralPurpose",
-      capacity: 32,
-      family: "Gen5",
-      size: "204800",
+    {
+        label: "GP32",
+        description: "General Purpose, 32 vCores, 160GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_32",
+            tier: "GeneralPurpose",
+            capacity: 32,
+            family: "Gen5",
+            size: "204800",
+        },
     },
-  },
-  {
-    label: "GP64",
-    description: "General Purpose, 64 vCores, 320GiB Memory, 200GB storage",
-    sku: {
-      name: "GP_Gen5_64",
-      tier: "GeneralPurpose",
-      capacity: 64,
-      family: "Gen5",
-      size: "204800",
+    {
+        label: "GP64",
+        description: "General Purpose, 64 vCores, 320GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_64",
+            tier: "GeneralPurpose",
+            capacity: 64,
+            family: "Gen5",
+            size: "204800",
+        },
     },
-  },
 ];

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Sku } from '@azure/arm-postgresql/src/models';
+import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { ext } from '../../../../extensionVariables';
+import { localize } from '../../../../utils/localize';
+import { nonNullProp } from '../../../../utils/nonNull';
+import { IPostgresServerWizardContext } from '../IPostgresServerWizardContext';
+
+class SkuOption {
+    label: string
+    sku: Sku
+}
+
+export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServerWizardContext> {
+    public postgresDefaultStorageSizeMB: number = 51200;
+
+
+    public async prompt(wizardContext: IPostgresServerWizardContext): Promise<void> {
+
+        const placeHolder: string = localize('selectPostgresSku', 'Select the Postgres SKU and options.');
+
+        wizardContext.sku = (await ext.ui.showQuickPick(this.getPicks(), { placeHolder })).data;
+
+    }
+
+    public shouldPrompt(wizardContext: IPostgresServerWizardContext): boolean {
+        return wizardContext.sku === undefined;
+    }
+
+    public async getPicks(): Promise<IAzureQuickPickItem<Sku>[]> {
+        const options: IAzureQuickPickItem<Sku>[] = [];
+        availableSkus.forEach(option => {
+            options.push({ label: localize(nonNullProp(option.sku, 'name'), option.label), data: option.sku });
+        });
+        return options;
+    }
+}
+
+const availableSkus: Array<SkuOption> = [
+    {
+        label: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
+        sku: {
+            name: "B_Gen5_1",
+            tier: "Basic",
+            capacity: 1,
+            family: "Gen5",
+            size: "5000"
+        }
+    },
+    {
+        label: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
+        sku: {
+            name: "B_Gen5_2",
+            tier: "Basic",
+            capacity: 1,
+            family: "Gen5",
+            size: "50000"
+        }
+    },
+    {
+        label: "General, 2 vCores, 10GiB Memory, 50GB storage",
+        sku: {
+            name: "GP_Gen5_2",
+            tier: "GeneralPurpose",
+            capacity: 1,
+            family: "Gen5",
+            size: "50000"
+        }
+    },
+    {
+        label: "General, 4 vCores, 20GiB Memory, 50GB storage",
+        sku: {
+            name: "GP_Gen5_4",
+            tier: "GeneralPurpose",
+            capacity: 1,
+            family: "Gen5",
+            size: "50000"
+        }
+    },
+    {
+        label: "General, 8 vCores, 40GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_8",
+            tier: "GeneralPurpose",
+            capacity: 1,
+            family: "Gen5",
+            size: "200000"
+        }
+    },
+    {
+        label: "General, 16 vCores, 80GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_16",
+            tier: "GeneralPurpose",
+            capacity: 1,
+            family: "Gen5",
+            size: "200000"
+        }
+    },
+    {
+        label: "General, 32 vCores, 160GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_32",
+            tier: "GeneralPurpose",
+            capacity: 1,
+            family: "Gen5",
+            size: "200000"
+        }
+    },
+    {
+        label: "General, 64 vCores, 320GiB Memory, 200GB storage",
+        sku: {
+            name: "GP_Gen5_64",
+            tier: "GeneralPurpose",
+            capacity: 1,
+            family: "Gen5",
+            size: "200000"
+        }
+    }
+];

--- a/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
+++ b/src/postgres/commands/createPostgresServer/steps/PostgresServerSkuStep.ts
@@ -3,125 +3,142 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Sku } from '@azure/arm-postgresql/src/models';
-import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
-import { ext } from '../../../../extensionVariables';
-import { localize } from '../../../../utils/localize';
-import { nonNullProp } from '../../../../utils/nonNull';
-import { IPostgresServerWizardContext } from '../IPostgresServerWizardContext';
+import { Sku } from "@azure/arm-postgresql/src/models";
+import {
+    AzureWizardPromptStep,
+    IAzureQuickPickItem
+} from "vscode-azureextensionui";
+import { ext } from "../../../../extensionVariables";
+import { localize } from "../../../../utils/localize";
+import { nonNullProp } from "../../../../utils/nonNull";
+import { IPostgresServerWizardContext } from "../IPostgresServerWizardContext";
 
 interface ISkuOption {
-    label: string
-    description: string
-    sku: Sku
+  label: string;
+  description: string;
+  sku: Sku;
 }
 
 export class PostgresServerSkuStep extends AzureWizardPromptStep<IPostgresServerWizardContext> {
-    public async prompt(wizardContext: IPostgresServerWizardContext): Promise<void> {
-        const placeHolder: string = localize('selectPostgresSku', 'Select the Postgres SKU and options.');
-        wizardContext.sku = (await ext.ui.showQuickPick(this.getPicks(), { placeHolder })).data;
-    }
+  public async prompt(
+    wizardContext: IPostgresServerWizardContext
+  ): Promise<void> {
+    const placeHolder: string = localize(
+      "selectPostgresSku",
+      "Select the Postgres SKU and options."
+    );
+    wizardContext.sku = (
+      await ext.ui.showQuickPick(this.getPicks(), { placeHolder })
+    ).data;
+  }
 
-    public shouldPrompt(wizardContext: IPostgresServerWizardContext): boolean {
-        return wizardContext.sku === undefined;
-    }
+  public shouldPrompt(wizardContext: IPostgresServerWizardContext): boolean {
+    return wizardContext.sku === undefined;
+  }
 
-    public async getPicks(): Promise<IAzureQuickPickItem<Sku>[]> {
-        const options: IAzureQuickPickItem<Sku>[] = [];
-        availableSkus.forEach(option => {
-            options.push({ label: option.label, description: localize(nonNullProp(option.sku, 'name'), option.description), data: option.sku });
-        });
-        return options;
-    }
+  public async getPicks(): Promise<IAzureQuickPickItem<Sku>[]> {
+    const options: IAzureQuickPickItem<Sku>[] = [];
+    availableSkus.forEach((option) => {
+      options.push({
+        label: option.label,
+        description: localize(
+          nonNullProp(option.sku, "name"),
+          option.description
+        ),
+        data: option.sku,
+      });
+    });
+    return options;
+  }
 }
 
 const availableSkus: ISkuOption[] = [
-    {
-        label: "B1",
-        description: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
-        sku: {
-            name: "B_Gen5_1",
-            tier: "Basic",
-            capacity: 1,
-            family: "Gen5",
-            size: "5120"
-        }
+  {
+    label: "B1",
+    description: "Basic, 1 vCore, 2GiB Memory, 5GB storage",
+    sku: {
+      name: "B_Gen5_1",
+      tier: "Basic",
+      capacity: 1,
+      family: "Gen5",
+      size: "5120",
     },
-    {
-        label: "B2",
-        description: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
-        sku: {
-            name: "B_Gen5_2",
-            tier: "Basic",
-            capacity: 2,
-            family: "Gen5",
-            size: "51200"
-        }
+  },
+  {
+    label: "B2",
+    description: "Basic, 2 vCores, 4GiB Memory, 50GB storage",
+    sku: {
+      name: "B_Gen5_2",
+      tier: "Basic",
+      capacity: 2,
+      family: "Gen5",
+      size: "51200",
     },
-    {
-        label: "GP2",
-        description: "General Purpose, 2 vCores, 10GiB Memory, 50GB storage",
-        sku: {
-            name: "GP_Gen5_2",
-            tier: "GeneralPurpose",
-            capacity: 2,
-            family: "Gen5",
-            size: "51200"
-        }
+  },
+  {
+    label: "GP2",
+    description: "General Purpose, 2 vCores, 10GiB Memory, 50GB storage",
+    sku: {
+      name: "GP_Gen5_2",
+      tier: "GeneralPurpose",
+      capacity: 2,
+      family: "Gen5",
+      size: "51200",
     },
-    {
-        label: "GP4",
-        description: "General Purpose, 4 vCores, 20GiB Memory, 50GB storage",
-        sku: {
-            name: "GP_Gen5_4",
-            tier: "GeneralPurpose",
-            capacity: 4,
-            family: "Gen5",
-            size: "51200"
-        }
+  },
+  {
+    label: "GP4",
+    description: "General Purpose, 4 vCores, 20GiB Memory, 50GB storage",
+    sku: {
+      name: "GP_Gen5_4",
+      tier: "GeneralPurpose",
+      capacity: 4,
+      family: "Gen5",
+      size: "51200",
     },
-    {
-        label: "GP8",
-        description: "General Purpose, 8 vCores, 40GiB Memory, 200GB storage",
-        sku: {
-            name: "GP_Gen5_8",
-            tier: "GeneralPurpose",
-            capacity: 8,
-            family: "Gen5",
-            size: "204800"
-        }
+  },
+  {
+    label: "GP8",
+    description: "General Purpose, 8 vCores, 40GiB Memory, 200GB storage",
+    sku: {
+      name: "GP_Gen5_8",
+      tier: "GeneralPurpose",
+      capacity: 8,
+      family: "Gen5",
+      size: "204800",
     },
-    {
-        label: "GP16",
-        description: "General Purpose, 16 vCores, 80GiB Memory, 200GB storage",
-        sku: {
-            name: "GP_Gen5_16",
-            tier: "GeneralPurpose",
-            capacity: 16,
-            family: "Gen5",
-            size: "204800"
-        }
+  },
+  {
+    label: "GP16",
+    description: "General Purpose, 16 vCores, 80GiB Memory, 200GB storage",
+    sku: {
+      name: "GP_Gen5_16",
+      tier: "GeneralPurpose",
+      capacity: 16,
+      family: "Gen5",
+      size: "204800",
     },
-    {
-        label: "GP32",
-        description: "General Purpose, 32 vCores, 160GiB Memory, 200GB storage",
-        sku: {
-            name: "GP_Gen5_32",
-            tier: "GeneralPurpose",
-            capacity: 32,
-            family: "Gen5",
-            size: "204800"
-        }
+  },
+  {
+    label: "GP32",
+    description: "General Purpose, 32 vCores, 160GiB Memory, 200GB storage",
+    sku: {
+      name: "GP_Gen5_32",
+      tier: "GeneralPurpose",
+      capacity: 32,
+      family: "Gen5",
+      size: "204800",
     },
-    {
-        label: "GP64",
-        description: "General Purpose, 64 vCores, 320GiB Memory, 200GB storage",
-        sku: {
-            name: "GP_Gen5_64",
-            tier: "GeneralPurpose",
-            capacity: 64,
-            family: "Gen5",
-            size: "204800"
-        }
-    }
+  },
+  {
+    label: "GP64",
+    description: "General Purpose, 64 vCores, 320GiB Memory, 200GB storage",
+    sku: {
+      name: "GP_Gen5_64",
+      tier: "GeneralPurpose",
+      capacity: 64,
+      family: "Gen5",
+      size: "204800",
+    },
+  },
 ];

--- a/src/tree/AzureDBAPIStep.ts
+++ b/src/tree/AzureDBAPIStep.ts
@@ -15,6 +15,7 @@ import { PostgresServerFirewallStep } from '../postgres/commands/createPostgresS
 import { PostgresServerNameStep } from '../postgres/commands/createPostgresServer/steps/PostgresServerNameStep';
 import { PostgresServerSetCredentialsStep } from '../postgres/commands/createPostgresServer/steps/PostgresServerSetCredentialsStep';
 import { PostgresServerSetFirewallStep } from '../postgres/commands/createPostgresServer/steps/PostgresServerSetFirewallStep';
+import { PostgresServerSkuStep } from '../postgres/commands/createPostgresServer/steps/PostgresServerSkuStep';
 import { localize } from '../utils/localize';
 import { CosmosDBAccountCreateStep } from './CosmosDBAccountWizard/CosmosDBAccountCreateStep';
 import { CosmosDBAccountNameStep } from './CosmosDBAccountWizard/CosmosDBAccountNameStep';
@@ -38,6 +39,7 @@ export class AzureDBAPIStep extends AzureWizardPromptStep<IPostgresServerWizardC
         if (wizardContext.defaultExperience?.api === API.Postgres) {
             promptSteps = [
                 new PostgresServerNameStep(),
+                new PostgresServerSkuStep(),
                 new PostgresServerCredUserStep(),
                 new PostgresServerCredPWStep(),
                 new PostgresServerConfirmPWStep(),


### PR DESCRIPTION
This PR extends the create server wizard for Postgres to allow the user to select which SKU, vCore and storage configuration instead of the default value in the current wizard.

The list isn't exhaustive, but would cover most use cases.

<img width="888" alt="CleanShot 2021-05-20 at 11 01 22@2x" src="https://user-images.githubusercontent.com/1532417/118905636-702d9800-b95f-11eb-889c-8a906bea2a24.png">
