### PR TITLE
Shorten Postgres Flexible Servers connection timeout

### DIFF
--- a/src/postgres/commands/configurePostgresFirewall.ts
+++ b/src/postgres/commands/configurePostgresFirewall.ts
@@ -18,7 +18,7 @@ export async function configurePostgresFirewall(context: IActionContext, treeIte
         treeItem = <PostgresServerTreeItem>await ext.tree.showTreeItemPicker(PostgresServerTreeItem.contextValue, context);
     }
 
-    const ip: string = await getPublicIp();
+    const ip: string = await getPublicIp('Getting public IP to configure firewall rule...');
     await context.ui.showWarningMessage(
         localize('firewallRuleWillBeAdded', 'A firewall rule for your IP ({0}) will be added to server "{1}". Would you like to continue?', ip, treeItem.label),
         {
@@ -60,10 +60,10 @@ export async function setFirewallRule(context: IActionContext, treeItem: Postgre
     await treeItem.refresh(context);
 }
 
-export async function getPublicIp(): Promise<string> {
+export async function getPublicIp(message: string): Promise<string> {
     const options: vscode.ProgressOptions = {
         location: vscode.ProgressLocation.Notification,
-        title: localize('gettingPublicIp', 'Getting public IP...')
+        title: localize('gettingPublicIp', message)
     };
 
     return await vscode.window.withProgress(options, async () => {

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -98,7 +98,7 @@ export class PostgresDatabaseTreeItem extends AzureParentTreeItem<ISubscriptionC
         const serverType: PostgresServerType = nonNullProp(treeItem, 'serverType');
         const client = createAbstractPostgresClient(serverType, treeItem.root);
         const result: FirewallRuleListResult = (await client.firewallRules.listByServer(nonNullProp(treeItem, 'resourceGroup'), nonNullProp(treeItem, 'azureName')))._response.parsedBody;
-        const publicIp: string = await getPublicIp();
+        const publicIp: string = await getPublicIp('Getting Public IP to verify server connectivity...');
         return (result.some(async value => value.startIpAddress === publicIp));
     }
 

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -6,7 +6,7 @@
 import { FirewallRuleListResult } from '@azure/arm-postgresql/esm/models';
 import { ClientConfig } from 'pg';
 import { ThemeIcon } from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IParsedError, ISubscriptionContext, parseError, TreeItemIconPath } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IActionContext, IParsedError, ISubscriptionContext, parseError, TreeItemIconPath } from 'vscode-azureextensionui';
 import { postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
@@ -57,7 +57,7 @@ export class PostgresDatabaseTreeItem extends AzureParentTreeItem<ISubscriptionC
         return false;
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
+    public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         try {
             if (this.parent.azureName && !(await this.parent.getFullConnectionString()).username) {
                 return [this.getCredentialsTreeItem()];
@@ -77,8 +77,10 @@ export class PostgresDatabaseTreeItem extends AzureParentTreeItem<ISubscriptionC
             return children;
         } catch (error) {
             const parsedError: IParsedError = parseError(error);
-
-            if (this.parent.azureName && (parsedError.errorType === firewallNotConfiguredErrorType || (parsedError.errorType === 'ETIMEDOUT' && !(await this.isFirewallRuleSet(this.parent))))) {
+            if (this.parent.azureName && parsedError.errorType === invalidCredentialsErrorType) {
+                void context.ui.showWarningMessage(localize('couldNotConnect', 'Could not connect to "{0}": {1}', this.parent.label, parsedError.message), { stepName: 'loadPostgresDatabases' });
+                return [this.getCredentialsTreeItem()];
+            } else if (this.parent.azureName && (parsedError.errorType === firewallNotConfiguredErrorType)) {
                 return [this.getFirewallTreeItem()];
             } else {
                 throw error;

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -6,7 +6,7 @@
 import { FirewallRuleListResult } from '@azure/arm-postgresql/esm/models';
 import { ClientConfig } from 'pg';
 import { ThemeIcon } from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IActionContext, IParsedError, ISubscriptionContext, parseError, TreeItemIconPath } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IParsedError, ISubscriptionContext, parseError, TreeItemIconPath } from 'vscode-azureextensionui';
 import { postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
@@ -57,8 +57,13 @@ export class PostgresDatabaseTreeItem extends AzureParentTreeItem<ISubscriptionC
         return false;
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
+    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         try {
+            if (this.parent.azureName && !(await this.parent.getFullConnectionString()).username) {
+                return [this.getCredentialsTreeItem()];
+            } else if ((this.parent.serverType === PostgresServerType.Flexible) && !(await this.isFirewallRuleSet(this.parent))) {
+                return [this.getFirewallTreeItem()];
+            }
             const clientConfig: ClientConfig = await getClientConfig(this.parent, this.databaseName);
             const children: AzExtTreeItem[] = [
                 new PostgresFunctionsTreeItem(this, clientConfig),
@@ -73,23 +78,8 @@ export class PostgresDatabaseTreeItem extends AzureParentTreeItem<ISubscriptionC
         } catch (error) {
             const parsedError: IParsedError = parseError(error);
 
-            if (this.parent.azureName && parsedError.errorType === invalidCredentialsErrorType) {
-                void context.ui.showWarningMessage(localize('couldNotConnect', 'Could not connect to "{0}": {1}', this.parent.label, parsedError.message), { stepName: 'loadPostgresDatabases' });
-                const credentialsTreeItem: AzExtTreeItem = new GenericTreeItem(this, {
-                    contextValue: 'postgresCredentials',
-                    label: localize('enterCredentials', 'Enter server credentials to connect to "{0}"...', this.parent.label),
-                    commandId: 'postgreSQL.enterCredentials'
-                });
-                credentialsTreeItem.commandArgs = [this.parent];
-                return [credentialsTreeItem];
-            } else if (this.parent.azureName && (parsedError.errorType === firewallNotConfiguredErrorType || (parsedError.errorType === 'ETIMEDOUT' && !(await this.isFirewallRuleSet(this.parent))))) {
-                const firewallTreeItem: AzExtTreeItem = new GenericTreeItem(this, {
-                    contextValue: 'postgresFirewall',
-                    label: localize('configureFirewall', 'Configure firewall to connect to "{0}"...', this.parent.label),
-                    commandId: 'postgreSQL.configureFirewall'
-                });
-                firewallTreeItem.commandArgs = [this.parent];
-                return [firewallTreeItem];
+            if (this.parent.azureName && (parsedError.errorType === firewallNotConfiguredErrorType || (parsedError.errorType === 'ETIMEDOUT' && !(await this.isFirewallRuleSet(this.parent))))) {
+                return [this.getFirewallTreeItem()];
             } else {
                 throw error;
             }
@@ -108,5 +98,25 @@ export class PostgresDatabaseTreeItem extends AzureParentTreeItem<ISubscriptionC
         const result: FirewallRuleListResult = (await client.firewallRules.listByServer(nonNullProp(treeItem, 'resourceGroup'), nonNullProp(treeItem, 'azureName')))._response.parsedBody;
         const publicIp: string = await getPublicIp();
         return (result.some(async value => value.startIpAddress === publicIp));
+    }
+
+    private getCredentialsTreeItem(): AzExtTreeItem {
+        const credentialsTreeItem: AzExtTreeItem = new GenericTreeItem(this, {
+            contextValue: 'postgresCredentials',
+            label: localize('enterCredentials', 'Enter server credentials to connect to "{0}"...', this.parent.label),
+            commandId: 'postgreSQL.enterCredentials'
+        });
+        credentialsTreeItem.commandArgs = [this.parent];
+        return credentialsTreeItem;
+    }
+
+    private getFirewallTreeItem(): AzExtTreeItem {
+        const firewallTreeItem: AzExtTreeItem = new GenericTreeItem(this, {
+            contextValue: 'postgresFirewall',
+            label: localize('configureFirewall', 'Configure firewall to connect to "{0}"...', this.parent.label),
+            commandId: 'postgreSQL.configureFirewall'
+        });
+        firewallTreeItem.commandArgs = [this.parent];
+        return firewallTreeItem;
     }
 }


### PR DESCRIPTION
The recently merged PR #1890 catches the `ETIMEDOUT` error but it takes close to 1 min for "client.connect()" before timing out. 

This PR completely prevents `ETIMEDOUT` error for loadChildren() in PostgresDatabaseTreeItem by checking for firewall rules on the portal (for Flexible Servers only) and configuring a firewall rule if there is none. 

`ETIMEDOUT` error might still happen with "checkAuthentication()" especially if "executePostgresQuery()" or "copyConnectionString()" is called before loading PostgresDatabaseTreeItem children. This case is not as common in my opinion, so I think we can wait until next release to improve this. 