### PR TITLE
Fix broken build by removing unused code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.10",
+    "version": "0.18.2-alpha.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-cosmosdb",
-            "version": "0.18.2-alpha.10",
+            "version": "0.18.2-alpha.11",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-cosmosdb": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.10",
+    "version": "0.18.2-alpha.11",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-azuretools",
     "displayName": "Azure Databases",

--- a/src/commands/api/pickTreeItem.ts
+++ b/src/commands/api/pickTreeItem.ts
@@ -7,12 +7,10 @@ import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vs
 import { PickAppResourceOptions } from '@microsoft/vscode-azext-utils/hostapi';
 import { databaseAccountType } from '../../constants';
 import { parseDocDBConnectionString } from '../../docdb/docDBConnectionStrings';
-import { DocDBAccountTreeItem } from '../../docdb/tree/DocDBAccountTreeItem';
 import { DocDBAccountTreeItemBase } from '../../docdb/tree/DocDBAccountTreeItemBase';
 import { DocDBDatabaseTreeItem } from '../../docdb/tree/DocDBDatabaseTreeItem';
 import { DocDBDatabaseTreeItemBase } from '../../docdb/tree/DocDBDatabaseTreeItemBase';
 import { ext } from '../../extensionVariables';
-import { GraphAccountTreeItem } from '../../graph/tree/GraphAccountTreeItem';
 import { GraphDatabaseTreeItem } from '../../graph/tree/GraphDatabaseTreeItem';
 import { parseMongoConnectionString } from '../../mongo/mongoConnectionStrings';
 import { MongoAccountTreeItem } from '../../mongo/tree/MongoAccountTreeItem';
@@ -20,7 +18,6 @@ import { MongoDatabaseTreeItem } from '../../mongo/tree/MongoDatabaseTreeItem';
 import { ParsedConnectionString } from '../../ParsedConnectionString';
 import { PostgresDatabaseTreeItem } from '../../postgres/tree/PostgresDatabaseTreeItem';
 import { PostgresServerTreeItem } from '../../postgres/tree/PostgresServerTreeItem';
-import { TableAccountTreeItem } from '../../table/tree/TableAccountTreeItem';
 import { localize } from '../../utils/localize';
 import { AzureDatabasesApiType, DatabaseAccountTreeItem, DatabaseTreeItem, PickTreeItemOptions } from '../../vscode-cosmosdb.api';
 import { cacheTreeItem } from './apiCache';
@@ -28,7 +25,6 @@ import { DatabaseAccountTreeItemInternal } from './DatabaseAccountTreeItemIntern
 import { DatabaseTreeItemInternal } from './DatabaseTreeItemInternal';
 
 const databaseContextValues = [MongoDatabaseTreeItem.contextValue, DocDBDatabaseTreeItem.contextValue, GraphDatabaseTreeItem.contextValue, PostgresDatabaseTreeItem.contextValue];
-const accountContextValues = [GraphAccountTreeItem.contextValue, DocDBAccountTreeItem.contextValue, TableAccountTreeItem.contextValue, MongoAccountTreeItem.contextValue, PostgresServerTreeItem.contextValue];
 function getDatabaseContextValue(apiType: AzureDatabasesApiType): string {
     switch (apiType) {
         case 'Mongo':
@@ -44,22 +40,6 @@ function getDatabaseContextValue(apiType: AzureDatabasesApiType): string {
     }
 }
 
-function getAccountContextValue(apiType: AzureDatabasesApiType): string {
-    switch (apiType) {
-        case 'Mongo':
-            return MongoAccountTreeItem.contextValue;
-        case 'SQL':
-            return DocDBAccountTreeItem.contextValue;
-        case 'Graph':
-            return GraphAccountTreeItem.contextValue;
-        case 'Table':
-            return TableAccountTreeItem.contextValue;
-        case 'Postgres':
-            return PostgresServerTreeItem.contextValue;
-        default:
-            throw new RangeError(`Unsupported api type "${apiType}".`);
-    }
-}
 
 export async function pickTreeItem(pickTreeOptions: PickTreeItemOptions): Promise<DatabaseTreeItem | DatabaseAccountTreeItem | undefined> {
     return await callWithTelemetryAndErrorHandling('api.pickTreeItem', async (context: IActionContext) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,15 +60,15 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         context.subscriptions.push(ext.azureAccountTreeItem);
         ext.keytar = tryGetKeyTar();
 
-        registerDocDBCommands();
-        registerGraphCommands();
-        registerPostgresCommands();
-        registerMongoCommands();
-
         ext.rgApi = await getResourceGroupsApi();
         ext.rgApi.registerApplicationResourceResolver('ms-azuretools.vscode-cosmosdb', new DatabaseResolver());
         ext.rgApi.registerWorkspaceResourceProvider('ms-azuretools.vscode-cosmosdb', new DatabaseWorkspaceProvider());
         ext.fileSystem = new DatabasesFileSystem(ext.rgApi.appResourceTree);
+
+        registerDocDBCommands();
+        registerGraphCommands();
+        registerPostgresCommands();
+        registerMongoCommands();
 
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider(DatabasesFileSystem.scheme, ext.fileSystem));
 


### PR DESCRIPTION
Also re-ordered some calls in extension.ts because they relied on AppResourceTreeItem to be defined on rgApi.