### PR TITLE
Delete a no-longer-working getIp function

### DIFF
--- a/src/postgres/commands/configurePostgresFirewall.ts
+++ b/src/postgres/commands/configurePostgresFirewall.ts
@@ -65,12 +65,5 @@ export async function setFirewallRule(context: IActionContext, treeItem: Postgre
 }
 
 export async function getPublicIp(context: IActionContext): Promise<string> {
-    const options: vscode.ProgressOptions = {
-        location: vscode.ProgressLocation.Notification,
-        title: localize('gettingPublicIp', 'Getting public IP...')
-    };
-
-    return await vscode.window.withProgress(options, async () => {
-        return await getPublicIpv4(context);
-    });
+    return await getPublicIpv4(context);
 }

--- a/src/utils/getIp.ts
+++ b/src/utils/getIp.ts
@@ -5,7 +5,6 @@
 
 import { sendRequestWithTimeout } from '@microsoft/vscode-azext-azureutils';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { Resolver } from 'dns';
 import { isIPv4 } from 'net';
 import { localize } from './localize';
 
@@ -20,7 +19,6 @@ export function isIpInRanges(ip: string, ranges: { startIpAddress: string, endIp
 
 export async function getPublicIpv4(context: IActionContext): Promise<string> {
     const methods: (() => Promise<string>)[] = [
-        () => getPublicIpv4Dns(),
         () => getPublicIpv4Https(context, 'https://api.ipify.org/'),
         () => getPublicIpv4Https(context, 'https://ipv4.icanhazip.com/'),
     ];
@@ -45,27 +43,6 @@ function ipToNum(ip: string) {
             .map(d => ("000" + d).substring(-3))
             .join("")
     );
-}
-
-async function getPublicIpv4Dns(): Promise<string> {
-    const resolver = new Resolver();
-    // Must use OpenDNS's name servers
-    resolver.setServers(['208.67.222.222', '208.67.220.220']);
-
-    return new Promise((resolve, reject) => {
-        resolver.resolve4('myip.opendns.com.', (err, addresses) => {
-
-            if (err) {
-                reject(err);
-            }
-
-            if (!isIPv4(addresses[0])) {
-                reject(failedToGetIp);
-            }
-
-            resolve(addresses[0]);
-        });
-    });
 }
 
 async function getPublicIpv4Https(context: IActionContext, url: string): Promise<string> {


### PR DESCRIPTION
Mitigates https://github.com/microsoft/vscode-cosmosdb/issues/2168

Based on my testing, the deleted function no longer work for getting IP. Besides, I get rid of the notification for getting public IP since it's supposed to be a quick operation and doesn't convey much useful information to user.