### PR TITLE
Fix attached database authentication

### DIFF
--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -21,13 +21,21 @@ export class PostgresClientConfigFactory {
         const parsedConnectionString = await treeItem.getFullConnectionString();
         const azureUserSession = await getAzureAdUserSession();
 
+        let hasSubscription: boolean = false;
+        let tokenFunction: (() => Promise<string>) | undefined = undefined;
+        try {
+            const subscription = treeItem.subscription;
+            tokenFunction = getTokenFunction(subscription.credentials, postgresResourceType);
+        } catch (error) {
+            hasSubscription = false;
+        }
         const clientConfigs = await getClientConfigs(
             parsedConnectionString,
             treeItem.serverType,
-            !!treeItem.azureName,
+            hasSubscription,
             databaseName,
             azureUserSession?.userId,
-            getTokenFunction(treeItem.subscription.credentials, postgresResourceType)
+            tokenFunction
         );
 
         const clientConfigTypeOrder: PostgresClientConfigType[] = ["azureAd", "password", "connectionString"];

--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -25,6 +25,7 @@ export class PostgresClientConfigFactory {
         let tokenFunction: (() => Promise<string>) | undefined = undefined;
         try {
             const subscription = treeItem.subscription;
+            hasSubscription = true;
             tokenFunction = getTokenFunction(subscription.credentials, postgresResourceType);
         } catch (error) {
             hasSubscription = false;


### PR DESCRIPTION
`treeItem.subscription` will throw if `treeItem` is an attached database node.