### PR TITLE
Improve warning message on firewall error

### DIFF
--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -68,8 +68,17 @@ export class PostgresClientConfigFactory {
                 } else if (parsedError.errorType === firewallNotConfiguredErrorType || parsedError.errorType === timeoutErrorType) {
                     // The time out error are common when the firewall rules doesn't grant access from the current IP address.
                     // If the client is blocked by the firewall, let the user go to Azure Portal to grant access.
+                    const publicIp = PostgresServerTreeItem.ipAddr;
+                    let ipMessage: string;
+                    if (publicIp !== undefined) {
+                        ipMessage = localize("ipAlreadyInFirewall", "The IP address '{0}' already exists in the firewall rules.", publicIp);
+                    } else {
+                        // The code should never reach here but handle it just in case.
+                        ipMessage = "Your IP address is already in the firewall rules.";
+                    }
+                    const configureFirewallMessage = localize("mustConfigureFirewall", "Some network environments may not report the actual public-facing IP address needed to access your server. Contact your network administrator to add the actual IP address to the firewall rules.");
                     throw {
-                        message: localize("mustConfigureFirewall", 'Your IP address we tested is already in the firewall rules. Some network environments may not report the actual public-facing IP address needed to access your server. Contact your network administrator to add the actual IP address to the firewall rules.'),
+                        message: `${ipMessage} ${configureFirewallMessage}`,
                         code: firewallNotConfiguredErrorType
                     };
                 } else {

--- a/src/postgres/tree/ClientConfigFactory.ts
+++ b/src/postgres/tree/ClientConfigFactory.ts
@@ -69,7 +69,7 @@ export class PostgresClientConfigFactory {
                     // The time out error are common when the firewall rules doesn't grant access from the current IP address.
                     // If the client is blocked by the firewall, let the user go to Azure Portal to grant access.
                     throw {
-                        message: localize("mustConfigureFirewall", 'Must configure firewall from Azure Portal to grant access.'),
+                        message: localize("mustConfigureFirewall", 'Your IP address we tested is already in the firewall rules. Some network environments may not report the actual public-facing IP address needed to access your server. Contact your network administrator to add the actual IP address to the firewall rules.'),
                         code: firewallNotConfiguredErrorType
                     };
                 } else {

--- a/src/postgres/tree/PostgresServerTreeItem.ts
+++ b/src/postgres/tree/PostgresServerTreeItem.ts
@@ -38,6 +38,8 @@ interface IPersistedServer {
 export class PostgresServerTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = "postgresServer";
     public static serviceName: string = "ms-azuretools.vscode-azuredatabases.postgresPasswords";
+    public static ipAddr: string | undefined;
+
     public readonly contextValue: string = PostgresServerTreeItem.contextValue;
     public readonly childTypeLabel: string = "Database";
     public readonly serverType: PostgresServerType;
@@ -225,6 +227,10 @@ export class PostgresServerTreeItem extends AzExtParentTreeItem {
             const client: AbstractPostgresClient = await createAbstractPostgresClient(serverType, [context, this.subscription]);
             const results: SingleModels.FirewallRule[] = (await uiUtils.listAllIterator(client.firewallRules.listByServer(nonNullProp(this, 'resourceGroup'), nonNullProp(this, 'azureName'))));
             const publicIp: string = await getPublicIp(context);
+
+            // Cache/update the ip address for potential error reporting.
+            PostgresServerTreeItem.ipAddr = publicIp;
+
             return isIpInRanges(publicIp, results);
         } catch (error) {
             // We cannot get the firewall rules from attached databases because we cannot get the subscription object.


### PR DESCRIPTION
The original warning message is not 100% correct since Azure Portal doesn't guarantee that it can add the actual IP address to the firewall rules. The string is a slightly modified version of the Portal string indicating what to do for the next step.