### PR TITLE
chore: New theme for Slickgrid

### DIFF
--- a/src/webviews/theme/slickgrid.scss
+++ b/src/webviews/theme/slickgrid.scss
@@ -5,30 +5,7 @@
 
 @import '@slickgrid-universal/common/dist/styles/sass/variables';
 
-@import 'vscode-to-slickgrid.scss';
+@import 'vscode-to-slickgrid2.scss';
 
 /* make sure to add the @import the SlickGrid Bootstrap Theme AFTER the variables changes */
 @import '@slickgrid-universal/common/dist/styles/sass/slickgrid-theme-salesforce.scss';
-
-// the themes below are also available but didn't render well, e.g. selected cells were
-// partialy hiding content in adjacent cells.
-//@import '@slickgrid-universal/common/dist/styles/sass/slickgrid-theme-material.lite.scss';
-//@import '@slickgrid-universal/common/dist/styles/sass/slickgrid-theme-bootstrap.scss';
-
-// override some of existing and add some missing definitions:
-.grid-canvas {
-    .slick-cell.selected {
-        color: var(--vscode-list-activeSelectionForeground);
-    }
-}
-
-// .slickgrid-container .slick-row.odd .slick-cell {
-//     //background-color: var(--vscode-list-activeSelectionForeground);
-// }
-
-// .slick-cell-menu .slick-menu-item:hover,
-// .slick-context-menu .slick-menu-item:hover,
-// .slick-grid-menu .slick-menu-item:hover,
-// .slick-header-menu .slick-menu-item:hover {
-//     color: var(--vscode-menu-selectionForeground);
-// }

--- a/src/webviews/theme/vscode-to-slickgrid2.scss
+++ b/src/webviews/theme/vscode-to-slickgrid2.scss
@@ -1,0 +1,97 @@
+@use 'sass:color';
+
+$base-background-color:                                     var(--vscode-editor-background);
+$base-text-color:                                           var(--vscode-editor-foreground);
+
+$primary-color:                                             #006DCC !default; // Can't replace here since the adjust function fails on variables
+$slick-highlight-color:                                     $base-text-color;
+$slick-primary-color:                                       $primary-color !default;
+
+$slick-border-color:                                        $base-text-color;
+$slick-font-color:                                          $base-text-color;
+
+/* Slickgrid container, including headers but excluding pagination */
+$slick-container-border-top:                                0 none;
+$slick-container-border-right:                              0 none;
+$slick-container-border-bottom:                             0 none;
+$slick-container-border-left:                               0 none;
+$slick-canvas-bg-color:                                     $base-background-color;
+
+/* grid */
+$slick-grid-border-color:                                   none;
+$slick-grid-header-background:                              $base-background-color;
+$slick-grid-header-unorderable-bg-color:                    $slick-grid-header-background;
+$slick-grid-cell-color:                                     $base-text-color;
+$slick-gray-dark:                                           $base-text-color;
+$slick-link-color:                                          var(--vscode-textLink-foreground);
+$slick-link-color-hover:                                    var(--vscode-textLink-activeForeground);
+$slick-navbar-default-link-hover-color:                     $slick-gray-dark;
+$slick-text-color:                                          $slick-gray-dark;
+$slick-table-background:                                    transparent;
+$slick-scrollbar-color:                                     var(--vscode-scrollbarSlider-activeBackground) var(--vscode-scrollbarSlider-background);
+$slick-hover-header-color:                                  var(--vscode-editor-placeholder-foreground);
+$slick-sorting-header-color:                                $base-text-color;
+$slick-placeholder-color:                                   var(--vscode-editor-placeholder-foreground);
+
+/* cell */
+$slick-cell-active-border:                                  none;
+$slick-cell-active-box-shadow:                              inset 0 0 0 1px #aaaaaa !default;
+$slick-cell-box-shadow:                                     none;
+$slick-cell-display:                                        block;
+$slick-cell-text-color:                                     $base-text-color;
+$slick-cell-border-top:                                     1px transparent;
+$slick-cell-border-right:                                   1px transparent;
+$slick-cell-border-bottom:                                  1px transparent;
+$slick-cell-border-left:                                    1px transparent;
+$slick-cell-even-background-color:                          var(--vscode-diffEditor-unchangedRegionBackground);
+$slick-cell-odd-background-color:                           var(--vscode-diffEditor-unchangedCodeBackground); // for striping every second row
+$slick-cell-odd-active-background-color:                    var(--vscode-diffEditor-unchangedCodeBackground);
+// var(--vscode-diffEditor-removedLineBackground);
+
+/* row */
+$slick-row-mouse-hover-color:                               var(--vscode-diffEditor-insertedLineBackground);
+$slick-row-mouse-hover-box-shadow:                          none;
+$slick-row-selected-color:                                  var(--vscode-diffEditor-insertedTextBackground);
+$slick-row-highlight-background-color:                      var(--vscode-diffEditor-insertedLineBackground);
+$slick-row-checkbox-selector-background:                    inherit;
+$slick-row-checkbox-selector-border:                        none;
+
+/* header */
+$slick-header-row-count:                                    1;
+$slick-header-background-color:                             $base-background-color;
+$slick-header-border-top:                                   0 none;                      // header, column titles, that is without the Filters
+$slick-header-border-right:                                 0 none;
+$slick-header-border-bottom:                                0 none;
+$slick-header-border-left:                                  0 none;
+$slick-header-column-background-active:                     color.adjust($slick-grid-header-background, $lightness: -5%) !default;
+$slick-header-column-background-hover:                      color.adjust($slick-grid-header-background, $lightness: -2%) !default;
+$slick-header-column-sortable-background-hover:             $base-background-color;
+$slick-header-column-border-top:                            0 none;                      // header, column titles, that is without the Filters
+$slick-header-column-border-right:                          0 none;
+$slick-header-column-border-bottom:                         0 none;
+$slick-header-column-border-left:                           0 none;
+$slick-header-filter-row-border-top:                        0 none;                      // header row is where the Filters are showing
+$slick-header-filter-row-border-right:                      0 none;
+$slick-header-filter-row-border-bottom:                     0 none;
+$slick-header-filter-row-border-left:                       0 none;
+$slick-header-row-background-color:                         $base-background-color;
+$slick-header-text-color:                                   $base-text-color;
+$slick-header-resizable-hover:                              1px solid var(--vscode-editor-selectionBackground);
+$slick-header-resizable-hover-border-bottom:                0 none;
+$slick-header-resizable-hover-border-left:                  0 none;
+$slick-header-resizable-hover-border-right:                 $slick-header-resizable-hover;
+$slick-header-resizable-hover-border-top:                   0 none;
+
+/* Empty Data Warning element */
+$slick-empty-data-warning-color:                            $slick-cell-text-color;
+
+/* icons */
+$slick-icon-color:                                          inherit;
+$slick-icon-group-color:                                    $slick-icon-color;
+$slick-icon-sort-color:                                     $slick-icon-color;
+$slick-detail-view-icon-color:                              $slick-icon-color;
+$slick-column-picker-icon-color:                            $slick-icon-color;
+$slick-checkbox-icon-color:                                 $slick-icon-color;
+$slick-multiselect-icon-color:                              $slick-icon-color;
+$slick-multiselect-icon-checked-color:                      $slick-icon-color;
+$slick-pagination-icon-color:                               $slick-icon-color;

--- a/src/webviews/theme/vscode-to-slickgrid2.scss
+++ b/src/webviews/theme/vscode-to-slickgrid2.scss
@@ -43,7 +43,7 @@ $slick-cell-border-top:                                     1px transparent;
 $slick-cell-border-right:                                   1px transparent;
 $slick-cell-border-bottom:                                  1px transparent;
 $slick-cell-border-left:                                    1px transparent;
-$slick-cell-even-background-color:                          var(--vscode-diffEditor-unchangedRegionBackground);
+$slick-cell-even-background-color:                          var(--vscode-diffEditor-unchangedCodeBackground);
 $slick-cell-odd-background-color:                           var(--vscode-diffEditor-unchangedCodeBackground); // for striping every second row
 $slick-cell-odd-active-background-color:                    var(--vscode-diffEditor-unchangedCodeBackground);
 // var(--vscode-diffEditor-removedLineBackground);
@@ -51,8 +51,8 @@ $slick-cell-odd-active-background-color:                    var(--vscode-diffEdi
 /* row */
 $slick-row-mouse-hover-color:                               var(--vscode-diffEditor-insertedLineBackground);
 $slick-row-mouse-hover-box-shadow:                          none;
-$slick-row-selected-color:                                  var(--vscode-diffEditor-insertedTextBackground);
-$slick-row-highlight-background-color:                      var(--vscode-diffEditor-insertedLineBackground);
+$slick-row-selected-color:                                  var(--vscode-list-activeSelectionBackground);
+$slick-row-highlight-background-color:                      var(--vscode-list-activeSelectionBackground);
 $slick-row-checkbox-selector-background:                    inherit;
 $slick-row-checkbox-selector-border:                        none;
 


### PR DESCRIPTION
I've tried to rewrite/rethinkg slickgrid theme. 
- Changes less variables
- Suitable for dark themes
- Suitable for light themes

New theme screenshots
![image](https://github.com/user-attachments/assets/80f6c320-e0ef-4b54-a9c2-335fe179d5b2)
![image](https://github.com/user-attachments/assets/30ef7d8a-e450-4047-8086-1fb1fd24230c)


Old theme screenshots
![image](https://github.com/user-attachments/assets/92652a8c-e142-4cb7-b04c-05be9d0d8fb4)
![image](https://github.com/user-attachments/assets/eb39df97-ca85-4c70-9e6f-4899b0f59ca4)
