### PR TITLE
Improve AAD fallback if key authentication is disabled

### DIFF
--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -121,31 +121,38 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const label: string = name + (accountKindLabel ? ` (${accountKindLabel})` : ``);
         const isEmulator: boolean = false;
 
-        if (experience && experience.api === "MongoDB") {
-            const result = await client.databaseAccounts.listConnectionStrings(resourceGroup, name);
-            const connectionString: URL = new URL(nonNullProp(nonNullProp(result, 'connectionStrings')[0], 'connectionString'));
-            // for any Mongo connectionString, append this query param because the Cosmos Mongo API v3.6 doesn't support retrywrites
-            // but the newer node.js drivers started breaking this
-            const searchParam: string = 'retrywrites';
-            if (!connectionString.searchParams.has(searchParam)) {
-                connectionString.searchParams.set(searchParam, 'false');
-            }
+        const newNode = await callWithTelemetryAndErrorHandling('cosmosDB.initCosmosDBChild', async (context: IActionContext) => {
+            // leave error handling to the caller (command or tree node)
+            context.errorHandling.suppressDisplay = true;
+            // rethrow all errors to satisfy initCosmosDBChild contract
+            context.errorHandling.rethrow = true;
+            context.telemetry.properties.experience = experience?.api;
 
-            // Use the default connection string
-            return new MongoAccountTreeItem(parent, id, label, connectionString.toString(), isEmulator, databaseAccount);
-        } else {
-            let keyCred: CosmosDBKeyCredential | undefined = undefined;
+            if (experience && experience.api === "MongoDB") {
+                const result = await client.databaseAccounts.listConnectionStrings(resourceGroup, name);
+                const connectionString: URL = new URL(nonNullProp(nonNullProp(result, 'connectionStrings')[0], 'connectionString'));
+                // for any Mongo connectionString, append this query param because the Cosmos Mongo API v3.6 doesn't support retrywrites
+                // but the newer node.js drivers started breaking this
+                const searchParam: string = 'retrywrites';
+                if (!connectionString.searchParams.has(searchParam)) {
+                    connectionString.searchParams.set(searchParam, 'false');
+                }
 
-            const forceOAuth = vscode.workspace.getConfiguration().get<boolean>("azureDatabases.useCosmosOAuth");
-            // disable key auth if the user has opted in to OAuth (AAD/Entra ID)
-            if (!forceOAuth) {
-                let keyResult: DatabaseAccountListKeysResult | undefined;
-                await callWithTelemetryAndErrorHandling('cosmosDB.listAccountKeys', async (context: IActionContext) => {
+                // Use the default connection string
+                return new MongoAccountTreeItem(parent, id, label, connectionString.toString(), isEmulator, databaseAccount);
+            } else {
+                let keyCred: CosmosDBKeyCredential | undefined = undefined;
+
+                const forceOAuth = vscode.workspace.getConfiguration().get<boolean>("azureDatabases.useCosmosOAuth");
+                context.telemetry.properties.useCosmosOAuth = (forceOAuth ?? false).toString();
+
+                // disable key auth if the user has opted in to OAuth (AAD/Entra ID)
+                if (!forceOAuth) {
                     try {
-                        context.errorHandling.suppressDisplay = true;
                         const acc = await client.databaseAccounts.get(resourceGroup, name);
                         const localAuthDisabled = acc.disableLocalAuth === true;
                         context.telemetry.properties.localAuthDisabled = localAuthDisabled.toString();
+                        let keyResult: DatabaseAccountListKeysResult | undefined;
                         // If the account has local auth disabled, don't even try to use key auth
                         if (!localAuthDisabled) {
                             keyResult = await client.databaseAccounts.listKeys(resourceGroup, name);
@@ -153,10 +160,12 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
                                 type: "key",
                                 key: keyResult.primaryMasterKey
                             } : undefined;
+                            context.telemetry.properties.receivedKeyCreds = "true";
                         } else {
                             throw new Error("Local auth is disabled");
                         }
                     } catch (error) {
+                        context.telemetry.properties.receivedKeyCreds = "false";
                         const message = localize("keyPermissionErrorMsg", "You do not have the required permissions to list auth keys for [{0}].\nFalling back to using Entra ID.\nYou can change the default authentication in the settings.", name);
                         const openSettingsItem = localize("openSettings", "Open Settings");
                         void vscode.window.showWarningMessage(message, ...[openSettingsItem]).then((item) => {
@@ -164,29 +173,34 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
                                 void vscode.commands.executeCommand('workbench.action.openSettings', 'azureDatabases.useCosmosOAuth');
                             }
                         });
-                        throw error; // rethrow to log the failure
                     }
-                });
-            }
-
-            // OAuth is always enabled for Cosmos DB and will be used as a fall back if key auth is unavailable
-            const authCred = { type: "auth" };
-            const credentials = [keyCred, authCred].filter((cred): cred is CosmosDBCredential => cred !== undefined);
-            switch (experience && experience.api) {
-                case "Table":
-                    return new TableAccountTreeItem(parent, id, label, documentEndpoint, credentials, isEmulator, databaseAccount);
-                case "Graph": {
-                    const gremlinEndpoint = await tryGetGremlinEndpointFromAzure(client, resourceGroup, name);
-                    return new GraphAccountTreeItem(parent, id, label, documentEndpoint, gremlinEndpoint, credentials, isEmulator, databaseAccount);
                 }
-                case "Core":
-                default:
-                    // Default to DocumentDB, the base type for all Cosmos DB Accounts
-                    return new DocDBAccountTreeItem(parent, id, label, documentEndpoint, credentials, isEmulator, databaseAccount);
 
+                // OAuth is always enabled for Cosmos DB and will be used as a fall back if key auth is unavailable
+                const authCred = { type: "auth" };
+                const credentials = [keyCred, authCred].filter((cred): cred is CosmosDBCredential => cred !== undefined);
+                switch (experience && experience.api) {
+                    case "Table":
+                        return new TableAccountTreeItem(parent, id, label, documentEndpoint, credentials, isEmulator, databaseAccount);
+                    case "Graph": {
+                        const gremlinEndpoint = await tryGetGremlinEndpointFromAzure(client, resourceGroup, name);
+                        return new GraphAccountTreeItem(parent, id, label, documentEndpoint, gremlinEndpoint, credentials, isEmulator, databaseAccount);
+                    }
+                    case "Core":
+                    default:
+                        // Default to DocumentDB, the base type for all Cosmos DB Accounts
+                        return new DocDBAccountTreeItem(parent, id, label, documentEndpoint, credentials, isEmulator, databaseAccount);
+
+                }
             }
+        });
+        if (!(newNode instanceof AzExtTreeItem)) {
+            // note: this should never happen, callWithTelemetryAndErrorHandling will rethrow all errors
+            throw new Error(localize('invalidCosmosDBAccount', 'Invalid Cosmos DB account.'));
         }
+        return newNode;
     }
+
     public static async initPostgresChild(server: PostgresAbstractServer, parent: AzExtParentTreeItem): Promise<AzExtTreeItem> {
         const connectionString: string = createPostgresConnectionString(nonNullProp(server, 'fullyQualifiedDomainName'));
         const parsedCS: ParsedPostgresConnectionString = parsePostgresConnectionString(connectionString);


### PR DESCRIPTION
Currently the extension will prefer account key auth even if local auth is disabled enforcing AAD auth from the server side.
Don't load and preserve account keys if user has opted in for AAD or if the account has local authentication disabled.