### PR TITLE
Change API version to use ^

### DIFF
--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -24,7 +24,7 @@ export async function getApiExport<T>(extensionId: string): Promise<T | undefine
 export async function getResourceGroupsApi(): Promise<AzureHostExtensionApi> {
     const rgApiProvider = await getApiExport<apiUtils.AzureExtensionApiProvider>('ms-azuretools.vscode-azureresourcegroups');
     if (rgApiProvider) {
-        return rgApiProvider.getApi<AzureHostExtensionApi>('0.0.1');
+        return rgApiProvider.getApi<AzureHostExtensionApi>('^0.0.1');
     } else {
         throw new Error(localize('noResourceGroupExt', 'Could not find the Azure Resource Groups extension'));
     }


### PR DESCRIPTION
When upgrading the resources API, there's an error being thrown due to the versioning demanding `0.0.1`. Adding the `^` fixes that.

This pull request includes a change to the `getApiExport<T>` function in the `src/getExtensionApi.ts` file. The change updates the version parameter in the `getApi` function from a fixed version '0.0.1' to a version range '^0.0.1'. This allows the function to use any version that is compatible with version 0.0.1, rather than strictly using version 0.0.1. This change should make the function more flexible and resilient to future updates of the Azure Resource Groups extension.