### PR TITLE
Remove getCoreNodeModule from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,15 +50,7 @@ let config = dev.getDefaultWebpackConfig({
 
             /[/\\]vscode-languageserver[/\\]lib[/\\]files\.js/,
             require.resolve('./build/vscode-languageserver-files-stub.js')
-        ),
-
-        // Copy files to dist folder where the runtime can find them
-        new CopyWebpackPlugin({
-            patterns: [
-                // getCoreNodeModule.js -> dist/node_modules/getCoreNodeModule.js
-                { from: './out/src/utils/getCoreNodeModule.js', to: 'node_modules' },
-            ]
-        })
+        )
     ]
 });
 


### PR DESCRIPTION
This [PR](https://github.com/microsoft/vscode-cosmosdb/commit/ded030361a652a5b753fbf2dd6fed6bd42cf9431) missed one instance of `getCoreNodeModule` which was causing the build to fail. CTI brought to my attention that there was no extension to download in our Pipelines 😅