### PR TITLE
fix: Only show executeNoSqlQuery command on active nosql document

### DIFF
--- a/package.json
+++ b/package.json
@@ -974,6 +974,10 @@
                 {
                     "command": "postgreSQL.executeQuery",
                     "when": "editorLangId == 'postgres'"
+                },
+                {
+                    "command": "cosmosDB.executeNoSqlQuery",
+                    "when": "editorLangId == 'nosql'"
                 }
             ]
         },


### PR DESCRIPTION
fixes: https://github.com/microsoft/vscode-cosmosdb/issues/2265