### PR TITLE
Fixes opening file from Workspace view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.3",
+    "version": "0.18.2-alpha.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-cosmosdb",
-            "version": "0.18.2-alpha.3",
+            "version": "0.18.2-alpha.4",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-cosmosdb": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.3",
+    "version": "0.18.2-alpha.4",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-azuretools",
     "displayName": "Azure Databases",

--- a/src/DatabasesFileSystem.ts
+++ b/src/DatabasesFileSystem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtItemQuery, AzExtItemUriParts, AzExtTreeFileSystem, AzExtTreeItem, DialogResponses, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import { AzExtItemQuery, AzExtItemUriParts, AzExtTreeDataProvider, AzExtTreeFileSystem, AzExtTreeItem, DialogResponses, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { Collection, Db } from "mongodb";
 import { basename, dirname } from 'path';
 import { FileStat, FileType, MessageItem, Uri, workspace } from "vscode";
@@ -24,9 +24,13 @@ export interface IEditableTreeItem extends AzExtTreeItem {
 }
 
 export class DatabasesFileSystem extends AzExtTreeFileSystem<IEditableTreeItem> {
-    public static scheme: string = 'azureDatabases';
-    public scheme: string = DatabasesFileSystem.scheme;
+    public scheme: string;
     private _showSaveConfirmation: boolean = true;
+
+    public constructor(tree: AzExtTreeDataProvider, scheme: string) {
+        super(tree);
+        this.scheme = scheme;
+    }
 
     public async statImpl(context: IActionContext, node: IEditableTreeItem): Promise<FileStat> {
         const size: number = Buffer.byteLength(await node.getFileContent(context));

--- a/src/DatabasesFileSystem.ts
+++ b/src/DatabasesFileSystem.ts
@@ -24,6 +24,8 @@ export interface IEditableTreeItem extends AzExtTreeItem {
 }
 
 export class DatabasesFileSystem extends AzExtTreeFileSystem<IEditableTreeItem> {
+    public static appScheme = 'azureDatabases';
+    public static workspaceScheme = 'azureDatabasesWorkspace';
     public scheme: string;
     private _showSaveConfirmation: boolean = true;
 

--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -41,7 +41,7 @@ export function registerDocDBCommands(): void {
         if (!node) {
             node = <DocDBStoredProcedureTreeItem>await ext.rgApi.appResourceTree.showTreeItemPicker([DocDBStoredProcedureTreeItem.contextValue], context);
         }
-        await ext.fileSystem.showTextDocument(node);
+        await ext.getFileSystem(node).showTextDocument(node);
     }, doubleClickDebounceDelay);
     registerCommand('cosmosDB.deleteDocDBDocument', async (context: IActionContext, node?: DocDBDocumentTreeItem) => {
         const suppressCreateContext: ITreeItemPickerContext = context;

--- a/src/docdb/tree/DocDBDocumentTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentTreeItem.ts
@@ -31,7 +31,7 @@ export class DocDBDocumentTreeItem extends AzExtTreeItem implements IEditableTre
         super(parent);
         this._document = document;
         this._label = getDocumentTreeItemLabel(this._document);
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
         this.commandId = 'cosmosDB.openDocument';
     }
 
@@ -52,7 +52,7 @@ export class DocDBDocumentTreeItem extends AzExtTreeItem implements IEditableTre
 
     public async refreshImpl(): Promise<void> {
         this._label = getDocumentTreeItemLabel(this._document);
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
     }
 
     public get link(): string {

--- a/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
@@ -24,7 +24,7 @@ export class DocDBStoredProcedureTreeItem extends AzExtTreeItem implements IEdit
 
     constructor(parent: DocDBStoredProceduresTreeItem, public procedure: (StoredProcedureDefinition & Resource)) {
         super(parent);
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
         this.commandId = 'cosmosDB.openStoredProcedure';
     }
 
@@ -54,7 +54,7 @@ export class DocDBStoredProcedureTreeItem extends AzExtTreeItem implements IEdit
     }
 
     public async refreshImpl(): Promise<void> {
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
     }
 
     public async writeFileContent(_context: IActionContext, content: string): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         ext.rgApi = await getResourceGroupsApi();
         ext.rgApi.registerApplicationResourceResolver('ms-azuretools.vscode-cosmosdb', new DatabaseResolver());
         ext.rgApi.registerWorkspaceResourceProvider('ms-azuretools.vscode-cosmosdb', new DatabaseWorkspaceProvider());
-        ext.fileSystem = new DatabasesFileSystem(ext.rgApi.appResourceTree);
+        ext.fileSystem = new DatabasesFileSystem(ext.rgApi.workspaceResourceTree);
 
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider(DatabasesFileSystem.scheme, ext.fileSystem));
 
@@ -112,7 +112,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 await ext.rgApi.workspaceResourceTree.refresh(actionContext, ext.attachedAccountsNode);
             }
         });
-        registerCommand('cosmosDB.importDocument', async (actionContext: IActionContext, selectedNode: vscode.Uri | MongoCollectionTreeItem | DocDBCollectionTreeItem, uris: vscode.Uri[]) => {
+        registerCommand('cosmosDB.importDocufment', async (actionContext: IActionContext, selectedNode: vscode.Uri | MongoCollectionTreeItem | DocDBCollectionTreeItem, uris: vscode.Uri[]) => {
             if (selectedNode instanceof vscode.Uri) {
                 await importDocuments(actionContext, uris || [selectedNode], undefined);
             } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,12 +70,13 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         ext.rgApi = await getResourceGroupsApi();
         ext.rgApi.registerApplicationResourceResolver('ms-azuretools.vscode-cosmosdb', new DatabaseResolver());
         ext.rgApi.registerWorkspaceResourceProvider('ms-azuretools.vscode-cosmosdb', new DatabaseWorkspaceProvider());
-        ext.appResourceFileSystem = new DatabasesFileSystem(ext.rgApi.appResourceTree, 'azureDatabases');
-        ext.workspaceFileSystem = new DatabasesFileSystem(ext.rgApi.workspaceResourceTree, 'azureDatabasesWorkspace');
+        ext.appResourceFileSystem = new DatabasesFileSystem(ext.rgApi.appResourceTree, DatabasesFileSystem.appScheme);
+        ext.workspaceFileSystem = new DatabasesFileSystem(ext.rgApi.workspaceResourceTree, DatabasesFileSystem.workspaceScheme);
+        // figure out at call time which fileSystem to use
         ext.getFileSystem = node => node.treeDataProvider === ext.rgApi.appResourceTree ? ext.appResourceFileSystem : ext.workspaceFileSystem;
 
-        context.subscriptions.push(vscode.workspace.registerFileSystemProvider('azureDatabases', ext.appResourceFileSystem));
-        context.subscriptions.push(vscode.workspace.registerFileSystemProvider('azureDatabasesWorkspace', ext.workspaceFileSystem));
+        context.subscriptions.push(vscode.workspace.registerFileSystemProvider(DatabasesFileSystem.appScheme, ext.appResourceFileSystem));
+        context.subscriptions.push(vscode.workspace.registerFileSystemProvider(DatabasesFileSystem.workspaceScheme, ext.workspaceFileSystem));
 
         registerCommand('cosmosDB.selectSubscriptions', () => vscode.commands.executeCommand("azure-account.selectSubscriptions"));
 

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -32,7 +32,9 @@ export namespace ext {
     export let keytar: KeyTar | undefined;
     export let postgresCodeLensProvider: PostgresCodeLensProvider | undefined;
     export const prefix: string = 'azureDatabases';
-    export let fileSystem: DatabasesFileSystem;
+    export let getFileSystem: (node: AzExtTreeItem) => DatabasesFileSystem;
+    export let appResourceFileSystem: DatabasesFileSystem;
+    export let workspaceFileSystem: DatabasesFileSystem;
     export let mongoCodeLensProvider: MongoCodeLensProvider;
     export let mongoLanguageClient: MongoDBLanguageClient;
     export let rgApi: AzureHostExtensionApi;

--- a/src/mongo/MongoScrapbook.ts
+++ b/src/mongo/MongoScrapbook.ts
@@ -116,7 +116,7 @@ async function executeCommand(context: IActionContext, command: MongoCommand, re
             // NOTE: Intentionally creating a _new_ tree item rather than searching for a cached node in the tree because
             // the executed 'find' command could have a filter or projection that is not handled by a cached tree node
             const node = new MongoCollectionTreeItem(database, collection, command.argumentObjects);
-            await ext.fileSystem.showTextDocument(node, { viewColumn: vscode.ViewColumn.Beside });
+            await ext.getFileSystem(node).showTextDocument(node, { viewColumn: vscode.ViewColumn.Beside });
         } else {
             const result = await database.executeCommand(command, context);
             if (command.name === 'findOne') {
@@ -134,7 +134,7 @@ async function executeCommand(context: IActionContext, command: MongoCommand, re
                     throw new Error(localize('failedToFind', 'Failed to find collection "{0}".', collectionName));
                 }
                 const docNode = new MongoDocumentTreeItem(colNode, document);
-                await ext.fileSystem.showTextDocument(docNode, { viewColumn: vscode.ViewColumn.Beside });
+                await ext.getFileSystem(docNode).showTextDocument(docNode, { viewColumn: vscode.ViewColumn.Beside });
             } else {
                 if (readOnlyContent) {
                     await readOnlyContent.append(`${result}${EOL}${EOL}`);

--- a/src/mongo/registerMongoCommands.ts
+++ b/src/mongo/registerMongoCommands.ts
@@ -80,7 +80,7 @@ export function registerMongoCommands(): void {
         if (!node) {
             node = <MongoCollectionTreeItem>await ext.rgApi.appResourceTree.showTreeItemPicker(MongoCollectionTreeItem.contextValue, context);
         }
-        await ext.fileSystem.showTextDocument(node);
+        await ext.getFileSystem(node).showTextDocument(node);
     });
     registerCommand('cosmosDB.launchMongoShell', launchMongoShell);
     registerCommand('cosmosDB.newMongoScrapbook', async () => await vscodeUtil.showNewFile('', 'Scrapbook', '.mongo'));

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -51,7 +51,7 @@ export class MongoCollectionTreeItem extends AzExtParentTreeItem implements IEdi
             this._query = findArgs[0];
             this._projection = findArgs.length > 1 ? findArgs[1] : undefined;
         }
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
     }
 
     public async writeFileContent(context: IActionContext, content: string): Promise<void> {
@@ -83,7 +83,7 @@ export class MongoCollectionTreeItem extends AzExtParentTreeItem implements IEdi
 
         if (nodeInTree && this !== nodeInTree) {
             // Don't need to fire a changed event on the item being saved at the moment. Just the node in the tree if it's different
-            ext.fileSystem.fireChangedEvent(nodeInTree);
+            ext.getFileSystem(nodeInTree).fireChangedEvent(nodeInTree);
         }
     }
 
@@ -111,7 +111,7 @@ export class MongoCollectionTreeItem extends AzExtParentTreeItem implements IEdi
 
     public async refreshImpl(): Promise<void> {
         this._batchSize = getBatchSizeSetting();
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
     }
 
     public async refreshChildren(context: IActionContext, docs: IMongoDocument[]): Promise<void> {

--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -37,7 +37,7 @@ export class MongoDocumentTreeItem extends AzExtTreeItem implements IEditableTre
         this.document = document;
         this._label = getDocumentTreeItemLabel(this.document);
         this.commandId = 'cosmosDB.openDocument';
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
     }
 
     public get id(): string {
@@ -77,7 +77,7 @@ export class MongoDocumentTreeItem extends AzExtTreeItem implements IEditableTre
 
     public async refreshImpl(): Promise<void> {
         this._label = getDocumentTreeItemLabel(this.document);
-        ext.fileSystem.fireChangedEvent(this);
+        ext.getFileSystem(this).fireChangedEvent(this);
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {


### PR DESCRIPTION
Originally, all of the tree items were in one view, so we only had one FileSystemProvider.  In order to get the data, it would traverse the tree and find the appropriate node, and then display that in the vs code editor.  If you use today's build, you can't open any of the attached accounts documents.

Now that there are two separate views, each with their own tree, we need a FileSystemProvider for both.  However, it's tricky to know what node they clicked.  Basically, I'm looking at what the treeProvider on the node that they clicked is to figure out which provider to serve them.

`azureDatabases.update` was a weird one where it only passes in the uri.  My understanding of this command is that it should only happen on Azure resources, so I'm just assuming `appResourceFileSystem`.  It also only has 190 events so I'm not super concerned about it because I don't even know how to test it.