### PR TITLE
Move isFirewallRuleSet to DatabaseServerTreeItem

### DIFF
--- a/src/postgres/commands/checkAuthentication.ts
+++ b/src/postgres/commands/checkAuthentication.ts
@@ -34,7 +34,7 @@ export async function checkAuthentication(context: IActionContext, treeItem: Pos
                 await enterPostgresCredentials(context, treeItem.parent);
 
                 // Need to configure firewall only for Azure Subscritption accounts
-            } else if (treeItem.parent.resourceGroup && (parsedError.errorType === firewallNotConfiguredErrorType || (parsedError.errorType === 'ETIMEDOUT' && !(await treeItem.isFirewallRuleSet(context, treeItem.parent))))) {
+            } else if (treeItem.parent.resourceGroup && (parsedError.errorType === firewallNotConfiguredErrorType || (parsedError.errorType === 'ETIMEDOUT' && !(await treeItem.parent.isFirewallRuleSet(context))))) {
                 await configurePostgresFirewall(context, treeItem.parent);
             } else {
                 throw error;

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -115,13 +115,4 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
         );
         await runPostgresQuery(clientConfig, `Drop Database ${wrapArgInQuotes(this.databaseName)};`);
     }
-
-    // // Flexible servers throw a generic 'ETIMEDOUT' error instead of the firewall-specific error, so we have to check the firewall rules
-    // public async isFirewallRuleSet(context: IActionContext, treeItem: PostgresServerTreeItem): Promise<boolean> {
-    //     const serverType: PostgresServerType = nonNullProp(treeItem, 'serverType');
-    //     const client: AbstractPostgresClient = await createAbstractPostgresClient(serverType, [context, treeItem.subscription]);
-    //     const results: FirewallRule[] = (await uiUtils.listAllIterator(client.firewallRules.listByServer(nonNullProp(treeItem, 'resourceGroup'), nonNullProp(treeItem, 'azureName'))));
-    //     const publicIp: string = await getPublicIp(context);
-    //     return (results.some((value: FirewallRule) => value.startIpAddress === publicIp));
-    // }
 }


### PR DESCRIPTION
`isFirewallRuleSet` should be a concept of the server tree item since it only collaborates with members of a server tree item.