### PR TITLE
Remove Azure Account from extension dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1109,7 +1109,6 @@
         "vscode-uri": "^1.0.1"
     },
     "extensionDependencies": [
-        "ms-vscode.azure-account",
         "ms-azuretools.vscode-azureresourcegroups"
     ]
 }


### PR DESCRIPTION
The Azure Resources extension A. can bring in AA if it needs, and B. no longer has AA as a dependency