### PR TITLE
Search for subNode on appResourceTree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.10",
+    "version": "0.18.2-alpha.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-cosmosdb",
-            "version": "0.18.2-alpha.10",
+            "version": "0.18.2-alpha.11",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-cosmosdb": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-cosmosdb",
-    "version": "0.18.2-alpha.10",
+    "version": "0.18.2-alpha.11",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-azuretools",
     "displayName": "Azure Databases",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,6 @@ import { DatabaseResolver } from './resolver/AppResolver';
 import { DatabaseWorkspaceProvider } from './resolver/DatabaseWorkspaceProvider';
 import { TableAccountTreeItem } from './table/tree/TableAccountTreeItem';
 import { AttachedAccountSuffix } from './tree/AttachedAccountsTreeItem';
-import { AzureAccountTreeItemWithAttached } from './tree/AzureAccountTreeItemWithAttached';
 import { SubscriptionTreeItem } from './tree/SubscriptionTreeItem';
 import { tryGetKeyTar } from './utils/keytar';
 import { localize } from './utils/localize';
@@ -56,8 +55,6 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
 
-        ext.azureAccountTreeItem = new AzureAccountTreeItemWithAttached();
-        context.subscriptions.push(ext.azureAccountTreeItem);
         ext.keytar = tryGetKeyTar();
 
         registerDocDBCommands();

--- a/src/resolver/AppResolver.ts
+++ b/src/resolver/AppResolver.ts
@@ -28,7 +28,7 @@ const resourceTypes = [
 export class DatabaseResolver implements AppResourceResolver {
     public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedDatabaseAccountResource | null | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
-            const subNode = (await ext.azureAccountTreeItem.getCachedChildren(context)).find(sub => sub.subscription.subscriptionId === subContext.subscriptionId) as SubscriptionTreeItem;
+            const subNode = await ext.rgApi.appResourceTree.findTreeItem(`/subscriptions/${subContext.subscriptionId}`, context);
             try {
                 const resourceGroupName = azureUtils.getResourceGroupFromId(nonNullProp(resource, 'id'));
                 const name = nonNullProp(resource, 'name');


### PR DESCRIPTION
Now that we have access to the rgApi, it's better to get the subNode from that tree provider rather than one that was being created exclusively just to be used by the Databases extension.

Can't actually remove it from the extensionVariables because the tests will complain.