### PR TITLE
Replace Promise.all with Promise.allSettled when deleting test RGs

### DIFF
--- a/test/nightly/global.resource.test.ts
+++ b/test/nightly/global.resource.test.ts
@@ -64,7 +64,8 @@ suiteTeardown(async function (this: Mocha.Context): Promise<void> {
 
 async function deleteResourceGroups(): Promise<void> {
     const rmClient: ResourceManagementClient = createAzureClient([await createTestActionContext(), testAccount.getSubscriptionContext()], ResourceManagementClient);
-    await Promise.all(resourceGroupsToDelete.map(async resourceGroup => {
+    // Promise.allSettled resolves when all of the provided Promises resolve or reject.
+    await Promise.allSettled(resourceGroupsToDelete.map(async resourceGroup => {
         if (await rmClient.resourceGroups.checkExistence(resourceGroup)) {
             console.log(`Deleting resource group "${resourceGroup}"...`);
             await rmClient.resourceGroups.beginDeleteMethod(resourceGroup);

--- a/test/nightly/global.resource.test.ts
+++ b/test/nightly/global.resource.test.ts
@@ -25,7 +25,7 @@ export enum AccountApi {
 
 suiteSetup(async function (this: Mocha.Context): Promise<void> {
     if (longRunningTestsEnabled) {
-        this.timeout(20 * 60 * 1000);
+        this.timeout(40 * 60 * 1000);
         testAccount = new TestAzureAccount(vscode);
         await testAccount.signIn();
         ext.azureAccountTreeItem = new AzureAccountTreeItemWithAttached(testAccount);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "outDir": "out",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "ES2020.Promise"
         ],
         "sourceMap": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Attempt to mitigate leftover resource groups from test runs.

[`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) - method returns a promise that resolves after all of the given promises have either fulfilled or rejected. Whereas `Promise.all` resolves after any of the given promises fulfill or reject. So now even if one of the promises rejects, it doesn't stop all of the other promises.

