### PR TITLE
Remove Create Server command from workspace submenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -446,10 +446,6 @@
         "menus": {
             "azureDatabases.submenus.workspaceActions": [
                 {
-                    "command": "azureDatabases.createServer",
-                    "group": "2_create@1"
-                },
-                {
                     "command": "cosmosDB.attachDatabaseAccount",
                     "group": "1_attach@1"
                 }


### PR DESCRIPTION
Command breaks if you select anything in the resources view before running the command. It might be nice to be able to tell registerCommand to just ignore selected items.