### PR TITLE
Hardcode experience tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.9",
+    "version": "0.18.2-alpha.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-cosmosdb",
-            "version": "0.18.2-alpha.9",
+            "version": "0.18.2-alpha.10",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-cosmosdb": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.9",
+    "version": "0.18.2-alpha.10",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-azuretools",
     "displayName": "Azure Databases",

--- a/src/AzureDBExperiences.ts
+++ b/src/AzureDBExperiences.ts
@@ -5,7 +5,6 @@
 
 import { DatabaseAccountGetResults } from '@azure/arm-cosmosdb/src/models';
 import { IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
-import { gremlinDefaultExperienceTag, mongoDefaultExperienceTag, sqlDefaultExperienceTag, tableDefaultExperienceTag } from './constants';
 import { nonNullProp } from './utils/nonNull';
 
 export enum API {
@@ -107,10 +106,10 @@ export function getExperienceQuickPickForAttached(api: API): IAzureQuickPickItem
 
 // Mongo is distinguished by having kind="MongoDB". All others have kind="GlobalDocumentDB"
 // Table and Gremlin are distinguished from SQL by their capabilities
-export const CoreExperience: Experience = { api: API.Core, longName: "Core", description: "(SQL)", shortName: "SQL", kind: DBAccountKind.GlobalDocumentDB, tag: sqlDefaultExperienceTag } as const;
-export const MongoExperience: Experience = { api: API.MongoDB, longName: "Azure Cosmos DB for MongoDB API", shortName: "MongoDB", kind: DBAccountKind.MongoDB, tag: mongoDefaultExperienceTag } as const;
-export const TableExperience: Experience = { api: API.Table, longName: "Azure Table", shortName: "Table", kind: DBAccountKind.GlobalDocumentDB, capability: 'EnableTable', tag: tableDefaultExperienceTag } as const;
-export const GremlinExperience: Experience = { api: API.Graph, longName: "Gremlin", description: "(graph)", shortName: "Gremlin", kind: DBAccountKind.GlobalDocumentDB, capability: 'EnableGremlin', tag: gremlinDefaultExperienceTag } as const;
+export const CoreExperience: Experience = { api: API.Core, longName: "Core", description: "(SQL)", shortName: "SQL", kind: DBAccountKind.GlobalDocumentDB, tag: 'Core (SQL)' } as const;
+export const MongoExperience: Experience = { api: API.MongoDB, longName: "Azure Cosmos DB for MongoDB API", shortName: "MongoDB", kind: DBAccountKind.MongoDB, tag: "Azure Cosmos DB for MongoDB API" } as const;
+export const TableExperience: Experience = { api: API.Table, longName: "Azure Table", shortName: "Table", kind: DBAccountKind.GlobalDocumentDB, capability: 'EnableTable', tag: 'Azure Table' } as const;
+export const GremlinExperience: Experience = { api: API.Graph, longName: "Gremlin", description: "(graph)", shortName: "Gremlin", kind: DBAccountKind.GlobalDocumentDB, capability: 'EnableGremlin', tag: 'Gremlin (graph)' } as const;
 const PostgresSingleExperience: Experience = { api: API.PostgresSingle, longName: "PostgreSQL Single Server", shortName: "PostgreSQLSingle" };
 const PostgresFlexibleExperience: Experience = { api: API.PostgresFlexible, longName: "PostgreSQL Flexible Server (Preview)", shortName: "PostgreSQLFlexible" };
 


### PR DESCRIPTION
Fixes #2005 

The way the compiler is loading the constants is throwing things off here.  Having constants import and use constants can cause weirdness depending on when it's loaded.

In this case, we were seeing the tags were `undefined` because the experiences were being created before all of the tags were.  We could probably move things around and fix this, but it seems a bit too high-risk of breaking other things that import these constants.