### PR TITLE
Fix opening files in fs by searching the proper tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.3",
+    "version": "0.18.2-alpha.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-cosmosdb",
-            "version": "0.18.2-alpha.3",
+            "version": "0.18.2-alpha.4",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-cosmosdb": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.3",
+    "version": "0.18.2-alpha.4",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-azuretools",
     "displayName": "Azure Databases",

--- a/src/DatabasesFileSystem.ts
+++ b/src/DatabasesFileSystem.ts
@@ -87,10 +87,15 @@ export class DatabasesFileSystem extends AzExtTreeFileSystem<IEditableTreeItem> 
     }
 
     protected async findItem(context: IActionContext, query: AzExtItemQuery): Promise<IEditableTreeItem | undefined> {
-        let node: IEditableTreeItem | undefined = await super.findItem(context, query);
+        let node: IEditableTreeItem | undefined = query.id.includes('cosmosDBAttachedAccounts') ?
+            await ext.rgApi.workspaceResourceTree.findTreeItem(query.id, context) :
+            await ext.rgApi.appResourceTree.findTreeItem(query.id, context);
+
         if (!node) {
             const parentId: string = dirname(query.id);
-            const parentNode: IEditableTreeItem | undefined = await ext.rgApi.appResourceTree.findTreeItem(parentId, context);
+            const parentNode: IEditableTreeItem | undefined = parentId.includes('cosmosDBAttachedAccounts') ?
+                await ext.rgApi.workspaceResourceTree.findTreeItem(parentId, context) :
+                await ext.rgApi.appResourceTree.findTreeItem(parentId, context);
             if (parentNode instanceof MongoDatabaseTreeItem) {
                 const db: Db = await parentNode.connectToDb();
                 const collectionName: string = basename(query.id);


### PR DESCRIPTION
`findItem` in AzExtFileSystemProvider is hard-coded to search `this._tree` whenever you call `findItem`.  Checking the code, the only time `this._tree` is checked is when `findItem` is called, so it makes sense to just not use the `super` method for Databases.