### PR TITLE
Replace public-ip with our own util to fix CVE-2022-33987

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -44,5 +44,6 @@ export { getGlobalSetting, updateGlobalSetting } from './src/utils/settingUtils'
 export { rejectOnTimeout, valueOnTimeout } from './src/utils/timeout';
 export { getDocumentTreeItemLabel, IDisposable } from './src/utils/vscodeUtils';
 export { wrapError } from './src/utils/wrapError';
+export { getPublicIpv4 } from './src/utils/getIp'
 
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
                 "pg": "^8.3.3",
                 "pg-connection-string": "^2.3.0",
                 "pg-structure": "^6.2.0",
-                "public-ip": "^4.0.0",
                 "semver": "^7.2.2",
                 "underscore": "^1.12.1",
                 "vscode-json-languageservice": "^3.0.8",
@@ -780,25 +779,6 @@
             },
             "funding": {
                 "url": "https://ko-fi.com/killymxi"
-            }
-        },
-        "node_modules/@sindresorhus/is": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-            "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-            "dependencies": {
-                "defer-to-connect": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -2545,45 +2525,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/cacheable-request": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-            "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-            "dependencies": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^3.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^4.1.0",
-                "responselike": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/lowercase-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2861,14 +2802,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/clone-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
             }
         },
         "node_modules/clone-stats": {
@@ -3327,17 +3260,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/decompress-response": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3381,11 +3303,6 @@
             "engines": {
                 "node": ">= 0.10"
             }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
         },
         "node_modules/define-lazy-prop": {
             "version": "2.0.0",
@@ -3579,28 +3496,6 @@
             "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
             "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
         },
-        "node_modules/dns-packet": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.2.tgz",
-            "integrity": "sha512-sQN+vLwC3PvOXiCH/oHcdzML2opFeIdVh8gjjMZrM45n4dR80QF6o3AzInQy6F9Eoc0VJYog4JpQTilt4RFLYQ==",
-            "dependencies": {
-                "ip": "^1.1.5"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/dns-socket": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.0.tgz",
-            "integrity": "sha512-4XuD3z28jht3jvHbiom6fAipgG5LkjYeDLrX5OH8cbl0AtzTyUUAxGckcW8T7z0pLfBBV5qOiuC4wUEohk6FrQ==",
-            "dependencies": {
-                "dns-packet": "^5.1.2"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3678,11 +3573,6 @@
                 "readable-stream": "^2.0.2"
             }
         },
-        "node_modules/duplexer3": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-        },
         "node_modules/duplexify": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -3739,6 +3629,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -5383,17 +5274,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -5565,27 +5445,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/got": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-            "dependencies": {
-                "@sindresorhus/is": "^0.14.0",
-                "@szmarczak/http-timer": "^1.1.2",
-                "cacheable-request": "^6.0.0",
-                "decompress-response": "^3.3.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^4.1.0",
-                "lowercase-keys": "^1.0.1",
-                "mimic-response": "^1.0.1",
-                "p-cancelable": "^1.0.0",
-                "to-readable-stream": "^1.0.0",
-                "url-parse-lax": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8.6"
             }
         },
         "node_modules/graceful-fs": {
@@ -5817,11 +5676,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-        },
         "node_modules/http-proxy-agent": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -6002,19 +5856,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "node_modules/ip-regex": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-absolute": {
@@ -6239,17 +6080,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-ip": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-            "dependencies": {
-                "ip-regex": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-negated-glob": {
@@ -6535,11 +6365,6 @@
             "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
             "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ=="
         },
-        "node_modules/json-buffer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6633,14 +6458,6 @@
             "dependencies": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/keyv": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-            "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-            "dependencies": {
-                "json-buffer": "3.0.0"
             }
         },
         "node_modules/kind-of": {
@@ -6895,14 +6712,6 @@
                 "node": ">= 6.14.4"
             }
         },
-        "node_modules/lowercase-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7135,14 +6944,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/minimatch": {
@@ -7911,14 +7712,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/normalize-url": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-            "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/now-and-later": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
@@ -8135,6 +7928,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -8234,14 +8028,6 @@
             "dependencies": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
-            }
-        },
-        "node_modules/p-cancelable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/p-limit": {
@@ -8742,14 +8528,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/prepend-http": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -8794,31 +8572,6 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-        },
-        "node_modules/public-ip": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.1.tgz",
-            "integrity": "sha512-uy7G5RtP7MH9KILMX6cschB9aOxxRwFo0zv7Lf+ZXIw5IrH4EfdKQfACIwUEFilEHtkgJ9lpRfggwi1GVzN2vw==",
-            "dependencies": {
-                "dns-socket": "^4.2.0",
-                "got": "^9.6.0",
-                "is-ip": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "node_modules/pumpify": {
             "version": "1.5.1",
@@ -9223,14 +8976,6 @@
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "deprecated": "https://github.com/lydell/resolve-url#deprecated",
             "dev": true
-        },
-        "node_modules/responselike": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-            "dependencies": {
-                "lowercase-keys": "^1.0.0"
-            }
         },
         "node_modules/ret": {
             "version": "0.1.15",
@@ -10298,14 +10043,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/to-readable-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/to-regex": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -10784,17 +10521,6 @@
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
             "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
             "dev": true
-        },
-        "node_modules/url-parse-lax": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-            "dependencies": {
-                "prepend-http": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/use": {
             "version": "3.1.1",
@@ -11548,7 +11274,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/xml": {
             "version": "1.0.1",
@@ -12448,19 +12175,6 @@
             "requires": {
                 "domhandler": "^4.2.0",
                 "selderee": "^0.6.0"
-            }
-        },
-        "@sindresorhus/is": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
-        },
-        "@szmarczak/http-timer": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-            "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-            "requires": {
-                "defer-to-connect": "^1.0.1"
             }
         },
         "@tootallnate/once": {
@@ -13849,35 +13563,6 @@
                 "unset-value": "^1.0.0"
             }
         },
-        "cacheable-request": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-            "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-            "requires": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^3.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^4.1.0",
-                "responselike": "^1.0.2"
-            },
-            "dependencies": {
-                "get-stream": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                },
-                "lowercase-keys": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-                    "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-                }
-            }
-        },
         "call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -14091,14 +13776,6 @@
                 "is-plain-object": "^2.0.4",
                 "kind-of": "^6.0.2",
                 "shallow-clone": "^3.0.0"
-            }
-        },
-        "clone-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-            "requires": {
-                "mimic-response": "^1.0.0"
             }
         },
         "clone-stats": {
@@ -14450,14 +14127,6 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "decompress-response": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-            "requires": {
-                "mimic-response": "^1.0.0"
-            }
-        },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -14491,11 +14160,6 @@
             "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
             "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
             "dev": true
-        },
-        "defer-to-connect": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
         },
         "define-lazy-prop": {
             "version": "2.0.0",
@@ -14647,22 +14311,6 @@
             "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
             "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
         },
-        "dns-packet": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.2.tgz",
-            "integrity": "sha512-sQN+vLwC3PvOXiCH/oHcdzML2opFeIdVh8gjjMZrM45n4dR80QF6o3AzInQy6F9Eoc0VJYog4JpQTilt4RFLYQ==",
-            "requires": {
-                "ip": "^1.1.5"
-            }
-        },
-        "dns-socket": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.0.tgz",
-            "integrity": "sha512-4XuD3z28jht3jvHbiom6fAipgG5LkjYeDLrX5OH8cbl0AtzTyUUAxGckcW8T7z0pLfBBV5qOiuC4wUEohk6FrQ==",
-            "requires": {
-                "dns-packet": "^5.1.2"
-            }
-        },
         "doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -14719,11 +14367,6 @@
                 "readable-stream": "^2.0.2"
             }
         },
-        "duplexer3": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-        },
         "duplexify": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -14777,6 +14420,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -16065,14 +15709,6 @@
                 "has-symbols": "^1.0.1"
             }
         },
-        "get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "requires": {
-                "pump": "^3.0.0"
-            }
-        },
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -16207,24 +15843,6 @@
             "dev": true,
             "requires": {
                 "sparkles": "^1.0.0"
-            }
-        },
-        "got": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-            "requires": {
-                "@sindresorhus/is": "^0.14.0",
-                "@szmarczak/http-timer": "^1.1.2",
-                "cacheable-request": "^6.0.0",
-                "decompress-response": "^3.3.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^4.1.0",
-                "lowercase-keys": "^1.0.1",
-                "mimic-response": "^1.0.1",
-                "p-cancelable": "^1.0.0",
-                "to-readable-stream": "^1.0.0",
-                "url-parse-lax": "^3.0.0"
             }
         },
         "graceful-fs": {
@@ -16396,11 +16014,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-        },
         "http-proxy-agent": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -16530,16 +16143,6 @@
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
             "dev": true
-        },
-        "ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "ip-regex": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
         },
         "is-absolute": {
             "version": "1.0.0",
@@ -16700,14 +16303,6 @@
             "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
-            }
-        },
-        "is-ip": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-            "requires": {
-                "ip-regex": "^4.0.0"
             }
         },
         "is-negated-glob": {
@@ -16916,11 +16511,6 @@
             "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
             "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ=="
         },
-        "json-buffer": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -16999,14 +16589,6 @@
             "requires": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "keyv": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-            "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-            "requires": {
-                "json-buffer": "3.0.0"
             }
         },
         "kind-of": {
@@ -17217,11 +16799,6 @@
             "integrity": "sha512-JpjaJhIN1reaSb26SIxDGtE0uc67gPl19OMVHrr+Ggt6b/Vy60jmCtKgQBrygAH0bhRA2nkxgDvM+8QvR8r0YA==",
             "dev": true
         },
-        "lowercase-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-        },
         "lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -17411,11 +16988,6 @@
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true
-        },
-        "mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
         },
         "minimatch": {
             "version": "3.0.4",
@@ -18032,11 +17604,6 @@
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
         },
-        "normalize-url": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-            "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
-        },
         "now-and-later": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
@@ -18198,6 +17765,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -18274,11 +17842,6 @@
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
             }
-        },
-        "p-cancelable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
         },
         "p-limit": {
             "version": "2.3.0",
@@ -18662,11 +18225,6 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
         },
-        "prepend-http": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-        },
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -18705,25 +18263,6 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-        },
-        "public-ip": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/public-ip/-/public-ip-4.0.1.tgz",
-            "integrity": "sha512-uy7G5RtP7MH9KILMX6cschB9aOxxRwFo0zv7Lf+ZXIw5IrH4EfdKQfACIwUEFilEHtkgJ9lpRfggwi1GVzN2vw==",
-            "requires": {
-                "dns-socket": "^4.2.0",
-                "got": "^9.6.0",
-                "is-ip": "^3.1.0"
-            }
-        },
-        "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "pumpify": {
             "version": "1.5.1",
@@ -19050,14 +18589,6 @@
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "dev": true
-        },
-        "responselike": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-            "requires": {
-                "lowercase-keys": "^1.0.0"
-            }
         },
         "ret": {
             "version": "0.1.15",
@@ -19913,11 +19444,6 @@
                 }
             }
         },
-        "to-readable-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
-        },
         "to-regex": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -20303,14 +19829,6 @@
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
             "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
             "dev": true
-        },
-        "url-parse-lax": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-            "requires": {
-                "prepend-http": "^2.0.0"
-            }
         },
         "use": {
             "version": "3.1.1",
@@ -20900,7 +20418,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "xml": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1043,7 +1043,6 @@
         "pg": "^8.3.3",
         "pg-connection-string": "^2.3.0",
         "pg-structure": "^6.2.0",
-        "public-ip": "^4.0.0",
         "semver": "^7.2.2",
         "underscore": "^1.12.1",
         "vscode-json-languageservice": "^3.0.8",

--- a/src/postgres/commands/configurePostgresFirewall.ts
+++ b/src/postgres/commands/configurePostgresFirewall.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DialogResponses, IActionContext } from "@microsoft/vscode-azext-utils";
-import * as publicIp from 'public-ip';
 import * as vscode from 'vscode';
 import { postgresFlexibleFilter, postgresSingleFilter } from "../../constants";
 import { ext } from "../../extensionVariables";
+import { getPublicIpv4 } from "../../utils/getIp";
 import { localize } from "../../utils/localize";
 import { nonNullProp } from '../../utils/nonNull';
 import { randomUtils } from '../../utils/randomUtils';
@@ -22,7 +22,7 @@ export async function configurePostgresFirewall(context: IActionContext, treeIte
         });
     }
 
-    const ip: string = await getPublicIp();
+    const ip: string = await getPublicIp(context);
     await context.ui.showWarningMessage(
         localize('firewallRuleWillBeAdded', 'A firewall rule for your IP ({0}) will be added to server "{1}". Would you like to continue?', ip, treeItem.label),
         {
@@ -64,13 +64,13 @@ export async function setFirewallRule(context: IActionContext, treeItem: Postgre
     await treeItem.refresh(context);
 }
 
-export async function getPublicIp(): Promise<string> {
+export async function getPublicIp(context: IActionContext): Promise<string> {
     const options: vscode.ProgressOptions = {
         location: vscode.ProgressLocation.Notification,
         title: localize('gettingPublicIp', 'Getting public IP...')
     };
 
     return await vscode.window.withProgress(options, async () => {
-        return await publicIp.v4();
+        return await getPublicIpv4(context);
     });
 }

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -108,7 +108,7 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
         const serverType: PostgresServerType = nonNullProp(treeItem, 'serverType');
         const client: AbstractPostgresClient = await createAbstractPostgresClient(serverType, [context, treeItem.subscription]);
         const results: FirewallRule[] = (await uiUtils.listAllIterator(client.firewallRules.listByServer(nonNullProp(treeItem, 'resourceGroup'), nonNullProp(treeItem, 'azureName'))));
-        const publicIp: string = await getPublicIp();
+        const publicIp: string = await getPublicIp(context);
         return (results.some((value: FirewallRule) => value.startIpAddress === publicIp));
     }
 }

--- a/src/utils/getIp.ts
+++ b/src/utils/getIp.ts
@@ -13,7 +13,7 @@ export async function getPublicIpv4(context: IActionContext): Promise<string> {
     const methods: (() => Promise<string>)[] = [
         () => getPublicIpv4Dns(),
         () => getPublicIpv4Https(context, 'https://api.ipify.org/'),
-        () => getPublicIpv4Https(context, 'https://icanhazip.com/'),
+        () => getPublicIpv4Https(context, 'https://ipv4.icanhazip.com/'),
     ];
 
     let lastError: unknown;

--- a/src/utils/getIp.ts
+++ b/src/utils/getIp.ts
@@ -28,6 +28,8 @@ export async function getPublicIpv4(context: IActionContext): Promise<string> {
     throw lastError;
 }
 
+const failedToGetIp = localize('failedToGetIp', 'Failed to get public IP');
+
 async function getPublicIpv4Dns(): Promise<string> {
     const resolver = new Resolver();
     // Must use OpenDNS's name servers
@@ -41,7 +43,7 @@ async function getPublicIpv4Dns(): Promise<string> {
             }
 
             if (!isIPv4(addresses[0])) {
-                reject(localize('failedToGetIp', 'Failed to get public IP'));
+                reject(failedToGetIp);
             }
 
             resolve(addresses[0]);
@@ -58,7 +60,7 @@ async function getPublicIpv4Https(context: IActionContext, url: string): Promise
     const ip = req.bodyAsText;
 
     if (!ip || !isIPv4(ip)) {
-        throw new Error(localize('failedToGetIp', 'Failed to get public IP'));
+        throw new Error(failedToGetIp);
     }
 
     return ip;

--- a/src/utils/getIp.ts
+++ b/src/utils/getIp.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { sendRequestWithTimeout } from '@microsoft/vscode-azext-azureutils';
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { Resolver } from 'dns';
+import { isIPv4 } from 'net';
+import { localize } from './localize';
+
+export async function getPublicIpv4(context: IActionContext): Promise<string> {
+    const methods: (() => Promise<string>)[] = [
+        () => getPublicIpv4Dns(),
+        () => getPublicIpv4Https(context, 'https://api.ipify.org/'),
+        () => getPublicIpv4Https(context, 'https://icanhazip.com/'),
+    ];
+
+    let lastError: unknown;
+    for (const getIp of methods) {
+        try {
+            return await getIp();
+        } catch (e: unknown) {
+            lastError = e;
+        }
+    }
+
+    throw lastError;
+}
+
+async function getPublicIpv4Dns(): Promise<string> {
+    const resolver = new Resolver();
+    // Must use OpenDNS's name servers
+    resolver.setServers(['208.67.222.222', '208.67.220.220']);
+
+    return new Promise((resolve, reject) => {
+        resolver.resolve4('myip.opendns.com.', (err, addresses) => {
+
+            if (err) {
+                reject(err);
+            }
+
+            if (!isIPv4(addresses[0])) {
+                reject(localize('failedToGetIp', 'Failed to get public IP'));
+            }
+
+            resolve(addresses[0]);
+        });
+    });
+}
+
+async function getPublicIpv4Https(context: IActionContext, url: string): Promise<string> {
+    const req = await sendRequestWithTimeout(context, {
+        method: 'GET',
+        url,
+    }, 5000, undefined);
+
+    const ip = req.bodyAsText;
+
+    if (!ip || !isIPv4(ip)) {
+        throw new Error(localize('failedToGetIp', 'Failed to get public IP'));
+    }
+
+    return ip;
+}

--- a/test/util/getIp.test.ts
+++ b/test/util/getIp.test.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { isIPv4 } from 'net';
+import { createTestActionContext } from 'vscode-azureextensiondev';
+import { getPublicIpv4 } from '../../extension.bundle';
+
+suite("getPublicIpv4", () => {
+    test("get IP", async () => {
+        const context = await createTestActionContext();
+        const ip = await getPublicIpv4(context);
+        assert(isIPv4(ip));
+    });
+});


### PR DESCRIPTION
Fixes CVE-2022-33987 by replacing the [`public-ip`](https://www.npmjs.com/package/public-ip) package with our own util function. 

The util function uses the same methods to get the public IP as the package which are:
1. DNS via OpenDNS
2. HTTPS request to public API
