### PR TITLE
Add AzureAd ClientConfig

### DIFF
--- a/src/azureAccountUtils.ts
+++ b/src/azureAccountUtils.ts
@@ -8,11 +8,15 @@ import { getApiExport } from "./getExtensionApi";
 
 const azureAccountExtensionId = "ms-vscode.azure-account";
 
+type AzureSession = {
+    userId: string;
+};
+
 /**
  * @returns The userId of the signed-in azure account.
  */
 export async function getAzureAdUserId(): Promise<string | undefined> {
-    const azureAccountExport: any = await getApiExport(azureAccountExtensionId);
+    const azureAccountExport = await getApiExport(azureAccountExtensionId) as { sessions?: AzureSession[] };
     const session = azureAccountExport.sessions?.[0];
     return session?.userId;
 }
@@ -22,7 +26,7 @@ export async function getAzureAdUserId(): Promise<string | undefined> {
  */
 export function getTokenCredential(credentials: AzExtServiceClientCredentials, scope: string): () => Promise<string> {
     return async () => {
-        const getTokenResult = await credentials.getToken(scope);
+        const getTokenResult = await credentials.getToken(scope) as { token: string } | undefined;
         return getTokenResult?.token ?? "";
     };
 }

--- a/src/azureAccountUtils.ts
+++ b/src/azureAccountUtils.ts
@@ -13,12 +13,11 @@ type AzureSession = {
 };
 
 /**
- * @returns The userId of the signed-in azure account.
+ * @returns The user session of the signed-in azure account.
  */
-export async function getAzureAdUserId(): Promise<string | undefined> {
+export async function getAzureAdUserSession(): Promise<AzureSession | undefined> {
     const azureAccountExport = await getApiExport(azureAccountExtensionId) as { sessions?: AzureSession[] };
-    const session = azureAccountExport.sessions?.[0];
-    return session?.userId;
+    return azureAccountExport.sessions?.[0];
 }
 
 /**

--- a/src/azureAccountUtils.ts
+++ b/src/azureAccountUtils.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtServiceClientCredentials } from "@microsoft/vscode-azext-utils";
+import { getApiExport } from "./getExtensionApi";
+
+const azureAccountExtensionId = "ms-vscode.azure-account";
+
+/**
+ * @returns The userId of the signed-in azure account.
+ */
+export async function getAzureAdUserId(): Promise<string | undefined> {
+    const azureAccountExport: any = await getApiExport(azureAccountExtensionId);
+    const session = azureAccountExport.sessions?.[0];
+    return session?.userId;
+}
+
+/**
+ * Gets a token credential for a specified scope for the signed-in azure account.
+ */
+export function getTokenCredential(credentials: AzExtServiceClientCredentials, scope: string): () => Promise<string> {
+    return async () => {
+        const getTokenResult = await credentials.getToken(scope);
+        return getTokenResult?.token ?? "";
+    };
+}

--- a/src/azureAccountUtils.ts
+++ b/src/azureAccountUtils.ts
@@ -21,9 +21,9 @@ export async function getAzureAdUserSession(): Promise<AzureSession | undefined>
 }
 
 /**
- * Gets a token credential for a specified scope for the signed-in azure account.
+ * Gets a function that can request an access token for a specified scope for the signed-in azure account.
  */
-export function getTokenCredential(credentials: AzExtServiceClientCredentials, scope: string): () => Promise<string> {
+export function getTokenFunction(credentials: AzExtServiceClientCredentials, scope: string): () => Promise<string> {
     return async () => {
         const getTokenResult = await credentials.getToken(scope) as { token: string } | undefined;
         return getTokenResult?.token ?? "";

--- a/src/postgres/commands/checkAuthentication.ts
+++ b/src/postgres/commands/checkAuthentication.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, IParsedError, parseError } from "@microsoft/vscode-azext-utils";
 import { ClientConfig } from "pg";
-import { getAzureAdUserSession, getTokenCredential } from "../../azureAccountUtils";
+import { getAzureAdUserSession, getTokenFunction } from "../../azureAccountUtils";
 import { getClientConfigWithValidation, postgresResourceType } from "../getClientConfig";
 import { firewallNotConfiguredErrorType, invalidCredentialsErrorType } from "../postgresConstants";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
@@ -25,7 +25,7 @@ export async function checkAuthentication(context: IActionContext, treeItem: Pos
                 !!serverTreeItem.azureName,
                 treeItem.databaseName,
                 azureUserSession?.userId,
-                getTokenCredential(treeItem.subscription.credentials, postgresResourceType)
+                getTokenFunction(treeItem.subscription.credentials, postgresResourceType)
             );
         } catch (error) {
             const parsedError: IParsedError = parseError(error);

--- a/src/postgres/commands/checkAuthentication.ts
+++ b/src/postgres/commands/checkAuthentication.ts
@@ -5,7 +5,8 @@
 
 import { IActionContext, IParsedError, parseError } from "@microsoft/vscode-azext-utils";
 import { ClientConfig } from "pg";
-import { getClientConfigWithValidation } from "../getClientConfig";
+import { getAzureAdUserId, getTokenCredential } from "../../azureAccountUtils";
+import { getClientConfigWithValidation, postgresResourceType } from "../getClientConfig";
 import { firewallNotConfiguredErrorType, invalidCredentialsErrorType } from "../postgresConstants";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
 import { configurePostgresFirewall } from "./configurePostgresFirewall";
@@ -17,7 +18,15 @@ export async function checkAuthentication(context: IActionContext, treeItem: Pos
         try {
             const serverTreeItem = treeItem.parent;
             const parsedConnectionString = await serverTreeItem.getFullConnectionString();
-            clientConfig = await getClientConfigWithValidation(parsedConnectionString, serverTreeItem.serverType, !!serverTreeItem.azureName, treeItem.databaseName);
+            const azureUserId = await getAzureAdUserId();
+            clientConfig = await getClientConfigWithValidation(
+                parsedConnectionString,
+                serverTreeItem.serverType,
+                !!serverTreeItem.azureName,
+                treeItem.databaseName,
+                azureUserId,
+                getTokenCredential(treeItem.subscription.credentials, postgresResourceType)
+            );
         } catch (error) {
             const parsedError: IParsedError = parseError(error);
 

--- a/src/postgres/commands/checkAuthentication.ts
+++ b/src/postgres/commands/checkAuthentication.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, IParsedError, parseError } from "@microsoft/vscode-azext-utils";
 import { ClientConfig } from "pg";
-import { getAzureAdUserId, getTokenCredential } from "../../azureAccountUtils";
+import { getAzureAdUserSession, getTokenCredential } from "../../azureAccountUtils";
 import { getClientConfigWithValidation, postgresResourceType } from "../getClientConfig";
 import { firewallNotConfiguredErrorType, invalidCredentialsErrorType } from "../postgresConstants";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
@@ -18,13 +18,13 @@ export async function checkAuthentication(context: IActionContext, treeItem: Pos
         try {
             const serverTreeItem = treeItem.parent;
             const parsedConnectionString = await serverTreeItem.getFullConnectionString();
-            const azureUserId = await getAzureAdUserId();
+            const azureUserSession = await getAzureAdUserSession();
             clientConfig = await getClientConfigWithValidation(
                 parsedConnectionString,
                 serverTreeItem.serverType,
                 !!serverTreeItem.azureName,
                 treeItem.databaseName,
-                azureUserId,
+                azureUserSession?.userId,
                 getTokenCredential(treeItem.subscription.credentials, postgresResourceType)
             );
         } catch (error) {

--- a/src/postgres/getClientConfig.ts
+++ b/src/postgres/getClientConfig.ts
@@ -77,7 +77,7 @@ export async function getClientConfig(
             ca: serverType === PostgresServerType.Single ? [BaltimoreCyberTrustRoot, DigiCertGlobalRootG2] : [DigiCertGlobalRootCA]
         };
         const passwordClientConfig = await getUsernamePasswordClientConfig(parsedConnectionString, sslAzure, databaseName);
-        if (!!passwordClientConfig) {
+        if (passwordClientConfig) {
             clientConfig = passwordClientConfig;
         } else if (!!azureUserId && !!getToken) {
             const azureAdClientConfig = await getAzureAdClientConfig(parsedConnectionString, sslAzure, databaseName, azureUserId, getToken);

--- a/src/postgres/getClientConfig.ts
+++ b/src/postgres/getClientConfig.ts
@@ -12,6 +12,8 @@ import { PostgresServerType } from "./abstract/models";
 import { ParsedPostgresConnectionString, addDatabaseToConnectionString } from "./postgresConnectionStrings";
 import { invalidCredentialsErrorType } from "./postgresConstants";
 
+export const postgresResourceType = "https://ossrdbms-aad.database.windows.net/";
+
 /**
  * Test if the database can be connected to using the given client config.
  * @throws if the client failed to connect to the database.
@@ -46,11 +48,25 @@ async function getUsernamePasswordClientConfig(parsedConnectionString: ParsedPos
     }
 }
 
+async function getAzureAdClientConfig(
+    parsedConnectionString: ParsedPostgresConnectionString,
+    sslAzure: ConnectionOptions,
+    databaseName: string,
+    azureAdUserId: string,
+    getToken: () => Promise<string>
+): Promise<ClientConfig> {
+    const host = nonNullProp(parsedConnectionString, 'hostName');
+    const port: number = parsedConnectionString.port ? parseInt(parsedConnectionString.port) : parseInt(postgresDefaultPort);
+    return { user: azureAdUserId, password: getToken, ssl: sslAzure, host, port, database: databaseName };
+}
+
 export async function getClientConfig(
     parsedConnectionString: ParsedPostgresConnectionString,
     serverType: PostgresServerType,
     hasSubscription: boolean,
-    databaseName: string
+    databaseName: string,
+    azureUserId?: string,
+    getToken?: () => Promise<string>
 ): Promise<ClientConfig | undefined> {
     let clientConfig: ClientConfig | undefined;
     if (hasSubscription) {
@@ -61,7 +77,12 @@ export async function getClientConfig(
             ca: serverType === PostgresServerType.Single ? [BaltimoreCyberTrustRoot, DigiCertGlobalRootG2] : [DigiCertGlobalRootCA]
         };
         const passwordClientConfig = await getUsernamePasswordClientConfig(parsedConnectionString, sslAzure, databaseName);
-        clientConfig = passwordClientConfig;
+        if (!!passwordClientConfig) {
+            clientConfig = passwordClientConfig;
+        } else if (!!azureUserId && !!getToken) {
+            const azureAdClientConfig = await getAzureAdClientConfig(parsedConnectionString, sslAzure, databaseName, azureUserId, getToken);
+            clientConfig = azureAdClientConfig;
+        }
     } else {
         const connectionStringClientConfig = await getConnectionStringClientConfig(parsedConnectionString, databaseName);
         clientConfig = connectionStringClientConfig;
@@ -74,12 +95,16 @@ export async function getClientConfigWithValidation(
     parsedConnectionString: ParsedPostgresConnectionString,
     serverType: PostgresServerType,
     hasSubscription: boolean,
-    databaseName: string
+    databaseName: string,
+    azureUserId?: string,
+    getToken?: () => Promise<string>
 ): Promise<ClientConfig> {
     const clientConfig = await getClientConfig(parsedConnectionString,
         serverType,
         hasSubscription,
-        databaseName
+        databaseName,
+        azureUserId,
+        getToken
     );
 
     if (!clientConfig) {

--- a/src/postgres/getClientConfig.ts
+++ b/src/postgres/getClientConfig.ts
@@ -79,7 +79,7 @@ export async function getClientConfig(
         const passwordClientConfig = await getUsernamePasswordClientConfig(parsedConnectionString, sslAzure, databaseName);
         if (passwordClientConfig) {
             clientConfig = passwordClientConfig;
-        } else if (!!azureUserId && !!getToken) {
+        } else if (serverType === PostgresServerType.Flexible && !!azureUserId && !!getToken) {
             const azureAdClientConfig = await getAzureAdClientConfig(parsedConnectionString, sslAzure, databaseName, azureUserId, getToken);
             clientConfig = azureAdClientConfig;
         }

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -9,7 +9,7 @@ import { uiUtils } from '@microsoft/vscode-azext-azureutils';
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, IParsedError, parseError, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import { ClientConfig } from 'pg';
 import { ThemeIcon } from 'vscode';
-import { getAzureAdUserSession, getTokenCredential } from '../../azureAccountUtils';
+import { getAzureAdUserSession, getTokenFunction } from '../../azureAccountUtils';
 import { postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
@@ -69,7 +69,7 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
                 !!serverTreeItem.azureName,
                 this.databaseName,
                 azureUserSession?.userId,
-                getTokenCredential(serverTreeItem.subscription.credentials, postgresResourceType)
+                getTokenFunction(serverTreeItem.subscription.credentials, postgresResourceType)
             );
             const children: AzExtTreeItem[] = [
                 new PostgresFunctionsTreeItem(this, clientConfig),
@@ -117,7 +117,7 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
             !!serverTreeItem.azureName,
             postgresDefaultDatabase,
             azureUserSession?.userId,
-            getTokenCredential(serverTreeItem.subscription.credentials, postgresResourceType)
+            getTokenFunction(serverTreeItem.subscription.credentials, postgresResourceType)
         );
         await runPostgresQuery(clientConfig, `Drop Database ${wrapArgInQuotes(this.databaseName)};`);
     }

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -9,7 +9,7 @@ import { uiUtils } from '@microsoft/vscode-azext-azureutils';
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, IParsedError, parseError, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import { ClientConfig } from 'pg';
 import { ThemeIcon } from 'vscode';
-import { getAzureAdUserId, getTokenCredential } from '../../azureAccountUtils';
+import { getAzureAdUserSession, getTokenCredential } from '../../azureAccountUtils';
 import { postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
@@ -62,13 +62,13 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
         try {
             const serverTreeItem = this.parent;
             const parsedConnectionString = await serverTreeItem.getFullConnectionString();
-            const azureAdUserId = await getAzureAdUserId();
+            const azureUserSession = await getAzureAdUserSession();
             const clientConfig: ClientConfig = await getClientConfigWithValidation(
                 parsedConnectionString,
                 serverTreeItem.serverType,
                 !!serverTreeItem.azureName,
                 this.databaseName,
-                azureAdUserId,
+                azureUserSession?.userId,
                 getTokenCredential(serverTreeItem.subscription.credentials, postgresResourceType)
             );
             const children: AzExtTreeItem[] = [
@@ -110,13 +110,13 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
     public async deleteTreeItemImpl(): Promise<void> {
         const serverTreeItem = this.parent;
         const parsedConnectionString = await serverTreeItem.getFullConnectionString();
-        const azureAdUserId = await getAzureAdUserId();
+        const azureUserSession = await getAzureAdUserSession();
         const clientConfig = await getClientConfigWithValidation(
             parsedConnectionString,
             serverTreeItem.serverType,
             !!serverTreeItem.azureName,
             postgresDefaultDatabase,
-            azureAdUserId,
+            azureUserSession?.userId,
             getTokenCredential(serverTreeItem.subscription.credentials, postgresResourceType)
         );
         await runPostgresQuery(clientConfig, `Drop Database ${wrapArgInQuotes(this.databaseName)};`);

--- a/src/postgres/tree/PostgresServerTreeItem.ts
+++ b/src/postgres/tree/PostgresServerTreeItem.ts
@@ -10,7 +10,7 @@ import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, ICreateChildImplCon
 import { ClientConfig } from 'pg';
 import { SemVer, coerce, gte } from 'semver';
 import * as vscode from 'vscode';
-import { getAzureAdUserId, getTokenCredential } from '../../azureAccountUtils';
+import { getAzureAdUserSession, getTokenCredential } from '../../azureAccountUtils';
 import { getThemeAgnosticIconPath, postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { getSecretStorageKey } from '../../utils/getSecretStorageKey';
@@ -105,13 +105,13 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             dbNames = [this.partialConnectionString.databaseName];
         } else {
             const parsedConnectionString = await this.getFullConnectionString();
-            const azureAdUserId = await getAzureAdUserId();
+            const azureUserSession = await getAzureAdUserSession();
             const clientConfig = await getClientConfigWithValidation(
                 parsedConnectionString,
                 this.serverType,
                 !!this.azureName,
                 postgresDefaultDatabase,
-                azureAdUserId,
+                azureUserSession?.userId,
                 getTokenCredential(this.subscription.credentials, postgresResourceType)
             );
             const query = `SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;`;
@@ -155,13 +155,13 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             validateInput: (name: string) => validateDatabaseName(name, getChildrenTask)
         });
         const parsedConnectionString = await this.getFullConnectionString();
-        const azureAdUserId = await getAzureAdUserId();
+        const azureUserSession = await getAzureAdUserSession();
         const clientConfig = await getClientConfigWithValidation(
             parsedConnectionString,
             this.serverType,
             !!this.azureName,
             postgresDefaultDatabase,
-            azureAdUserId,
+            azureUserSession?.userId,
             getTokenCredential(this.subscription.credentials, postgresResourceType)
         );
         context.showCreatingTreeItem(databaseName);

--- a/src/postgres/tree/PostgresServerTreeItem.ts
+++ b/src/postgres/tree/PostgresServerTreeItem.ts
@@ -10,6 +10,7 @@ import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, ICreateChildImplCon
 import { ClientConfig } from 'pg';
 import { SemVer, coerce, gte } from 'semver';
 import * as vscode from 'vscode';
+import { getAzureAdUserId, getTokenCredential } from '../../azureAccountUtils';
 import { getThemeAgnosticIconPath, postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { getSecretStorageKey } from '../../utils/getSecretStorageKey';
@@ -17,7 +18,7 @@ import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { AbstractPostgresClient, createAbstractPostgresClient } from '../abstract/AbstractPostgresClient';
 import { PostgresAbstractServer, PostgresServerType } from '../abstract/models';
-import { getClientConfigWithValidation } from '../getClientConfig';
+import { getClientConfigWithValidation, postgresResourceType } from '../getClientConfig';
 import { ParsedPostgresConnectionString } from '../postgresConnectionStrings';
 import { runPostgresQuery, wrapArgInQuotes } from '../runPostgresQuery';
 import { PostgresDatabaseTreeItem } from './PostgresDatabaseTreeItem';
@@ -104,7 +105,15 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             dbNames = [this.partialConnectionString.databaseName];
         } else {
             const parsedConnectionString = await this.getFullConnectionString();
-            const clientConfig = await getClientConfigWithValidation(parsedConnectionString, this.serverType, !!this.azureName, postgresDefaultDatabase);
+            const azureAdUserId = await getAzureAdUserId();
+            const clientConfig = await getClientConfigWithValidation(
+                parsedConnectionString,
+                this.serverType,
+                !!this.azureName,
+                postgresDefaultDatabase,
+                azureAdUserId,
+                getTokenCredential(this.subscription.credentials, postgresResourceType)
+            );
             const query = `SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;`;
             const queryResult = await runPostgresQuery(clientConfig, query);
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
@@ -146,7 +155,15 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             validateInput: (name: string) => validateDatabaseName(name, getChildrenTask)
         });
         const parsedConnectionString = await this.getFullConnectionString();
-        const clientConfig = await getClientConfigWithValidation(parsedConnectionString, this.serverType, !!this.azureName, postgresDefaultDatabase);
+        const azureAdUserId = await getAzureAdUserId();
+        const clientConfig = await getClientConfigWithValidation(
+            parsedConnectionString,
+            this.serverType,
+            !!this.azureName,
+            postgresDefaultDatabase,
+            azureAdUserId,
+            getTokenCredential(this.subscription.credentials, postgresResourceType)
+        );
         context.showCreatingTreeItem(databaseName);
         await runPostgresQuery(clientConfig, `Create Database ${wrapArgInQuotes(databaseName)};`);
         return new PostgresDatabaseTreeItem(this, databaseName);

--- a/src/postgres/tree/PostgresServerTreeItem.ts
+++ b/src/postgres/tree/PostgresServerTreeItem.ts
@@ -10,7 +10,7 @@ import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, ICreateChildImplCon
 import { ClientConfig } from 'pg';
 import { SemVer, coerce, gte } from 'semver';
 import * as vscode from 'vscode';
-import { getAzureAdUserSession, getTokenCredential } from '../../azureAccountUtils';
+import { getAzureAdUserSession, getTokenFunction } from '../../azureAccountUtils';
 import { getThemeAgnosticIconPath, postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { getSecretStorageKey } from '../../utils/getSecretStorageKey';
@@ -112,7 +112,7 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
                 !!this.azureName,
                 postgresDefaultDatabase,
                 azureUserSession?.userId,
-                getTokenCredential(this.subscription.credentials, postgresResourceType)
+                getTokenFunction(this.subscription.credentials, postgresResourceType)
             );
             const query = `SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;`;
             const queryResult = await runPostgresQuery(clientConfig, query);
@@ -162,7 +162,7 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             !!this.azureName,
             postgresDefaultDatabase,
             azureUserSession?.userId,
-            getTokenCredential(this.subscription.credentials, postgresResourceType)
+            getTokenFunction(this.subscription.credentials, postgresResourceType)
         );
         context.showCreatingTreeItem(databaseName);
         await runPostgresQuery(clientConfig, `Create Database ${wrapArgInQuotes(databaseName)};`);

--- a/test/unit/getClientConfig.test.ts
+++ b/test/unit/getClientConfig.test.ts
@@ -85,7 +85,7 @@ describe("getClientConfig Tests", () => {
             assert(clientConfig === undefined);
         });
 
-        it("Get client config - aad", async () => {
+        it("Get client config - flexible aad", async () => {
             const parsedConnectionString = new ParsedPostgresConnectionString(
                 "",
                 {
@@ -109,6 +109,29 @@ describe("getClientConfig Tests", () => {
             assert(clientConfig?.host === "fake_host.com");
             assert(clientConfig?.port === 1234);
         });
+
+        it("Get client config - single aad", async () => {
+            const parsedConnectionString = new ParsedPostgresConnectionString(
+                "",
+                {
+                    host: "fake_host.com",
+                    port: "1234",
+                    database: "fake_database"
+                }
+            );
+            const databaseName = "fake_database_2";
+
+            const clientConfig = await getClientConfig(
+                parsedConnectionString,
+                PostgresServerType.Single,
+                true,
+                databaseName,
+                "fake_azureAd_userId",
+                async () => "fake_token"
+            );
+            assert(clientConfig === undefined);
+        });
+
 
         describe("in attachment", () => {
             it("Get client config - connection string", async () => {


### PR DESCRIPTION
When `getClientConfig` cannot create a username-password clientConfig, attempt to create an AzureAd clientConfig. For new users who have configured their Azure AD access, they won't need to enter their user name and password.