### PR TITLE
Fix Cosmos DB user facing terminology

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,27 +309,27 @@
                 "title": "Copy Connection String"
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.createDocDBCollection",
-                "title": "Create Collection..."
+                "title": "Create Container..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.createDocDBDatabase",
                 "title": "Create Database..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.createDocDBDocument",
                 "title": "Create Document..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.createDocDBStoredProcedure",
                 "title": "Create Stored Procedure..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.createDocDBTrigger",
                 "title": "Create Trigger..."
             },
@@ -364,27 +364,27 @@
                 "title": "Delete Account..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.deleteDocDBCollection",
-                "title": "Delete Collection..."
+                "title": "Delete Container..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.deleteDocDBDatabase",
                 "title": "Delete Database..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.deleteDocDBDocument",
                 "title": "Delete Document..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.deleteDocDBStoredProcedure",
                 "title": "Delete Stored Procedure..."
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.deleteDocDBTrigger",
                 "title": "Delete Trigger..."
             },
@@ -419,7 +419,7 @@
                 "title": "Execute All MongoDB Commands"
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.executeDocDBStoredProcedure",
                 "title": "Execute Stored Procedure..."
             },
@@ -487,12 +487,12 @@
                 "title": "Open Trigger"
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.viewDocDBCollectionOffer",
-                "title": "View Collection Offer"
+                "title": "View Container Offer"
             },
             {
-                "category": "Core (SQL)",
+                "category": "NoSQL",
                 "command": "cosmosDB.writeNoSqlQuery",
                 "title": "Create New NoSQL Query"
             },

--- a/src/AzureDBExperiences.ts
+++ b/src/AzureDBExperiences.ts
@@ -11,7 +11,7 @@ export enum API {
     MongoDB = 'MongoDB',
     Graph = 'Graph',
     Table = 'Table',
-    Core = 'Core',
+    Core = 'Core', // Now called NoSQL
     PostgresSingle = 'PostgresSingle',
     PostgresFlexible = 'PostgresFlexible',
 }
@@ -108,11 +108,10 @@ export function getExperienceQuickPickForAttached(api: API): IAzureQuickPickItem
 // Table and Gremlin are distinguished from SQL by their capabilities
 export const CoreExperience: Experience = {
     api: API.Core,
-    longName: 'Core',
-    description: '(SQL)',
-    shortName: 'SQL',
+    longName: 'Azure Cosmos DB NoSQL',
+    shortName: 'NoSQL',
     kind: DBAccountKind.GlobalDocumentDB,
-    tag: 'Core (SQL)',
+    tag: 'Azure Cosmos DB NoSQL',
 } as const;
 export const MongoExperience: Experience = {
     api: API.MongoDB,

--- a/src/commands/importDocuments.ts
+++ b/src/commands/importDocuments.ts
@@ -150,7 +150,7 @@ async function insertDocumentsIntoDocdb(
             ids.push(retrieved.id);
         }
     }
-    const result: string = `Import into SQL successful. Inserted ${ids.length} document(s). See output for more details.`;
+    const result: string = `Import into NoSQL successful. Inserted ${ids.length} document(s). See output for more details.`;
     for (const id of ids) {
         ext.outputChannel.appendLog(`Inserted document: ${id}`);
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -136,7 +136,7 @@ export const cosmosTableFilter = {
     },
 };
 
-export const sqlDefaultExperienceTag = 'Core (SQL)';
+export const sqlDefaultExperienceTag = 'NoSQL';
 
 export const sqlFilter = {
     type: databaseAccountType,

--- a/src/docdb/tree/DocDBDatabaseTreeItem.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItem.ts
@@ -10,7 +10,7 @@ import { DocDBDatabaseTreeItemBase } from './DocDBDatabaseTreeItemBase';
 export class DocDBDatabaseTreeItem extends DocDBDatabaseTreeItemBase {
     public static contextValue: string = 'cosmosDBDocumentDatabase';
     public readonly contextValue: string = DocDBDatabaseTreeItem.contextValue;
-    public readonly childTypeLabel: string = 'Collection';
+    public readonly childTypeLabel: string = 'Container';
 
     public initChild(container: ContainerDefinition & Resource): DocDBCollectionTreeItem {
         return new DocDBCollectionTreeItem(this, container);

--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -89,7 +89,7 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Contai
     public async createChildImpl(context: ICreateChildImplContext): Promise<AzExtTreeItem> {
         const containerName = await context.ui.showInputBox({
             placeHolder: `Enter an id for your ${this.childTypeLabel}`,
-            validateInput: validateCollectionName,
+            validateInput: this.validateCollectionName.bind(this),
             stepName: `create${this.childTypeLabel}`,
         });
 
@@ -152,6 +152,19 @@ export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<Contai
         }
         return undefined;
     }
+
+    protected validateCollectionName(name: string): string | undefined | null {
+        if (!name) {
+            return `${this.childTypeLabel} name cannot be empty`;
+        }
+        if (name.endsWith(' ')) {
+            return `${this.childTypeLabel} name cannot end with space`;
+        }
+        if (/[/\\?#]/.test(name)) {
+            return `${this.childTypeLabel} name cannot contain the characters '\\', '/', '#', '?'`;
+        }
+        return undefined;
+    }
 }
 
 function validateThroughput(isFixed: boolean, input: string): string | undefined | null {
@@ -167,19 +180,6 @@ function validateThroughput(isFixed: boolean, input: string): string | undefined
         }
     } catch {
         return 'Input must be a number';
-    }
-    return undefined;
-}
-
-function validateCollectionName(name: string): string | undefined | null {
-    if (!name) {
-        return 'Collection name cannot be empty';
-    }
-    if (name.endsWith(' ')) {
-        return 'Collection name cannot end with space';
-    }
-    if (/[/\\?#]/.test(name)) {
-        return `Collection name cannot contain the characters '\\', '/', '#', '?'`;
     }
     return undefined;
 }


### PR DESCRIPTION
Fix the strings to reflect the updated Cosmos DB terminology.
* Legacy "Core (SQL)" is now "NoSQL".
* "collections" is for Mongo DB, "containers" is for NoSQL.