### PR TITLE
Stop dealing with IP address if it has been configured once

### DIFF
--- a/src/postgres/postgresConstants.ts
+++ b/src/postgres/postgresConstants.ts
@@ -5,3 +5,4 @@
 
 export const invalidCredentialsErrorType: string = '28P01';
 export const firewallNotConfiguredErrorType: string = '28000';
+export const timeoutErrorType = 'ETIMEDOUT';

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -8,7 +8,7 @@ import { AzExtParentTreeItem, AzExtTreeItem, createContextValue, GenericTreeItem
 import { ThemeIcon } from 'vscode';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
-import { invalidCredentialsErrorType } from '../postgresConstants';
+import { firewallNotConfiguredErrorType, invalidCredentialsErrorType } from '../postgresConstants';
 import { runPostgresQuery, wrapArgInQuotes } from '../runPostgresQuery';
 import { PostgresClientConfigFactory } from './ClientConfigFactory';
 import { PostgresFunctionsTreeItem } from './PostgresFunctionsTreeItem';
@@ -90,6 +90,9 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
                 });
                 credentialsTreeItem.commandArgs = [this.parent];
                 return [credentialsTreeItem];
+            } else if (this.parent.azureName && parsedError.errorType === firewallNotConfiguredErrorType) {
+                void context.ui.showWarningMessage(localize('couldNotConnect', 'Could not connect to "{0}": {1}', this.parent.label, parsedError.message), { stepName: 'loadPostgresDatabases' });
+                return [];
             } else {
                 throw error;
             }


### PR DESCRIPTION
resolves: https://github.com/microsoft/vscode-cosmosdb/issues/2179

Our old mechanism has a major flaw that it cannot guarantee getting the correct IP address visible to the database server. In the worst case, we may enter a dead loop as below:

1. Get IP from 3rd party services, named IP_0
2. Attempt to connect to database server, which sees a different IP address, named IP_1
3. IP_1 is not in the firewall rules
4. We prompt to add IP_0 to firewall rules, because this is the IP we assume we are using
5. We retry still get a firewall error

This PR let the extension stop trying to reconfigure it for the user if we have tested (and configured) it once. Instead, it directs the user to go to Azure Portal which ensures the correct IP address can be added to the firewall rules. In the network panel for the database server, Azure Portal offers the capability to add the current IP, which seems to be always accurate, to the firewall rules.