### PR TITLE
Mitigate unsupported throughput config

### DIFF
--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -90,12 +90,14 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Contai
             const minThroughput = isFixed ? minThroughputFixed : minThroughputPartitioned;
             const throughput: number = Number(await context.ui.showInputBox({
                 value: minThroughput.toString(),
-                prompt: `Initial throughput capacity, between ${minThroughput} and ${maxThroughput} inclusive in increments of ${throughputStepSize}`,
+                prompt: `Initial throughput capacity, between ${minThroughput} and ${maxThroughput} inclusive in increments of ${throughputStepSize}. Enter 0 if the account doesn't support throughput.`,
                 stepName: 'throughputCapacity',
                 validateInput: (input: string) => validateThroughput(isFixed, input)
             }));
 
-            options.offerThroughput = throughput;
+            if (throughput !== 0) {
+                options.offerThroughput = throughput;
+            }
         }
 
         context.showCreatingTreeItem(containerName);
@@ -129,6 +131,10 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Contai
 }
 
 function validateThroughput(isFixed: boolean, input: string): string | undefined | null {
+    if (input === "0") {
+        return undefined;
+    }
+
     try {
         const minThroughput = isFixed ? minThroughputFixed : minThroughputPartitioned;
         const value = Number(input);


### PR DESCRIPTION
resolves #2075.

We don't know the "serverless" property on the attached database accounts. The change work arounds that issue by letting people optionally skip setting the throughput property so they can create collections when the database account is serverless.