### PR TITLE
feature: cosmosDB triggers basic support

### DIFF
--- a/package.json
+++ b/package.json
@@ -882,6 +882,11 @@
                 },
                 {
                     "command": "azureDatabases.refresh",
+                    "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBTriggersGroup",
+                    "group": "2@1"
+                },
+                {
+                    "command": "azureDatabases.refresh",
                     "when": "view =~ /azureWorkspace/ && viewItem =~ /cosmosDBDocumentServer(?![a-z])/i",
                     "group": "3@2"
                 },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "onCommand:cosmosDB.createDocDBDatabase",
         "onCommand:cosmosDB.createDocDBDocument",
         "onCommand:cosmosDB.createDocDBStoredProcedure",
+        "onCommand:cosmosDB.createDocDBTrigger",
         "onCommand:cosmosDB.createGraph",
         "onCommand:cosmosDB.createGraphDatabase",
         "onCommand:cosmosDB.createMongoCollection",
@@ -73,6 +74,7 @@
         "onCommand:cosmosDB.openDocument",
         "onCommand:cosmosDB.openGraphExplorer",
         "onCommand:cosmosDB.openStoredProcedure",
+        "onCommand:cosmosDB.openTrigger",
         "onCommand:postgreSQL.configureFirewall",
         "onCommand:postgreSQL.connectDatabase",
         "onCommand:postgreSQL.createDatabase",
@@ -256,6 +258,11 @@
                 "title": "Create Stored Procedure..."
             },
             {
+                "category": "Core (SQL)",
+                "command": "cosmosDB.createDocDBTrigger",
+                "title": "Create Trigger..."
+            },
+            {
                 "category": "Graph (Gremlin)",
                 "command": "cosmosDB.createGraph",
                 "title": "Create Graph..."
@@ -304,6 +311,11 @@
                 "category": "Core (SQL)",
                 "command": "cosmosDB.deleteDocDBStoredProcedure",
                 "title": "Delete Stored Procedure..."
+            },
+            {
+                "category": "Core (SQL)",
+                "command": "cosmosDB.deleteDocDBTrigger",
+                "title": "Delete Trigger..."
             },
             {
                 "category": "Graph (Gremlin)",
@@ -392,6 +404,11 @@
                 "category": "Cosmos DB",
                 "command": "cosmosDB.openStoredProcedure",
                 "title": "Open Stored Procedure"
+            },
+            {
+                "category": "Cosmos DB",
+                "command": "cosmosDB.openTrigger",
+                "title": "Open Trigger"
             },
             {
                 "category": "Core (SQL)",
@@ -624,6 +641,11 @@
                     "group": "1@1"
                 },
                 {
+                    "command": "cosmosDB.createDocDBTrigger",
+                    "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBTriggersGroup",
+                    "group": "1@1"
+                },
+                {
                     "command": "cosmosDB.createDocDBCollection",
                     "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBDocumentDatabase",
                     "group": "1@1"
@@ -732,6 +754,11 @@
                     "command": "cosmosDB.executeDocDBStoredProcedure",
                     "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBStoredProcedure",
                     "group": "1@1"
+                },
+                {
+                    "command": "cosmosDB.deleteDocDBTrigger",
+                    "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBTrigger",
+                    "group": "1@2"
                 },
                 {
                     "command": "cosmosDB.deleteDocDBDatabase",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,6 +72,10 @@ export const defaultStoredProcedure =
     if (!isAccepted) throw new Error('The query was not accepted by the server.');
 };` ;
 
+export const defaultTrigger = `function trigger() {
+
+}`;
+
 export const emulatorPassword = 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==';
 
 // https://docs.mongodb.com/manual/mongo/#working-with-the-mongo-shell

--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -19,6 +19,8 @@ import { DocDBDocumentTreeItem } from "./tree/DocDBDocumentTreeItem";
 import { DocDBDocumentsTreeItem } from "./tree/DocDBDocumentsTreeItem";
 import { DocDBStoredProcedureTreeItem } from "./tree/DocDBStoredProcedureTreeItem";
 import { DocDBStoredProceduresTreeItem } from "./tree/DocDBStoredProceduresTreeItem";
+import { DocDBTriggerTreeItem } from "./tree/DocDBTriggerTreeItem";
+import { DocDBTriggersTreeItem } from "./tree/DocDBTriggersTreeItem";
 
 const nosqlLanguageId = "nosql";
 
@@ -46,13 +48,25 @@ export function registerDocDBCommands(): void {
         }
         const childNode = await node.createChild(context);
         await commands.executeCommand("cosmosDB.openStoredProcedure", childNode);
-
+    });
+    registerCommandWithTreeNodeUnwrapping('cosmosDB.createDocDBTrigger', async (context: IActionContext, node?: DocDBTriggersTreeItem) => {
+        if (!node) {
+            node = await pickDocDBAccount<DocDBTriggersTreeItem>(context, DocDBTriggersTreeItem.contextValue);
+        }
+        const childNode = await node.createChild(context);
+        await commands.executeCommand("cosmosDB.openTrigger", childNode);
     });
     registerCommandWithTreeNodeUnwrapping('cosmosDB.deleteDocDBDatabase', deleteDocDBDatabase);
     registerCommandWithTreeNodeUnwrapping('cosmosDB.deleteDocDBCollection', deleteDocDBCollection);
     registerCommandWithTreeNodeUnwrapping('cosmosDB.openStoredProcedure', async (context: IActionContext, node?: DocDBStoredProcedureTreeItem) => {
         if (!node) {
             node = await pickDocDBAccount<DocDBStoredProcedureTreeItem>(context, DocDBStoredProcedureTreeItem.contextValue);
+        }
+        await ext.fileSystem.showTextDocument(node);
+    }, doubleClickDebounceDelay);
+    registerCommandWithTreeNodeUnwrapping('cosmosDB.openTrigger', async (context: IActionContext, node?: DocDBTriggerTreeItem) => {
+        if (!node) {
+            node = await pickDocDBAccount<DocDBTriggerTreeItem>(context, DocDBTriggerTreeItem.contextValue);
         }
         await ext.fileSystem.showTextDocument(node);
     }, doubleClickDebounceDelay);
@@ -101,6 +115,15 @@ export function registerDocDBCommands(): void {
         }
 
         await node.execute(context, partitionKey, parameters);
+    });
+    registerCommandWithTreeNodeUnwrapping('cosmosDB.deleteDocDBTrigger', async (context: IActionContext, node?: DocDBTriggerTreeItem) => {
+        const suppressCreateContext: ITreeItemPickerContext = context;
+        suppressCreateContext.suppressCreatePick = true;
+        if (!node) {
+            node = await pickDocDBAccount<DocDBTriggerTreeItem>(context, DocDBTriggerTreeItem.contextValue);
+
+        }
+        await node.deleteTreeItem(context);
     });
 }
 

--- a/src/docdb/tree/DocDBCollectionTreeItem.ts
+++ b/src/docdb/tree/DocDBCollectionTreeItem.ts
@@ -7,10 +7,12 @@ import { Container, ContainerDefinition, CosmosClient, PartitionKeyDefinition, R
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, IActionContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { DocDBDatabaseTreeItem } from './DocDBDatabaseTreeItem';
-import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 import { DocDBDocumentTreeItem } from './DocDBDocumentTreeItem';
-import { DocDBStoredProceduresTreeItem } from './DocDBStoredProceduresTreeItem';
+import { DocDBDocumentsTreeItem } from './DocDBDocumentsTreeItem';
 import { DocDBStoredProcedureTreeItem } from './DocDBStoredProcedureTreeItem';
+import { DocDBStoredProceduresTreeItem } from './DocDBStoredProceduresTreeItem';
+import { DocDBTriggerTreeItem } from './DocDBTriggerTreeItem';
+import { DocDBTriggersTreeItem } from './DocDBTriggersTreeItem';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
 
 /**
@@ -19,16 +21,18 @@ import { IDocDBTreeRoot } from './IDocDBTreeRoot';
 export class DocDBCollectionTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = "cosmosDBDocumentCollection";
     public readonly contextValue: string = DocDBCollectionTreeItem.contextValue;
-    public readonly documentsTreeItem: DocDBDocumentsTreeItem;
     public readonly parent: DocDBDatabaseTreeItem;
 
+    public readonly documentsTreeItem: DocDBDocumentsTreeItem;
     private readonly _storedProceduresTreeItem: DocDBStoredProceduresTreeItem;
+    private readonly _triggersTreeItem: DocDBTriggersTreeItem;
 
     constructor(parent: DocDBDatabaseTreeItem, private _container: ContainerDefinition & Resource) {
         super(parent);
         this.parent = parent;
         this.documentsTreeItem = new DocDBDocumentsTreeItem(this);
         this._storedProceduresTreeItem = new DocDBStoredProceduresTreeItem(this);
+        this._triggersTreeItem = new DocDBTriggersTreeItem(this);
     }
 
     public get root(): IDocDBTreeRoot {
@@ -63,7 +67,7 @@ export class DocDBCollectionTreeItem extends AzExtParentTreeItem {
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
-        return [this.documentsTreeItem, this._storedProceduresTreeItem];
+        return [this.documentsTreeItem, this._storedProceduresTreeItem, this._triggersTreeItem];
     }
 
     public hasMoreChildrenImpl(): boolean {
@@ -79,6 +83,9 @@ export class DocDBCollectionTreeItem extends AzExtParentTreeItem {
                 case DocDBStoredProceduresTreeItem.contextValue:
                 case DocDBStoredProcedureTreeItem.contextValue:
                     return this._storedProceduresTreeItem;
+                case DocDBTriggersTreeItem.contextValue:
+                case DocDBTriggerTreeItem.contextValue:
+                    return this._triggersTreeItem;
                 default:
             }
         }

--- a/src/docdb/tree/DocDBTriggerTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggerTreeItem.ts
@@ -8,6 +8,7 @@ import { AzExtTreeItem, DialogResponses, IActionContext, TreeItemIconPath } from
 import * as vscode from "vscode";
 import { IEditableTreeItem } from '../../DatabasesFileSystem';
 import { ext } from '../../extensionVariables';
+import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { DocDBTriggersTreeItem, getTriggerOperation, getTriggerType } from './DocDBTriggersTreeItem';
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
@@ -86,7 +87,7 @@ export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTree
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
-        const message: string = `Are you sure you want to delete trigger '${this.label}'?`;
+        const message: string = localize("deleteCosmosTrigger", `Are you sure you want to delete trigger '{0}'?`, this.label);
         await context.ui.showWarningMessage(message, { modal: true, stepName: 'deleteTrigger' }, DialogResponses.deleteResponse);
         const client = this.root.getCosmosClient();
         await this.parent.getContainerClient(client).scripts.trigger(this.id).delete();

--- a/src/docdb/tree/DocDBTriggerTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggerTreeItem.ts
@@ -25,8 +25,8 @@ export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTree
 
     constructor(parent: DocDBTriggersTreeItem, trigger: (TriggerDefinition & Resource)) {
         super(parent);
-        ext.fileSystem.fireChangedEvent(this);
         this.trigger = trigger;
+        ext.fileSystem.fireChangedEvent(this);
         this.commandId = 'cosmosDB.openTrigger';
     }
 

--- a/src/docdb/tree/DocDBTriggerTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggerTreeItem.ts
@@ -20,11 +20,13 @@ export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTree
     public readonly contextValue: string = DocDBTriggerTreeItem.contextValue;
     public readonly cTime: number = Date.now();
     public readonly parent: DocDBTriggersTreeItem;
+    public trigger: (TriggerDefinition & Resource);
     public mTime: number = Date.now();
 
-    constructor(parent: DocDBTriggersTreeItem, public procedure: (TriggerDefinition & Resource)) {
+    constructor(parent: DocDBTriggersTreeItem, trigger: (TriggerDefinition & Resource)) {
         super(parent);
         ext.fileSystem.fireChangedEvent(this);
+        this.trigger = trigger;
         this.commandId = 'cosmosDB.openTrigger';
     }
 
@@ -37,20 +39,19 @@ export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTree
     }
 
     public get id(): string {
-        return this.procedure.id;
+        return this.trigger.id;
     }
 
     public get label(): string {
-        return this.procedure.id;
+        return this.trigger.id;
     }
 
     public get link(): string {
-        return this.procedure._self;
+        return this.trigger._self;
     }
 
     public async getFileContent(): Promise<string> {
-        return typeof this.procedure.body === 'string' ? this.procedure.body : '';
-
+        return typeof this.trigger.body === 'string' ? this.trigger.body : '';
     }
 
     public async refreshImpl(): Promise<void> {
@@ -77,7 +78,7 @@ export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTree
             triggerOperation: triggerOperation,
             body: content
         });
-        this.procedure = nonNullProp(replace, 'resource');
+        this.trigger = nonNullProp(replace, 'resource');
     }
 
     public get iconPath(): TreeItemIconPath {

--- a/src/docdb/tree/DocDBTriggerTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggerTreeItem.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Resource, StoredProcedureDefinition } from '@azure/cosmos';
+import { AzExtTreeItem, DialogResponses, IActionContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import * as vscode from "vscode";
+import { IEditableTreeItem } from '../../DatabasesFileSystem';
+import { ext } from '../../extensionVariables';
+import { nonNullProp } from '../../utils/nonNull';
+import { DocDBTriggersTreeItem } from './DocDBTriggersTreeItem';
+import { IDocDBTreeRoot } from './IDocDBTreeRoot';
+
+/**
+ * Represents a Cosmos DB DocumentDB (SQL) stored procedure
+ */
+export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTreeItem {
+    public static contextValue: string = "cosmosDBTrigger";
+    public readonly contextValue: string = DocDBTriggerTreeItem.contextValue;
+    public readonly cTime: number = Date.now();
+    public readonly parent: DocDBTriggersTreeItem;
+    public mTime: number = Date.now();
+
+    constructor(parent: DocDBTriggersTreeItem, public procedure: (StoredProcedureDefinition & Resource)) {
+        super(parent);
+        ext.fileSystem.fireChangedEvent(this);
+        this.commandId = 'cosmosDB.openTrigger';
+    }
+
+    public get root(): IDocDBTreeRoot {
+        return this.parent.root;
+    }
+
+    public get filePath(): string {
+        return this.label + '-cosmos-trigger.js';
+    }
+
+    public get id(): string {
+        return this.procedure.id;
+    }
+
+    public get label(): string {
+        return this.procedure.id;
+    }
+
+    public get link(): string {
+        return this.procedure._self;
+    }
+
+    public async getFileContent(): Promise<string> {
+        return typeof this.procedure.body === 'string' ? this.procedure.body : '';
+
+    }
+
+    public async refreshImpl(): Promise<void> {
+        ext.fileSystem.fireChangedEvent(this);
+    }
+
+    public async writeFileContent(_context: IActionContext, content: string): Promise<void> {
+        const client = this.root.getCosmosClient();
+        const replace = await this.parent.getContainerClient(client).scripts.storedProcedure(this.id).replace({ id: this.id, body: content });
+        this.procedure = nonNullProp(replace, 'resource');
+    }
+
+    public get iconPath(): TreeItemIconPath {
+        return new vscode.ThemeIcon('server-process');
+    }
+
+    public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
+        const message: string = `Are you sure you want to delete trigger '${this.label}'?`;
+        await context.ui.showWarningMessage(message, { modal: true, stepName: 'deleteTrigger' }, DialogResponses.deleteResponse);
+        const client = this.root.getCosmosClient();
+        await this.parent.getContainerClient(client).scripts.trigger(this.id).delete();
+    }
+}

--- a/src/docdb/tree/DocDBTriggerTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggerTreeItem.ts
@@ -13,7 +13,7 @@ import { DocDBTriggersTreeItem, getTriggerOperation, getTriggerType } from './Do
 import { IDocDBTreeRoot } from './IDocDBTreeRoot';
 
 /**
- * Represents a Cosmos DB DocumentDB (SQL) stored procedure
+ * Represents a Cosmos DB DocumentDB (SQL) trigger
  */
 export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTreeItem {
     public static contextValue: string = "cosmosDBTrigger";

--- a/src/docdb/tree/DocDBTriggersTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggersTreeItem.ts
@@ -110,12 +110,7 @@ export async function getTriggerType(context: IActionContext): Promise<TriggerTy
 }
 
 export async function getTriggerOperation(context: IActionContext): Promise<TriggerOperation> {
-    const triggerOperationOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
-        { label: "All" },
-        { label: "Create" },
-        { label: "Delete" },
-        { label: "Replace" },
-        { label: "Update" },
-    ], {})).label as "All" | "Create" | "Delete" | "Replace" | "Update";
-    return TriggerOperation[triggerOperationOption];
+    const options = Object.keys(TriggerOperation).map((key) => ({ label: key }));
+    const triggerOperationOption = await context.ui.showQuickPick<vscode.QuickPickItem>(options, {});
+    return TriggerOperation[triggerOperationOption.label];
 }

--- a/src/docdb/tree/DocDBTriggersTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggersTreeItem.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Container, CosmosClient, FeedOptions, QueryIterator, Resource, TriggerDefinition, TriggerOperation, TriggerType } from '@azure/cosmos';
+import { AzExtTreeItem, ICreateChildImplContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import * as vscode from "vscode";
+import { defaultTrigger } from '../../constants';
+import { GraphCollectionTreeItem } from '../../graph/tree/GraphCollectionTreeItem';
+import { localize } from '../../utils/localize';
+import { nonNullProp } from '../../utils/nonNull';
+import { DocDBCollectionTreeItem } from './DocDBCollectionTreeItem';
+import { DocDBTreeItemBase } from './DocDBTreeItemBase';
+import { DocDBTriggerTreeItem } from './DocDBTriggerTreeItem';
+
+/**
+ * This class represents the DocumentDB "Triggers" node in the tree
+ */
+export class DocDBTriggersTreeItem extends DocDBTreeItemBase<TriggerDefinition> {
+
+    public static contextValue: string = "cosmosDBTriggersGroup";
+    public readonly contextValue: string = DocDBTriggersTreeItem.contextValue;
+    public readonly childTypeLabel: string = "Trigger";
+    public readonly parent: DocDBCollectionTreeItem;
+    public suppressMaskLabel = true;
+
+    constructor(parent: DocDBCollectionTreeItem | GraphCollectionTreeItem) {
+        super(parent);
+        this.root = this.parent.root;
+    }
+
+    public initChild(resource: TriggerDefinition & Resource): DocDBTriggerTreeItem {
+        return new DocDBTriggerTreeItem(this, resource);
+    }
+
+    public get iconPath(): TreeItemIconPath {
+        // @todo: Find the correct icon
+        return new vscode.ThemeIcon('server-process');
+    }
+
+    public async createChildImpl(context: ICreateChildImplContext): Promise<DocDBTriggerTreeItem> {
+        const client = this.root.getCosmosClient();
+        const currTriggerList: AzExtTreeItem[] = await this.getCachedChildren(context);
+        const currTriggerNames: string[] = [];
+        for (const sp of currTriggerList) {
+            currTriggerNames.push(nonNullProp(sp, "id"));
+        }
+
+        const triggerID = (await context.ui.showInputBox({
+            prompt: "Enter a unique trigger ID",
+            stepName: 'createTrigger',
+            validateInput: (name: string) => this.validateTriggerName(name, currTriggerNames)
+        })).trim();
+
+        const triggerTypeOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
+            { label: "Pre" },
+            { label: "Post" }
+        ], {})).label as "Pre" | "Post";
+        const triggerType = triggerTypeOption === "Pre" ? TriggerType.Pre : TriggerType.Post;
+
+        const triggerOperationOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
+            { label: "All" },
+            { label: "Create" },
+            { label: "Delete" },
+            { label: "Replace" },
+            { label: "Update" },
+        ], {})).label as "All" | "Create" | "Delete" | "Replace" | "Update";
+        const triggerOperation: TriggerOperation = TriggerOperation[triggerOperationOption];
+
+        const body: TriggerDefinition = { id: triggerID, body: defaultTrigger, triggerType: triggerType, triggerOperation: triggerOperation };
+        context.showCreatingTreeItem(triggerID);
+        const response = await this.getContainerClient(client).scripts.triggers.create(body);
+
+        return this.initChild(nonNullProp(response, 'resource'));
+    }
+
+    public get id(): string {
+        return "$Triggers";
+    }
+
+    public get label(): string {
+        return "Triggers";
+    }
+
+    public get link(): string {
+        return this.parent.link;
+    }
+
+    public getIterator(client: CosmosClient, feedOptions: FeedOptions): QueryIterator<TriggerDefinition & Resource> {
+        return this.getContainerClient(client).scripts.triggers.readAll(feedOptions);
+    }
+
+    public getContainerClient(client: CosmosClient): Container {
+        return this.parent.getContainerClient(client);
+    }
+
+    private validateTriggerName(name: string, currStoredProcedureNames: string[]): string | undefined {
+        if (name.length < 1 || name.length > 255) {
+            return localize("nameLength", "Name has to be between 1 and 255 chars long");
+        }
+
+        if (/[/\\?#&]/.test(name)) {
+            return localize("illegalChars", "Name contains illegal chars: /, \\, ?, #, &");
+        }
+        if (name[name.length - 1] === " ") {
+            return localize("endsWithSpace", "Name cannot end with a space.");
+        }
+        if (currStoredProcedureNames.includes(name)) {
+            return localize('nameExists', 'Trigger "{0}" already exists.', name);
+        }
+
+        return undefined;
+    }
+}

--- a/src/docdb/tree/DocDBTriggersTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggersTreeItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Container, CosmosClient, FeedOptions, QueryIterator, Resource, TriggerDefinition, TriggerOperation, TriggerType } from '@azure/cosmos';
-import { AzExtTreeItem, ICreateChildImplContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeItem, IActionContext, ICreateChildImplContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from "vscode";
 import { defaultTrigger } from '../../constants';
 import { GraphCollectionTreeItem } from '../../graph/tree/GraphCollectionTreeItem';
@@ -35,8 +35,7 @@ export class DocDBTriggersTreeItem extends DocDBTreeItemBase<TriggerDefinition> 
     }
 
     public get iconPath(): TreeItemIconPath {
-        // @todo: Find the correct icon
-        return new vscode.ThemeIcon('server-process');
+        return new vscode.ThemeIcon('zap');
     }
 
     public async createChildImpl(context: ICreateChildImplContext): Promise<DocDBTriggerTreeItem> {
@@ -53,20 +52,8 @@ export class DocDBTriggersTreeItem extends DocDBTreeItemBase<TriggerDefinition> 
             validateInput: (name: string) => this.validateTriggerName(name, currTriggerNames)
         })).trim();
 
-        const triggerTypeOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
-            { label: "Pre" },
-            { label: "Post" }
-        ], {})).label as "Pre" | "Post";
-        const triggerType = triggerTypeOption === "Pre" ? TriggerType.Pre : TriggerType.Post;
-
-        const triggerOperationOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
-            { label: "All" },
-            { label: "Create" },
-            { label: "Delete" },
-            { label: "Replace" },
-            { label: "Update" },
-        ], {})).label as "All" | "Create" | "Delete" | "Replace" | "Update";
-        const triggerOperation: TriggerOperation = TriggerOperation[triggerOperationOption];
+        const triggerType = await getTriggerType(context);
+        const triggerOperation = await getTriggerOperation(context);
 
         const body: TriggerDefinition = { id: triggerID, body: defaultTrigger, triggerType: triggerType, triggerOperation: triggerOperation };
         context.showCreatingTreeItem(triggerID);
@@ -95,7 +82,7 @@ export class DocDBTriggersTreeItem extends DocDBTreeItemBase<TriggerDefinition> 
         return this.parent.getContainerClient(client);
     }
 
-    private validateTriggerName(name: string, currStoredProcedureNames: string[]): string | undefined {
+    private validateTriggerName(name: string, currTriggerNames: string[]): string | undefined {
         if (name.length < 1 || name.length > 255) {
             return localize("nameLength", "Name has to be between 1 and 255 chars long");
         }
@@ -106,10 +93,29 @@ export class DocDBTriggersTreeItem extends DocDBTreeItemBase<TriggerDefinition> 
         if (name[name.length - 1] === " ") {
             return localize("endsWithSpace", "Name cannot end with a space.");
         }
-        if (currStoredProcedureNames.includes(name)) {
+        if (currTriggerNames.includes(name)) {
             return localize('nameExists', 'Trigger "{0}" already exists.', name);
         }
 
         return undefined;
     }
+}
+
+export async function getTriggerType(context: IActionContext): Promise<TriggerType> {
+    const triggerTypeOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
+        { label: "Pre" },
+        { label: "Post" }
+    ], {})).label as "Pre" | "Post";
+    return triggerTypeOption === "Pre" ? TriggerType.Pre : TriggerType.Post;
+}
+
+export async function getTriggerOperation(context: IActionContext): Promise<TriggerOperation> {
+    const triggerOperationOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
+        { label: "All" },
+        { label: "Create" },
+        { label: "Delete" },
+        { label: "Replace" },
+        { label: "Update" },
+    ], {})).label as "All" | "Create" | "Delete" | "Replace" | "Update";
+    return TriggerOperation[triggerOperationOption];
 }

--- a/src/docdb/tree/DocDBTriggersTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggersTreeItem.ts
@@ -102,15 +102,13 @@ export class DocDBTriggersTreeItem extends DocDBTreeItemBase<TriggerDefinition> 
 }
 
 export async function getTriggerType(context: IActionContext): Promise<TriggerType> {
-    const triggerTypeOption = (await context.ui.showQuickPick<vscode.QuickPickItem>([
-        { label: "Pre" },
-        { label: "Post" }
-    ], {})).label as "Pre" | "Post";
-    return triggerTypeOption === "Pre" ? TriggerType.Pre : TriggerType.Post;
+    const options = Object.keys(TriggerType).map((type) => ({ label: type }));
+    const triggerTypeOption = await context.ui.showQuickPick<vscode.QuickPickItem>(options, {});
+    return triggerTypeOption.label === "Pre" ? TriggerType.Pre : TriggerType.Post;
 }
 
 export async function getTriggerOperation(context: IActionContext): Promise<TriggerOperation> {
     const options = Object.keys(TriggerOperation).map((key) => ({ label: key }));
     const triggerOperationOption = await context.ui.showQuickPick<vscode.QuickPickItem>(options, {});
-    return TriggerOperation[triggerOperationOption.label];
+    return TriggerOperation[triggerOperationOption.label as keyof typeof TriggerOperation];
 }


### PR DESCRIPTION
Supported features:
- list triggers of a cosmosDB collection
- create a trigger
- view/edit the function body of a trigger
- delete a trigger