### PR TITLE
perf: Use cached mongoDB connection

### DIFF
--- a/src/mongo/commands/connectMongoDatabase.ts
+++ b/src/mongo/commands/connectMongoDatabase.ts
@@ -19,7 +19,7 @@ export async function loadPersistedMongoDB(): Promise<void> {
 
         try {
             const persistedNodeId: string | undefined = ext.context.globalState.get(connectedMongoKey);
-            if (persistedNodeId) {
+            if (persistedNodeId && (!ext.connectedMongoDB || ext.connectedMongoDB.fullId !== persistedNodeId)) {
                 const persistedNode = await ext.rgApi.appResourceTree.findTreeItem(persistedNodeId, context);
                 if (persistedNode) {
                     await ext.mongoLanguageClient.client.onReady();


### PR DESCRIPTION
`ext.rgApi.appResourceTree.findTreeItem()` is a very slow API. If the underlying connection hasn't changed, the change avoids re-searching the tree for the node to allow almost instantaneous execution of the MongoDB commands in the scrapbook if a matching connection already exists. Otherwise, every command execution will have to wait for several seconds.

It's possible for a user to delete a database, recreate a new one with the same name to masquerade the old database and thus invalidate the connection. I think it's a rare case and the user can work around it by clicking the connect button to re-connect.