### PR TITLE
Enable OAuth for CosmosDB resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-cosmosdb": "^15.0.0",
                 "@azure/arm-postgresql": "^6.0.0",
                 "@azure/arm-postgresql-flexible": "^5.0.0",
-                "@azure/cosmos": "^3.6.3",
+                "@azure/cosmos": "^4.0.0",
                 "@microsoft/vscode-azext-azureutils": "^2.0.2",
                 "@microsoft/vscode-azext-utils": "^2.1.0",
                 "antlr4ts": "^0.4.1-alpha.0",
@@ -34,6 +34,7 @@
             },
             "devDependencies": {
                 "@azure/arm-resources": "^4.0.0",
+                "@azure/identity": "^4.0.0",
                 "@microsoft/eslint-config-azuretools": "^0.1.0",
                 "@microsoft/vscode-azext-dev": "^2.0.2",
                 "@types/copy-webpack-plugin": "^6.4.0",
@@ -1282,12 +1283,14 @@
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@azure/cosmos": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.15.1.tgz",
-            "integrity": "sha512-Pjn9CcoipUSsm/r9ZqAeyrqIQnh0AOeIDwYs/3pcLumK9ezCVFrfeLoOfas4Dm2X8bwL+/9puKAM55LJEaQwWg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.0.0.tgz",
+            "integrity": "sha512-/Z27p1+FTkmjmm8jk90zi/HrczPHw2t8WecFnsnTe4xGocWl0Z4clP0YlLUTJPhRLWYa5upwD9rMvKJkS1f1kg==",
             "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
                 "@azure/core-rest-pipeline": "^1.2.0",
+                "@azure/core-tracing": "^1.0.0",
                 "debug": "^4.1.1",
                 "fast-json-stable-stringify": "^2.1.0",
                 "jsbi": "^3.1.3",
@@ -1299,13 +1302,73 @@
                 "uuid": "^8.3.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@azure/cosmos/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "node_modules/@azure/cosmos/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@azure/identity": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.0.0.tgz",
+            "integrity": "sha512-gtPYxIL0kI39Dw4t3HvlbfhOdXqKD2MqDgynlklF0j728j51dcKgRo6FLX0QzpBw/1gGfLxjMXqq3nKOSQ2lmA==",
+            "dev": true,
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.5.0",
+                "@azure/core-client": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.0.0",
+                "@azure/logger": "^1.0.0",
+                "@azure/msal-browser": "^3.5.0",
+                "@azure/msal-node": "^2.5.1",
+                "events": "^3.0.0",
+                "jws": "^4.0.0",
+                "open": "^8.0.0",
+                "stoppable": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/identity/node_modules/jwa": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+            "dev": true,
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/@azure/identity/node_modules/jws": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+            "dev": true,
+            "dependencies": {
+                "jwa": "^2.0.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/@azure/identity/node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "dev": true
         },
         "node_modules/@azure/logger": {
             "version": "1.0.4",
@@ -1354,6 +1417,59 @@
                 "tunnel": "0.0.6",
                 "uuid": "^8.3.2",
                 "xml2js": "^0.5.0"
+            }
+        },
+        "node_modules/@azure/ms-rest-js/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@azure/msal-browser": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.5.0.tgz",
+            "integrity": "sha512-2NtMuel4CI3UEelCPKkNRXgKzpWEX48fvxIvPz7s0/sTcCaI08r05IOkH2GkXW+czUOtuY6+oGafJCpumnjRLg==",
+            "dev": true,
+            "dependencies": {
+                "@azure/msal-common": "14.4.0"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-common": {
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.4.0.tgz",
+            "integrity": "sha512-ffCymScQuMKVj+YVfwNI52A5Tu+uiZO2eTf+c+3TXxdAssks4nokJhtr+uOOMxH0zDi6d1OjFKFKeXODK0YLSg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-node": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.5.1.tgz",
+            "integrity": "sha512-PsPRISqCG253HQk1cAS7eJW7NWTbnBGpG+vcGGz5z4JYRdnM2EIXlj1aBpXCdozenEPtXEVvHn2ELleW1w82nQ==",
+            "dev": true,
+            "dependencies": {
+                "@azure/msal-common": "14.4.0",
+                "jsonwebtoken": "^9.0.0",
+                "uuid": "^8.3.0"
+            },
+            "engines": {
+                "node": "16|| 18 || 20"
+            }
+        },
+        "node_modules/@azure/msal-node/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -4444,6 +4560,12 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "dev": true
+        },
         "node_modules/buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -5506,6 +5628,15 @@
             "dependencies": {
                 "is-plain-object": "^2.0.1",
                 "object.defaults": "^1.1.0"
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/electron-to-chromium": {
@@ -8372,6 +8503,28 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "node_modules/jsonwebtoken": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+            "dev": true,
+            "dependencies": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
         "node_modules/jszip": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -8389,6 +8542,27 @@
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
             "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
             "dev": true
+        },
+        "node_modules/jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dev": true,
+            "dependencies": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dev": true,
+            "dependencies": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -8592,6 +8766,48 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        },
+        "node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "dev": true
+        },
+        "node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "dev": true
+        },
+        "node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "dev": true
+        },
+        "node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "dev": true
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "dev": true
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "dev": true
         },
         "node_modules/lodash.set": {
             "version": "4.3.2",
@@ -11225,9 +11441,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -11786,6 +12002,16 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stoppable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4",
+                "npm": ">=6"
             }
         },
         "node_modules/stream-browserify": {
@@ -12877,6 +13103,8 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -14802,12 +15030,14 @@
             }
         },
         "@azure/cosmos": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-3.15.1.tgz",
-            "integrity": "sha512-Pjn9CcoipUSsm/r9ZqAeyrqIQnh0AOeIDwYs/3pcLumK9ezCVFrfeLoOfas4Dm2X8bwL+/9puKAM55LJEaQwWg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.0.0.tgz",
+            "integrity": "sha512-/Z27p1+FTkmjmm8jk90zi/HrczPHw2t8WecFnsnTe4xGocWl0Z4clP0YlLUTJPhRLWYa5upwD9rMvKJkS1f1kg==",
             "requires": {
+                "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
                 "@azure/core-rest-pipeline": "^1.2.0",
+                "@azure/core-tracing": "^1.0.0",
                 "debug": "^4.1.1",
                 "fast-json-stable-stringify": "^2.1.0",
                 "jsbi": "^3.1.3",
@@ -14823,6 +15053,62 @@
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
                     "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
+            }
+        },
+        "@azure/identity": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.0.0.tgz",
+            "integrity": "sha512-gtPYxIL0kI39Dw4t3HvlbfhOdXqKD2MqDgynlklF0j728j51dcKgRo6FLX0QzpBw/1gGfLxjMXqq3nKOSQ2lmA==",
+            "dev": true,
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.5.0",
+                "@azure/core-client": "^1.4.0",
+                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.0.0",
+                "@azure/logger": "^1.0.0",
+                "@azure/msal-browser": "^3.5.0",
+                "@azure/msal-node": "^2.5.1",
+                "events": "^3.0.0",
+                "jws": "^4.0.0",
+                "open": "^8.0.0",
+                "stoppable": "^1.1.0",
+                "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "jwa": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+                    "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-equal-constant-time": "1.0.1",
+                        "ecdsa-sig-formatter": "1.0.11",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "jws": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+                    "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+                    "dev": true,
+                    "requires": {
+                        "jwa": "^2.0.0",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "tslib": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+                    "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+                    "dev": true
                 }
             }
         },
@@ -14872,6 +15158,48 @@
                 "tunnel": "0.0.6",
                 "uuid": "^8.3.2",
                 "xml2js": "^0.5.0"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
+            }
+        },
+        "@azure/msal-browser": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.5.0.tgz",
+            "integrity": "sha512-2NtMuel4CI3UEelCPKkNRXgKzpWEX48fvxIvPz7s0/sTcCaI08r05IOkH2GkXW+czUOtuY6+oGafJCpumnjRLg==",
+            "dev": true,
+            "requires": {
+                "@azure/msal-common": "14.4.0"
+            }
+        },
+        "@azure/msal-common": {
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.4.0.tgz",
+            "integrity": "sha512-ffCymScQuMKVj+YVfwNI52A5Tu+uiZO2eTf+c+3TXxdAssks4nokJhtr+uOOMxH0zDi6d1OjFKFKeXODK0YLSg==",
+            "dev": true
+        },
+        "@azure/msal-node": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.5.1.tgz",
+            "integrity": "sha512-PsPRISqCG253HQk1cAS7eJW7NWTbnBGpG+vcGGz5z4JYRdnM2EIXlj1aBpXCdozenEPtXEVvHn2ELleW1w82nQ==",
+            "dev": true,
+            "requires": {
+                "@azure/msal-common": "14.4.0",
+                "jsonwebtoken": "^9.0.0",
+                "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
             }
         },
         "@babel/code-frame": {
@@ -17475,6 +17803,12 @@
             "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
             "dev": true
         },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "dev": true
+        },
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -18303,6 +18637,15 @@
             "requires": {
                 "is-plain-object": "^2.0.1",
                 "object.defaults": "^1.1.0"
+            }
+        },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
             }
         },
         "electron-to-chromium": {
@@ -20488,6 +20831,24 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "jsonwebtoken": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+            "dev": true,
+            "requires": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            }
+        },
         "jszip": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -20505,6 +20866,27 @@
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
             "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
             "dev": true
+        },
+        "jwa": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "dev": true,
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jws": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "dev": true,
+            "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
         },
         "kind-of": {
             "version": "6.0.3",
@@ -20668,6 +21050,48 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "dev": true
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "dev": true
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "dev": true
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "dev": true
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "dev": true
+        },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "dev": true
         },
         "lodash.set": {
             "version": "4.3.2",
@@ -22658,9 +23082,9 @@
             "integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
         },
         "semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -23118,6 +23542,12 @@
                     }
                 }
             }
+        },
+        "stoppable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+            "dev": true
         },
         "stream-browserify": {
             "version": "3.0.0",
@@ -23985,7 +24415,9 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "optional": true,
+            "peer": true
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1075,6 +1075,11 @@
                     "type": "integer",
                     "default": 8081,
                     "description": "Port to use when connecting to a CosmosDB Emulator instance"
+                },
+                "azureDatabases.testCosmosAuth": {
+                    "type": "boolean",
+                    "description": "Whether to only use Auth credential for Cosmos DB resources",
+                    "default": false
                 }
             }
         }
@@ -1101,6 +1106,7 @@
     },
     "devDependencies": {
         "@azure/arm-resources": "^4.0.0",
+        "@azure/identity": "^4.0.0",
         "@microsoft/eslint-config-azuretools": "^0.1.0",
         "@microsoft/vscode-azext-dev": "^2.0.2",
         "@types/copy-webpack-plugin": "^6.4.0",
@@ -1134,7 +1140,7 @@
         "@azure/arm-cosmosdb": "^15.0.0",
         "@azure/arm-postgresql": "^6.0.0",
         "@azure/arm-postgresql-flexible": "^5.0.0",
-        "@azure/cosmos": "^3.6.3",
+        "@azure/cosmos": "^4.0.0",
         "@microsoft/vscode-azext-azureutils": "^2.0.2",
         "@microsoft/vscode-azext-utils": "^2.1.0",
         "antlr4ts": "^0.4.1-alpha.0",

--- a/src/commands/api/DatabaseAccountTreeItemInternal.ts
+++ b/src/commands/api/DatabaseAccountTreeItemInternal.ts
@@ -5,6 +5,7 @@
 
 import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
 import { API } from '../../AzureDBExperiences';
+import { CosmosDBKeyCredential } from '../../docdb/getCosmosClient';
 import { DocDBAccountTreeItemBase } from '../../docdb/tree/DocDBAccountTreeItemBase';
 import { ext } from '../../extensionVariables';
 import { ParsedMongoConnectionString } from '../../mongo/mongoConnectionStrings';
@@ -57,10 +58,15 @@ export class DatabaseAccountTreeItemInternal implements DatabaseAccountTreeItem 
 
     public get docDBData(): { masterKey: string; documentEndpoint: string; } | undefined {
         if (this._accountNode instanceof DocDBAccountTreeItemBase) {
-            return {
-                documentEndpoint: this._accountNode.root.endpoint,
-                masterKey: this._accountNode.root.masterKey
-            };
+            const keyCred = this._accountNode.root.credentials.filter((cred): cred is CosmosDBKeyCredential => cred.type === 'key')[0];
+            if (keyCred) {
+                return {
+                    documentEndpoint: this._accountNode.root.endpoint,
+                    masterKey: keyCred.key
+                };
+            } else {
+                return undefined;
+            }
         } else {
             return undefined;
         }

--- a/src/docdb/NoSqlCodeLensProvider.ts
+++ b/src/docdb/NoSqlCodeLensProvider.ts
@@ -21,7 +21,7 @@ export type NoSqlQueryConnection = {
     databaseId: string;
     containerId: string;
     endpoint: string;
-    masterKey: string;
+    masterKey?: string;
     isEmulator: boolean;
 };
 

--- a/src/docdb/getCosmosClient.ts
+++ b/src/docdb/getCosmosClient.ts
@@ -4,15 +4,51 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CosmosClient } from "@azure/cosmos";
+import { AzureDeveloperCliCredential } from "@azure/identity";
 import { appendExtensionUserAgent } from "@microsoft/vscode-azext-utils";
 import * as https from "https";
 import * as vscode from 'vscode';
 import { ext } from "../extensionVariables";
 
-export function getCosmosClient(endpoint: string, key: string, isEmulator: boolean | undefined): CosmosClient {
+export type CosmosDBKeyCredential = {
+    type: "key";
+    key: string;
+};
+export type CosmosDBAuthCredential = {
+    type: "auth";
+}
+export type CosmosDBCredential = CosmosDBKeyCredential | CosmosDBAuthCredential;
+
+export function getCosmosClient(
+    endpoint: string,
+    cosmosDBCredentials: CosmosDBCredential[],
+    isEmulator: boolean | undefined,
+): CosmosClient {
     const vscodeStrictSSL: boolean | undefined = vscode.workspace.getConfiguration().get<boolean>(ext.settingsKeys.vsCode.proxyStrictSSL);
     const enableEndpointDiscovery: boolean | undefined = vscode.workspace.getConfiguration().get<boolean>(ext.settingsKeys.enableEndpointDiscovery);
     const connectionPolicy = { enableEndpointDiscovery: (enableEndpointDiscovery === undefined) ? true : enableEndpointDiscovery };
-    return new CosmosClient({ endpoint, key, userAgentSuffix: appendExtensionUserAgent(), agent: new https.Agent({ rejectUnauthorized: isEmulator ? !isEmulator : vscodeStrictSSL }), connectionPolicy: connectionPolicy });
 
+    const keyCred = cosmosDBCredentials.filter((cred): cred is CosmosDBKeyCredential => cred.type === "key")[0];
+    const authCred = cosmosDBCredentials.filter((cred): cred is CosmosDBAuthCredential => cred.type === "auth")[0];
+
+    // @todo: Add telemetry to see how many code paths use key vs. auth
+    if (keyCred) {
+        return new CosmosClient({
+            endpoint,
+            key: keyCred.key,
+            userAgentSuffix: appendExtensionUserAgent(),
+            agent: new https.Agent({ rejectUnauthorized: isEmulator ? !isEmulator : vscodeStrictSSL }),
+            connectionPolicy: connectionPolicy
+        });
+    } else if (authCred) {
+        return new CosmosClient({
+            endpoint,
+            aadCredentials: new AzureDeveloperCliCredential(),
+            userAgentSuffix: appendExtensionUserAgent(),
+            agent: new https.Agent({ rejectUnauthorized: isEmulator ? !isEmulator : vscodeStrictSSL }),
+            connectionPolicy: connectionPolicy
+        });
+    } else {
+        throw Error("No credentials available to create CosmosClient");
+    }
 }

--- a/src/docdb/tree/DocDBAccountTreeItemBase.ts
+++ b/src/docdb/tree/DocDBAccountTreeItemBase.ts
@@ -12,7 +12,7 @@ import { deleteCosmosDBAccount } from '../../commands/deleteDatabaseAccount/dele
 import { SERVERLESS_CAPABILITY_NAME, getThemeAgnosticIconPath } from '../../constants';
 import { nonNullProp } from '../../utils/nonNull';
 import { rejectOnTimeout } from '../../utils/timeout';
-import { getCosmosClient } from '../getCosmosClient';
+import { CosmosDBCredential, CosmosDBKeyCredential, getCosmosClient } from '../getCosmosClient';
 import { DocDBTreeItemBase } from './DocDBTreeItemBase';
 
 /**
@@ -24,22 +24,38 @@ export abstract class DocDBAccountTreeItemBase extends DocDBTreeItemBase<Databas
     public readonly childTypeLabel: string = "Database";
 
 
-    constructor(parent: AzExtParentTreeItem, id: string, label: string, endpoint: string, masterKey: string, isEmulator: boolean | undefined, readonly databaseAccount?: DatabaseAccountGetResults) {
+    constructor(
+        parent: AzExtParentTreeItem,
+        id: string,
+        label: string,
+        endpoint: string,
+        credentials: CosmosDBCredential[],
+        isEmulator: boolean | undefined,
+        readonly databaseAccount?: DatabaseAccountGetResults
+    ) {
         super(parent);
         this.id = id;
         this.label = label;
         this.root = {
             endpoint,
-            masterKey,
+            credentials,
             isEmulator,
-            getCosmosClient: () => getCosmosClient(endpoint, masterKey, isEmulator)
+            getCosmosClient: () => getCosmosClient(endpoint, credentials, isEmulator)
         };
 
-        this.valuesToMask.push(id, endpoint, masterKey);
+        const keys = credentials
+            .map((cred) => cred.type === "key" ? cred.key : undefined)
+            .filter((value): value is string => value !== undefined);
+        this.valuesToMask.push(id, endpoint, ...keys);
     }
 
     public get connectionString(): string {
-        return `AccountEndpoint=${this.root.endpoint};AccountKey=${this.root.masterKey}`;
+        const firstKey = this.root.credentials.filter((cred): cred is CosmosDBKeyCredential => cred.type === "key")[0];
+        if (firstKey) {
+            return `AccountEndpoint=${this.root.endpoint};AccountKey=${firstKey}`;
+        } else {
+            return `AccountEndpoint=${this.root.endpoint}`;
+        }
     }
 
     public get iconPath(): string | vscode.Uri | { light: string | vscode.Uri; dark: string | vscode.Uri } {

--- a/src/docdb/tree/DocDBDocumentTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentTreeItem.ts
@@ -106,7 +106,7 @@ export class DocDBDocumentTreeItem extends AzExtTreeItem implements IEditableTre
         }
     }
 
-    private getPartitionKeyValue(): string | undefined {
+    private getPartitionKeyValue(): string | number | undefined {
         const partitionKey = this.parent.parent.partitionKey;
         if (!partitionKey) { //Fixed collections -> no partitionKeyValue
             return undefined;
@@ -115,7 +115,7 @@ export class DocDBDocumentTreeItem extends AzExtTreeItem implements IEditableTre
         if (fields[0] === '') {
             fields.shift();
         }
-        let value;
+        let value: any;
         for (const field of fields) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             value = value ? value[field] : this.document[field];
@@ -123,7 +123,10 @@ export class DocDBDocumentTreeItem extends AzExtTreeItem implements IEditableTre
                 return '';
             }
         }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
+        if (typeof value !== "string" && typeof value !== "number" && typeof value !== "undefined") {
+            throw new Error("Invalid data type for partition key");
+        }
         return value;
     }
 

--- a/src/docdb/tree/IDocDBTreeRoot.ts
+++ b/src/docdb/tree/IDocDBTreeRoot.ts
@@ -5,10 +5,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CosmosClient } from "@azure/cosmos";
+import { CosmosDBCredential } from "../getCosmosClient";
 
 export interface IDocDBTreeRoot {
     endpoint: string;
-    masterKey: string;
+    credentials: CosmosDBCredential[];
     isEmulator: boolean | undefined;
     getCosmosClient(): CosmosClient;
 }

--- a/src/graph/tree/GraphAccountTreeItem.ts
+++ b/src/graph/tree/GraphAccountTreeItem.ts
@@ -6,9 +6,10 @@
 import { DatabaseAccountGetResults } from '@azure/arm-cosmosdb/src/models';
 import { DatabaseDefinition, Resource } from '@azure/cosmos';
 import { AzExtParentTreeItem } from '@microsoft/vscode-azext-utils';
+import { CosmosDBCredential } from '../../docdb/getCosmosClient';
 import { DocDBAccountTreeItemBase } from '../../docdb/tree/DocDBAccountTreeItemBase';
-import { DocDBStoredProceduresTreeItem } from '../../docdb/tree/DocDBStoredProceduresTreeItem';
 import { DocDBStoredProcedureTreeItem } from '../../docdb/tree/DocDBStoredProcedureTreeItem';
+import { DocDBStoredProceduresTreeItem } from '../../docdb/tree/DocDBStoredProceduresTreeItem';
 import { IGremlinEndpoint } from '../../vscode-cosmosdbgraph.api';
 import { GraphCollectionTreeItem } from './GraphCollectionTreeItem';
 import { GraphDatabaseTreeItem } from './GraphDatabaseTreeItem';
@@ -18,8 +19,17 @@ export class GraphAccountTreeItem extends DocDBAccountTreeItemBase {
     public static contextValue: string = "cosmosDBGraphAccount";
     public contextValue: string = GraphAccountTreeItem.contextValue;
 
-    constructor(parent: AzExtParentTreeItem, id: string, label: string, documentEndpoint: string, private _gremlinEndpoint: IGremlinEndpoint | undefined, masterKey: string, isEmulator: boolean | undefined, readonly databaseAccount?: DatabaseAccountGetResults) {
-        super(parent, id, label, documentEndpoint, masterKey, isEmulator, databaseAccount);
+    constructor(
+        parent: AzExtParentTreeItem,
+        id: string,
+        label: string,
+        documentEndpoint: string,
+        private _gremlinEndpoint: IGremlinEndpoint | undefined,
+        credentials: CosmosDBCredential[],
+        isEmulator: boolean | undefined,
+        readonly databaseAccount?: DatabaseAccountGetResults
+    ) {
+        super(parent, id, label, documentEndpoint, credentials, isEmulator, databaseAccount);
         this.valuesToMask.push(documentEndpoint);
         if (_gremlinEndpoint) {
             this.valuesToMask.push(_gremlinEndpoint.host);

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -10,6 +10,7 @@ import { API, getExperienceFromApi, getExperienceQuickPick, getExperienceQuickPi
 import { removeTreeItemFromCache } from '../commands/api/apiCache';
 import { emulatorPassword, isWindows } from '../constants';
 import { parseDocDBConnectionString } from '../docdb/docDBConnectionStrings';
+import { CosmosDBCredential } from '../docdb/getCosmosClient';
 import { DocDBAccountTreeItem } from '../docdb/tree/DocDBAccountTreeItem';
 import { DocDBAccountTreeItemBase } from '../docdb/tree/DocDBAccountTreeItemBase';
 import { ext } from '../extensionVariables';
@@ -332,15 +333,17 @@ export class AttachedAccountsTreeItem extends AzExtParentTreeItem {
             const parsedCS = parseDocDBConnectionString(connectionString);
 
             label = label || `${parsedCS.accountId} (${getExperienceFromApi(api).shortName})`;
+
+            const credentials: CosmosDBCredential[] = [{ type: "key", key: parsedCS.masterKey }];
             switch (api) {
                 case API.Table:
-                    treeItem = new TableAccountTreeItem(this, parsedCS.accountId, label, parsedCS.documentEndpoint, parsedCS.masterKey, isEmulator);
+                    treeItem = new TableAccountTreeItem(this, parsedCS.accountId, label, parsedCS.documentEndpoint, credentials, isEmulator);
                     break;
                 case API.Graph:
-                    treeItem = new GraphAccountTreeItem(this, parsedCS.accountId, label, parsedCS.documentEndpoint, undefined, parsedCS.masterKey, isEmulator);
+                    treeItem = new GraphAccountTreeItem(this, parsedCS.accountId, label, parsedCS.documentEndpoint, undefined, credentials, isEmulator);
                     break;
                 case API.Core:
-                    treeItem = new DocDBAccountTreeItem(this, parsedCS.accountId, label, parsedCS.documentEndpoint, parsedCS.masterKey, isEmulator);
+                    treeItem = new DocDBAccountTreeItem(this, parsedCS.accountId, label, parsedCS.documentEndpoint, credentials, isEmulator);
                     break;
                 default:
                     throw new Error(`Unexpected defaultExperience "${api}".`);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -5,10 +5,11 @@
 
 import { CosmosDBManagementClient } from '@azure/arm-cosmosdb';
 import { DatabaseAccountGetResults, DatabaseAccountListKeysResult } from '@azure/arm-cosmosdb/src/models';
-import { getResourceGroupFromId, ILocationWizardContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItemBase, uiUtils } from '@microsoft/vscode-azext-azureutils';
+import { ILocationWizardContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItemBase, getResourceGroupFromId, uiUtils } from '@microsoft/vscode-azext-azureutils';
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, AzureWizardPromptStep, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { API, Experience, getExperienceLabel, tryGetExperience } from '../AzureDBExperiences';
+import { CosmosDBCredential } from '../docdb/getCosmosClient';
 import { DocDBAccountTreeItem } from "../docdb/tree/DocDBAccountTreeItem";
 import { ext } from '../extensionVariables';
 import { tryGetGremlinEndpointFromAzure } from '../graph/gremlinEndpoints';
@@ -16,7 +17,7 @@ import { GraphAccountTreeItem } from "../graph/tree/GraphAccountTreeItem";
 import { MongoAccountTreeItem } from '../mongo/tree/MongoAccountTreeItem';
 import { PostgresAbstractServer, PostgresServerType } from '../postgres/abstract/models';
 import { IPostgresServerWizardContext } from '../postgres/commands/createPostgresServer/IPostgresServerWizardContext';
-import { createPostgresConnectionString, ParsedPostgresConnectionString, parsePostgresConnectionString } from '../postgres/postgresConnectionStrings';
+import { ParsedPostgresConnectionString, createPostgresConnectionString, parsePostgresConnectionString } from '../postgres/postgresConnectionStrings';
 import { PostgresServerTreeItem } from '../postgres/tree/PostgresServerTreeItem';
 import { TableAccountTreeItem } from "../table/tree/TableAccountTreeItem";
 import { createActivityContext } from '../utils/activityUtils';
@@ -133,19 +134,33 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             // Use the default connection string
             return new MongoAccountTreeItem(parent, id, label, connectionString.toString(), isEmulator, databaseAccount);
         } else {
-            const keyResult: DatabaseAccountListKeysResult = await client.databaseAccounts.listKeys(resourceGroup, name);
-            const primaryMasterKey: string = nonNullProp(keyResult, 'primaryMasterKey');
+            let keyResult: DatabaseAccountListKeysResult | undefined;
+            try {
+                keyResult = await client.databaseAccounts.listKeys(resourceGroup, name);
+            } catch (error) {
+                // If the client failed to list keys, proceed without using keys.
+            }
+            let keyCred = keyResult?.primaryMasterKey ? {
+                type: "key",
+                key: keyResult.primaryMasterKey
+            } : undefined;
+            const testCosmosAuth = vscode.workspace.getConfiguration().get<boolean>("azureDatabases.testCosmosAuth");
+            if (testCosmosAuth) {
+                keyCred = undefined;
+            }
+            const authCred = { type: "auth" };
+            const credentials = [keyCred, authCred].filter((cred): cred is CosmosDBCredential => cred !== undefined);
             switch (experience && experience.api) {
                 case "Table":
-                    return new TableAccountTreeItem(parent, id, label, documentEndpoint, primaryMasterKey, isEmulator, databaseAccount);
+                    return new TableAccountTreeItem(parent, id, label, documentEndpoint, credentials, isEmulator, databaseAccount);
                 case "Graph": {
                     const gremlinEndpoint = await tryGetGremlinEndpointFromAzure(client, resourceGroup, name);
-                    return new GraphAccountTreeItem(parent, id, label, documentEndpoint, gremlinEndpoint, primaryMasterKey, isEmulator, databaseAccount);
+                    return new GraphAccountTreeItem(parent, id, label, documentEndpoint, gremlinEndpoint, credentials, isEmulator, databaseAccount);
                 }
                 case "Core":
                 default:
                     // Default to DocumentDB, the base type for all Cosmos DB Accounts
-                    return new DocDBAccountTreeItem(parent, id, label, documentEndpoint, primaryMasterKey, isEmulator, databaseAccount);
+                    return new DocDBAccountTreeItem(parent, id, label, documentEndpoint, credentials, isEmulator, databaseAccount);
 
             }
         }


### PR DESCRIPTION
Enable OAuth for CosmosDB resources using Azure CLI for logging in. To use OAuth to authenticate
- Download Azure CLI
- Login via Azure CLI
- Add the path to Azure CLI install location to the setting.
- Restart the extension

The master key will still be used if the user is able to list it. Those who want to only give OAuth access to the resources will need to configure the permission to prevent listing master keys.