### PR TITLE
chore: Use LogOutputChannel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1039,11 +1039,6 @@
                     "description": "The batch size to be used when querying Azure Database resources.",
                     "default": 50
                 },
-                "azureDatabases.enableOutputTimestamps": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Prepends each line displayed in the output channel with a timestamp."
-                },
                 "cosmosDB.emulator.mongoPort": {
                     "type": "integer",
                     "default": 10255,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { AzExtParentTreeItem, AzExtTreeItem, AzureExtensionApi, IActionContext, ITreeItemPickerContext, apiUtils, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, registerCommandWithTreeNodeUnwrapping, registerErrorHandler, registerEvent, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import { AzExtParentTreeItem, AzExtTreeItem, AzureExtensionApi, IActionContext, ITreeItemPickerContext, apiUtils, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtLogOutputChannel, registerCommandWithTreeNodeUnwrapping, registerErrorHandler, registerEvent, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
 import { platform } from 'os';
 import * as vscode from 'vscode';
@@ -45,7 +45,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     ext.context = context;
     ext.ignoreBundle = ignoreBundle;
 
-    ext.outputChannel = createAzExtOutputChannel("Azure Databases", ext.prefix);
+    ext.outputChannel = createAzExtLogOutputChannel("Azure Databases");
     context.subscriptions.push(ext.outputChannel);
     registerUIExtensionVariables(ext);
     registerAzureUtilsExtensionVariables(ext);

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel } from "@microsoft/vscode-azext-utils";
+import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtLogOutputChannel } from "@microsoft/vscode-azext-utils";
 import { AzureHostExtensionApi } from "@microsoft/vscode-azext-utils/hostapi";
 import { ExtensionContext, SecretStorage, TreeView } from "vscode";
 import { DatabasesFileSystem } from "./DatabasesFileSystem";
@@ -23,7 +23,7 @@ export namespace ext {
     export let connectedMongoDB: MongoDatabaseTreeItem | undefined;
     export let connectedPostgresDB: PostgresDatabaseTreeItem | undefined;
     export let context: ExtensionContext;
-    export let outputChannel: IAzExtOutputChannel;
+    export let outputChannel: IAzExtLogOutputChannel;
     export let tree: AzExtTreeDataProvider;
     export let treeView: TreeView<AzExtTreeItem>;
     export let attachedAccountsNode: AttachedAccountsTreeItem;


### PR DESCRIPTION
There is almost no reason to not include the timestamp since it provides important information for filtering the relevant messages. I removed the setting that governs whether the output will include timestamp. Using the LogOutputChannel will always include the timestamp in each message. It also allows the developer to add verbose logging output that can be checked into code to simplify testing and debugging without affecting user experience.