### PR TITLE
Fix CHANGELOG styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 0.18.0 - 2021-07-21
 ### Added
 - Postgres Flexible Servers (Preview) includes support for Databases, Functions and Stored Procedures
+
 ### Changed
 - Postgres Single Server defaults to version "11"
+
 ### Fixed
 - [Bugs Fixed](https://github.com/microsoft/vscode-cosmosdb/milestone/26?closed=1)
 
@@ -12,8 +14,10 @@
 ### Added
 - SKU type option is now available while creating PostgreSQL servers
 - Option to select either "Provisioned throughput" or "Serverless" model while creating CosmosDB accounts
+
 ### Changed
 - Icons updated to match VS Code's theme. Install new product icon themes [here](https://marketplace.visualstudio.com/search?term=tag%3Aproduct-icon-theme&target=VSCode)
+
 ### Fixed
 - [Bugs Fixed](https://github.com/microsoft/vscode-cosmosdb/milestone/30?closed=1)
 


### PR DESCRIPTION
Currently looks like this on the build/release...
![image](https://user-images.githubusercontent.com/17537419/126690876-87092fa7-5f03-408d-a882-422f2ad3064e.png)

