### PR TITLE
Automatic retry PostgreSQL available client configs

### DIFF
--- a/src/postgres/commands/checkAuthentication.ts
+++ b/src/postgres/commands/checkAuthentication.ts
@@ -5,9 +5,8 @@
 
 import { IActionContext, IParsedError, parseError } from "@microsoft/vscode-azext-utils";
 import { ClientConfig } from "pg";
-import { getAzureAdUserSession, getTokenFunction } from "../../azureAccountUtils";
-import { getClientConfigWithValidation, postgresResourceType } from "../getClientConfig";
 import { firewallNotConfiguredErrorType, invalidCredentialsErrorType } from "../postgresConstants";
+import { PostgresClientConfigFactory } from "../tree/ClientConfigFactory";
 import { PostgresDatabaseTreeItem } from "../tree/PostgresDatabaseTreeItem";
 import { configurePostgresFirewall } from "./configurePostgresFirewall";
 import { enterPostgresCredentials } from "./enterPostgresCredentials";
@@ -16,17 +15,7 @@ export async function checkAuthentication(context: IActionContext, treeItem: Pos
     let clientConfig: ClientConfig | undefined;
     while (!clientConfig) {
         try {
-            const serverTreeItem = treeItem.parent;
-            const parsedConnectionString = await serverTreeItem.getFullConnectionString();
-            const azureUserSession = await getAzureAdUserSession();
-            clientConfig = await getClientConfigWithValidation(
-                parsedConnectionString,
-                serverTreeItem.serverType,
-                !!serverTreeItem.azureName,
-                treeItem.databaseName,
-                azureUserSession?.userId,
-                getTokenFunction(treeItem.subscription.credentials, postgresResourceType)
-            );
+            clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(treeItem.parent, treeItem.databaseName);
         } catch (error) {
             const parsedError: IParsedError = parseError(error);
 

--- a/src/postgres/getClientConfig.ts
+++ b/src/postgres/getClientConfig.ts
@@ -21,7 +21,7 @@ export type PostgresClientConfigType = keyof PostgresClientConfigs;
  * Test if the database can be connected to using the given client config.
  * @throws if the client failed to connect to the database.
  */
-export async function testClientConfig(clientConfig: ClientConfig) {
+export async function testClientConfig(clientConfig: ClientConfig): Promise<void> {
     const client = new Client(clientConfig);
     try {
         await client.connect();
@@ -71,7 +71,7 @@ export async function getClientConfigs(
     azureUserId?: string,
     getToken?: () => Promise<string>
 ): Promise<PostgresClientConfigs> {
-    let clientConfigs: PostgresClientConfigs = {
+    const clientConfigs: PostgresClientConfigs = {
         password: undefined,
         azureAd: undefined,
         connectionString: undefined

--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -32,7 +32,6 @@ export class PostgresClientConfigFactory {
 
         const clientConfigTypeOrder: PostgresClientConfigType[] = ["azureAd", "password", "connectionString"];
 
-        // @todo: Add telemetry to figure out the distribution of client config types.
         for (const clientConfigType of clientConfigTypeOrder) {
             const clientConfig: ClientConfig | undefined = clientConfigs[clientConfigType];
             if (!clientConfig) {

--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { callWithTelemetryAndErrorHandling } from "@microsoft/vscode-azext-utils";
 import { ClientConfig } from "pg";
 import { getAzureAdUserSession, getTokenFunction } from "../../azureAccountUtils";
 import { localize } from "../../utils/localize";
@@ -39,7 +40,12 @@ export class PostgresClientConfigFactory {
             }
 
             try {
-                await testClientConfig(clientConfig);
+                await callWithTelemetryAndErrorHandling<void>("postgreSQL.testClientConfig", async (context) => {
+                    context.errorHandling.rethrow = true;
+                    context.errorHandling.suppressDisplay = true;
+                    context.telemetry.properties.clientConfigType = clientConfigType;
+                    await testClientConfig(clientConfig);
+                });
                 return clientConfig;
             } catch (error) {
                 // If the client config failed during test, skip and try the next available one.

--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -29,11 +29,7 @@ export class PostgresClientConfigFactory {
             getTokenFunction(treeItem.subscription.credentials, postgresResourceType)
         );
 
-        // @todo: Get this value from setting
-        const preferAzureAd = false;
-        const clientConfigTypeOrder: PostgresClientConfigType[] = preferAzureAd ?
-            ["azureAd", "password", "connectionString"] :
-            ["password", "azureAd", "connectionString"];
+        const clientConfigTypeOrder: PostgresClientConfigType[] = ["azureAd", "password", "connectionString"];
 
         // @todo: Add telemetry to figure out the distribution of client config types.
         for (const clientConfigType of clientConfigTypeOrder) {

--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ClientConfig } from "pg";
+import { getAzureAdUserSession, getTokenFunction } from "../../azureAccountUtils";
+import { localize } from "../../utils/localize";
+import { PostgresClientConfigType, getClientConfigs, testClientConfig } from "../getClientConfig";
+import { invalidCredentialsErrorType } from "../postgresConstants";
+import { PostgresServerTreeItem } from "./PostgresServerTreeItem";
+
+export const postgresResourceType = "https://ossrdbms-aad.database.windows.net/";
+
+/**
+ * Creates an object that can be used to execute a postgres query with connection test and telemetry.
+ */
+export class PostgresClientConfigFactory {
+    public static async getClientConfigFromNode(treeItem: PostgresServerTreeItem, databaseName: string): Promise<ClientConfig> {
+        const parsedConnectionString = await treeItem.getFullConnectionString();
+        const azureUserSession = await getAzureAdUserSession();
+
+        const clientConfigs = await getClientConfigs(
+            parsedConnectionString,
+            treeItem.serverType,
+            !!treeItem.azureName,
+            databaseName,
+            azureUserSession?.userId,
+            getTokenFunction(treeItem.subscription.credentials, postgresResourceType)
+        );
+
+        // @todo: Get this value from setting
+        const preferAzureAd = false;
+        const clientConfigTypeOrder: PostgresClientConfigType[] = preferAzureAd ?
+            ["azureAd", "password", "connectionString"] :
+            ["password", "azureAd", "connectionString"];
+
+        // @todo: Add telemetry to figure out the distribution of client config types.
+        for (const clientConfigType of clientConfigTypeOrder) {
+            const clientConfig: ClientConfig | undefined = clientConfigs[clientConfigType];
+            if (!clientConfig) {
+                continue;
+            }
+
+            try {
+                await testClientConfig(clientConfig);
+                return clientConfig;
+            } catch (error) {
+                // If the client config failed during test, skip and try the next available one.
+            }
+        }
+
+        throw {
+            message: localize('mustEnterCredentials', 'Must enter credentials to connect to server.'),
+            code: invalidCredentialsErrorType
+        };
+    }
+}

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -90,12 +90,7 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
     }
 
     public async deleteTreeItemImpl(): Promise<void> {
-        try {
-            const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this.parent, this.databaseName);
-            await runPostgresQuery(clientConfig, `Drop Database ${wrapArgInQuotes(this.databaseName)};`);
-        } catch (error) {
-            // @todo: Figure out if we need to do error handling here.
-            throw error;
-        }
+        const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this.parent, this.databaseName);
+        await runPostgresQuery(clientConfig, `Drop Database ${wrapArgInQuotes(this.databaseName)};`);
     }
 }

--- a/src/postgres/tree/PostgresServerTreeItem.ts
+++ b/src/postgres/tree/PostgresServerTreeItem.ts
@@ -10,7 +10,6 @@ import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, ICreateChildImplCon
 import { ClientConfig } from 'pg';
 import { SemVer, coerce, gte } from 'semver';
 import * as vscode from 'vscode';
-import { getAzureAdUserSession, getTokenFunction } from '../../azureAccountUtils';
 import { getThemeAgnosticIconPath, postgresDefaultDatabase } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { getSecretStorageKey } from '../../utils/getSecretStorageKey';
@@ -19,9 +18,9 @@ import { nonNullProp } from '../../utils/nonNull';
 import { AbstractPostgresClient, createAbstractPostgresClient } from '../abstract/AbstractPostgresClient';
 import { PostgresAbstractServer, PostgresServerType } from '../abstract/models';
 import { getPublicIp } from '../commands/configurePostgresFirewall';
-import { getClientConfigWithValidation, postgresResourceType } from '../getClientConfig';
 import { ParsedPostgresConnectionString } from '../postgresConnectionStrings';
 import { runPostgresQuery, wrapArgInQuotes } from '../runPostgresQuery';
+import { PostgresClientConfigFactory } from './ClientConfigFactory';
 import { PostgresDatabaseTreeItem } from './PostgresDatabaseTreeItem';
 import { PostgresFunctionTreeItem } from './PostgresFunctionTreeItem';
 import { PostgresFunctionsTreeItem } from './PostgresFunctionsTreeItem';
@@ -105,20 +104,16 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
         } else if (this.partialConnectionString.databaseName) {
             dbNames = [this.partialConnectionString.databaseName];
         } else {
-            const parsedConnectionString = await this.getFullConnectionString();
-            const azureUserSession = await getAzureAdUserSession();
-            const clientConfig = await getClientConfigWithValidation(
-                parsedConnectionString,
-                this.serverType,
-                !!this.azureName,
-                postgresDefaultDatabase,
-                azureUserSession?.userId,
-                getTokenFunction(this.subscription.credentials, postgresResourceType)
-            );
-            const query = `SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;`;
-            const queryResult = await runPostgresQuery(clientConfig, query);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-            dbNames = queryResult.rows.map(db => db?.datname);
+            try {
+                const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this, postgresDefaultDatabase);
+                const query = `SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;`;
+                const queryResult = await runPostgresQuery(clientConfig, query);
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+                dbNames = queryResult.rows.map(db => db?.datname);
+            } catch (error) {
+                // @todo: Figure out if we need to handle the error here.
+                throw error;
+            }
         }
 
         return this.createTreeItemsWithErrorHandling(
@@ -155,19 +150,15 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             stepName: 'createPostgresDatabase',
             validateInput: (name: string) => validateDatabaseName(name, getChildrenTask)
         });
-        const parsedConnectionString = await this.getFullConnectionString();
-        const azureUserSession = await getAzureAdUserSession();
-        const clientConfig = await getClientConfigWithValidation(
-            parsedConnectionString,
-            this.serverType,
-            !!this.azureName,
-            postgresDefaultDatabase,
-            azureUserSession?.userId,
-            getTokenFunction(this.subscription.credentials, postgresResourceType)
-        );
-        context.showCreatingTreeItem(databaseName);
-        await runPostgresQuery(clientConfig, `Create Database ${wrapArgInQuotes(databaseName)};`);
-        return new PostgresDatabaseTreeItem(this, databaseName);
+        try {
+            const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this, databaseName);
+            context.showCreatingTreeItem(databaseName);
+            await runPostgresQuery(clientConfig, `Create Database ${wrapArgInQuotes(databaseName)};`);
+            return new PostgresDatabaseTreeItem(this, databaseName);
+        } catch (error) {
+            // @todo: Figure out if we need to handle the error here.
+            throw error;
+        }
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {

--- a/src/postgres/tree/PostgresServerTreeItem.ts
+++ b/src/postgres/tree/PostgresServerTreeItem.ts
@@ -104,16 +104,11 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
         } else if (this.partialConnectionString.databaseName) {
             dbNames = [this.partialConnectionString.databaseName];
         } else {
-            try {
-                const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this, postgresDefaultDatabase);
-                const query = `SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;`;
-                const queryResult = await runPostgresQuery(clientConfig, query);
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-                dbNames = queryResult.rows.map(db => db?.datname);
-            } catch (error) {
-                // @todo: Figure out if we need to handle the error here.
-                throw error;
-            }
+            const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this, postgresDefaultDatabase);
+            const query = `SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false;`;
+            const queryResult = await runPostgresQuery(clientConfig, query);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+            dbNames = queryResult.rows.map(db => db?.datname);
         }
 
         return this.createTreeItemsWithErrorHandling(
@@ -150,15 +145,10 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             stepName: 'createPostgresDatabase',
             validateInput: (name: string) => validateDatabaseName(name, getChildrenTask)
         });
-        try {
-            const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this, databaseName);
-            context.showCreatingTreeItem(databaseName);
-            await runPostgresQuery(clientConfig, `Create Database ${wrapArgInQuotes(databaseName)};`);
-            return new PostgresDatabaseTreeItem(this, databaseName);
-        } catch (error) {
-            // @todo: Figure out if we need to handle the error here.
-            throw error;
-        }
+        const clientConfig = await PostgresClientConfigFactory.getClientConfigFromNode(this, databaseName);
+        context.showCreatingTreeItem(databaseName);
+        await runPostgresQuery(clientConfig, `Create Database ${wrapArgInQuotes(databaseName)};`);
+        return new PostgresDatabaseTreeItem(this, databaseName);
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {


### PR DESCRIPTION
`getClientConfig` is replaced by `getClientConfigs` which will now return all the client config objects that may work. Existing test cases for `getClientConfig` are rewritten to cover `getClientConfigs`. A new factory method is implemented to handle creating a working client config from a database tree item. The factory method will try all the "available" client configs and return the first one that actually works. A telemetry event is added to monitor the result of each client config test.