### PR TITLE
feature: View CosmosDB collection offer

### DIFF
--- a/package.json
+++ b/package.json
@@ -358,6 +358,11 @@
             },
             {
                 "category": "Core (SQL)",
+                "command": "cosmosDB.viewDocDBCollectionOffer",
+                "title": "View Collection Offer"
+            },
+            {
+                "category": "Core (SQL)",
                 "command": "cosmosDB.writeNoSqlQuery",
                 "title": "Create New NoSQL Query"
             },
@@ -688,6 +693,11 @@
                     "command": "cosmosDB.deleteDocDBCollection",
                     "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBDocumentCollection",
                     "group": "1@2"
+                },
+                {
+                    "command": "cosmosDB.viewDocDBCollectionOffer",
+                    "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBDocumentCollection",
+                    "group": "1@3"
                 },
                 {
                     "command": "cosmosDB.deleteDocDBDocument",

--- a/src/docdb/commands/viewDocDBCollectionOffer.ts
+++ b/src/docdb/commands/viewDocDBCollectionOffer.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, ITreeItemPickerContext } from "@microsoft/vscode-azext-utils";
+import * as vscodeUtil from "../../utils/vscodeUtils";
+import { DocDBCollectionTreeItem } from "../tree/DocDBCollectionTreeItem";
+import { pickDocDBAccount } from "./pickDocDBAccount";
+
+export async function viewDocDBCollectionOffer(context: IActionContext, node?: DocDBCollectionTreeItem): Promise<void> {
+    const suppressCreateContext: ITreeItemPickerContext = context;
+    suppressCreateContext.suppressCreatePick = true;
+    if (!node) {
+        node = await pickDocDBAccount<DocDBCollectionTreeItem>(context, DocDBCollectionTreeItem.contextValue);
+    }
+    const client = node.root.getCosmosClient();
+    const offer = await node.getContainerClient(client).readOffer();
+    await vscodeUtil.showNewFile(JSON.stringify(offer.resource, undefined, 2), `offer of ${node.label}`, ".json");
+}

--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -23,6 +23,7 @@ import { executeNoSqlQuery } from "./commands/executeNoSqlQuery";
 import { getNoSqlQueryPlan } from "./commands/getNoSqlQueryPlan";
 import { openStoredProcedure } from "./commands/openStoredProcedure";
 import { openTrigger } from "./commands/openTrigger";
+import { viewDocDBCollectionOffer } from "./commands/viewDocDBCollectionOffer";
 import { writeNoSqlQuery } from "./commands/writeNoSqlQuery";
 
 const nosqlLanguageId = "nosql";
@@ -52,6 +53,7 @@ export function registerDocDBCommands(): void {
 
     registerCommandWithTreeNodeUnwrapping('cosmosDB.writeNoSqlQuery', writeNoSqlQuery);
     registerCommandWithTreeNodeUnwrapping('cosmosDB.deleteDocDBCollection', deleteDocDBCollection);
+    registerCommandWithTreeNodeUnwrapping("cosmosDB.viewDocDBCollectionOffer", viewDocDBCollectionOffer);
 
     // #endregion
 


### PR DESCRIPTION
resolves: https://github.com/microsoft/vscode-cosmosdb/issues/1979

The offer of a CosmosDB NoSQL collection will look like this:
```json
{
  "resource": "dbs/xxx/colls/xxx/",
  "offerType": "Invalid",
  "offerResourceId": "xxx",
  "offerVersion": "V2",
  "content": {
    "offerThroughput": 400,
    "offerIsRUPerMinuteThroughputEnabled": false,
    "offerMinimumThroughputParameters": {
      "maxThroughputEverProvisioned": 400,
      "maxConsumedStorageEverInKB": 0
    }
  },
  "id": "xxx",
  "_rid": "xxx",
  "_self": "offers/xxx/",
  "_etag": "\"some_etag\"",
  "_ts": 123456
}
```

If the collection is serverless, there is no such offer for it because it scales automatically. Attempting to view its offer would result in an error in the output saying it's not available for a serverless database account.