### PR TITLE
feat: The edit mode was removed. View | Edit | Delete buttons are available if there are selected rows

### DIFF
--- a/src/webviews/Document/DocumentPanel.tsx
+++ b/src/webviews/Document/DocumentPanel.tsx
@@ -18,7 +18,8 @@ const useClasses = makeStyles({
         height: 'calc(100% - 50px)',
     },
     container: {
-        height: '100%',
+        marginTop: '10px',
+        height: 'calc(100% - 10px)',
     },
 });
 

--- a/src/webviews/QueryEditor/QueryEditor.tsx
+++ b/src/webviews/QueryEditor/QueryEditor.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles({
     root: {
         display: 'grid',
         gridTemplateRows: '100vh',
+        minWidth: '900px',
     },
 });
 

--- a/src/webviews/QueryEditor/QueryPanel/QueryPanel.tsx
+++ b/src/webviews/QueryEditor/QueryPanel/QueryPanel.tsx
@@ -9,6 +9,7 @@ import { QueryToolbar } from './QueryToolbar';
 
 const useClasses = makeStyles({
     toolbarContainer: {
+        marginTop: '10px',
         marginBottom: '10px',
     },
     monacoContainer: {

--- a/src/webviews/QueryEditor/ResultPanel/ResultPanel.tsx
+++ b/src/webviews/QueryEditor/ResultPanel/ResultPanel.tsx
@@ -7,6 +7,7 @@ import { makeStyles, Tab, TabList, type SelectTabData, type SelectTabEvent } fro
 import { useState, type PropsWithChildren } from 'react';
 import { ResultPanelToolbar } from './ResultPanelToolbar';
 import { ResultTab } from './ResultTab';
+import { ResultTabToolbar } from './ResultTabToolbar';
 import { StatsTab } from './StatsTab';
 
 const useStyles = makeStyles({
@@ -20,9 +21,7 @@ const useStyles = makeStyles({
         height: '100%',
     },
     tabs: {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        'flex-grow': 1,
+        flexGrow: 1,
     },
     tabContainer: {
         padding: '0 10px',
@@ -30,10 +29,10 @@ const useStyles = makeStyles({
     },
     actionBar: {
         display: 'flex',
-        'flex-direction': 'row',
-        'justify-content': 'space-between',
-        'align-items': 'center',
-        gap: '10px',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: '20px',
     },
 });
 
@@ -65,6 +64,7 @@ export const ResultPanel = () => {
                         </Tab>
                     </TabList>
                 </div>
+                <ResultTabToolbar selectedTab={selectedTab} />
                 <ResultPanelToolbar selectedTab={selectedTab} />
             </ActionBar>
             <div className={styles.tabContainer}>

--- a/src/webviews/QueryEditor/ResultPanel/ResultTab.tsx
+++ b/src/webviews/QueryEditor/ResultPanel/ResultTab.tsx
@@ -7,22 +7,15 @@ import { makeStyles } from '@fluentui/react-components';
 import { Suspense, useMemo } from 'react';
 import { queryResultToJSON, queryResultToTable, queryResultToTree } from '../../utils';
 import { useQueryEditorState } from '../state/QueryEditorContext';
-import { ResultTabToolbar } from './ResultTabToolbar';
 import { ResultTabViewJson } from './ResultTabViewJson';
 import { ResultTabViewTable } from './ResultTabViewTable';
 import { ResultTabViewTree } from './ResultTabViewTree';
 
 const useClasses = makeStyles({
-    toolbarContainer: {
-        marginBottom: '10px',
-    },
-    resultDisplay: {
-        marginTop: '10px',
-        width: '100%',
-        height: 'calc(100% - 50px)',
-    },
     container: {
-        height: '100%',
+        marginTop: '10px',
+        height: 'calc(100% - 10px)',
+        width: '100%',
     },
 });
 
@@ -42,15 +35,12 @@ export const ResultTab = () => {
     );
 
     return (
-        <section className={classes.container}>
-            <ResultTabToolbar></ResultTabToolbar>
-            <div className={[classes.resultDisplay, 'resultsDisplayArea'].join(' ')}>
-                <Suspense fallback={<div>Loading...</div>}>
-                    {tableViewMode === 'Table' && <ResultTabViewTable {...tableViewData} />}
-                    {tableViewMode === 'Tree' && <ResultTabViewTree data={treeViewData ?? []} />}
-                    {tableViewMode === 'JSON' && <ResultTabViewJson data={jsonViewData} />}
-                </Suspense>
-            </div>
-        </section>
+        <div className={[classes.container, 'resultsDisplayArea'].join(' ')}>
+            <Suspense fallback={<div>Loading...</div>}>
+                {tableViewMode === 'Table' && <ResultTabViewTable {...tableViewData} />}
+                {tableViewMode === 'Tree' && <ResultTabViewTree data={treeViewData ?? []} />}
+                {tableViewMode === 'JSON' && <ResultTabViewJson data={jsonViewData} />}
+            </Suspense>
+        </div>
     );
 };

--- a/src/webviews/QueryEditor/ResultPanel/ResultTabToolbar.tsx
+++ b/src/webviews/QueryEditor/ResultPanel/ResultTabToolbar.tsx
@@ -3,58 +3,25 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-    makeStyles,
-    Toolbar,
-    ToolbarButton,
-    ToolbarDivider,
-    ToolbarRadioButton,
-    Tooltip,
-    type ToolbarProps,
-} from '@fluentui/react-components';
-import {
-    DocumentAddRegular,
-    DocumentArrowDownRegular,
-    DocumentDismissRegular,
-    DocumentEditRegular,
-    EditRegular,
-    EyeRegular,
-} from '@fluentui/react-icons';
+import { type OptionOnSelectData } from '@fluentui/react-combobox';
+import { Dropdown, Option, Toolbar, ToolbarButton, Tooltip, useRestoreFocusTarget } from '@fluentui/react-components';
+import { AddFilled, DeleteRegular, EditRegular, EyeRegular } from '@fluentui/react-icons';
 import { extractPartitionKey } from '../../utils';
 import { useQueryEditorDispatcher, useQueryEditorState } from '../state/QueryEditorContext';
-import { type EditMode, type TableViewMode } from '../state/QueryEditorState';
+import { type TableViewMode } from '../state/QueryEditorState';
 
-const useStyles = makeStyles({
-    viewModeButton: {
-        maxWidth: '40px',
-        minWidth: '40px',
-    },
-    editModeButton: {
-        maxWidth: '60px',
-        minWidth: '60px',
-    },
-    toolbar: {
-        padding: '0 0px',
-    },
-});
+export type ResultToolbarProps = { selectedTab: string };
 
 const ToolbarDividerTransparent = () => {
     return <div style={{ padding: '18px' }} />;
 };
 
-export const ResultTabToolbar = () => {
-    const styles = useStyles();
-
+export const ResultTabToolbar = ({ selectedTab }: ResultToolbarProps) => {
     const state = useQueryEditorState();
     const dispatcher = useQueryEditorDispatcher();
+    const restoreFocusTargetAttribute = useRestoreFocusTarget();
 
-    const isEditMode = state.editMode === 'Edit';
-    const isTableViewMode = state.tableViewMode === 'Table';
-
-    const checkedValues = {
-        tableViewMode: [state.tableViewMode],
-        editMode: [state.editMode],
-    };
+    const hasSelectedRows = state.selectedRows.length > 0;
 
     const getSelectedDocuments = () => {
         return state.selectedRows
@@ -73,128 +40,69 @@ export const ResultTabToolbar = () => {
             .filter((document) => document !== undefined);
     };
 
-    const onCheckedValueChange: ToolbarProps['onCheckedValueChange'] = (_event, { name, checkedItems }) => {
-        if (name === 'tableViewMode') {
-            dispatcher.setTableViewMode(checkedItems[0] as TableViewMode);
-        } else if (name === 'editMode') {
-            dispatcher.setEditMode(checkedItems[0] as EditMode);
-        }
+    const onOptionSelect = (data: OptionOnSelectData) => {
+        if (data.optionValue) dispatcher.setTableViewMode(data.optionValue as TableViewMode);
     };
 
-    const onNewDocumentClick = () => {
-        void dispatcher.openDocument('add');
-    };
-    const onViewDocumentClick = () => {
-        const selectedDocuments = getSelectedDocuments();
-
-        void dispatcher.openDocuments('view', selectedDocuments);
-    };
-    const onEditDocumentClick = () => {
-        const selectedDocuments = getSelectedDocuments();
-
-        void dispatcher.openDocuments('edit', selectedDocuments);
-    };
-    const onDeleteDocumentClick = () => {
-        const selectedDocuments = getSelectedDocuments();
-
-        void dispatcher.deleteDocuments(selectedDocuments);
-    };
+    if (selectedTab === 'stats__tab') {
+        return <></>;
+    }
 
     return (
-        <Toolbar
-            aria-label="Table view toolbar"
-            size="small"
-            checkedValues={checkedValues}
-            className={styles.toolbar}
-            onCheckedValueChange={onCheckedValueChange}
-        >
-            <ToolbarRadioButton
-                aria-label="Tree view"
-                name={'tableViewMode'}
-                value={'Tree'}
-                appearance={'transparent'}
-                className={styles.viewModeButton}
-            >
-                Tree
-            </ToolbarRadioButton>
-            <ToolbarDivider />
-            <ToolbarRadioButton
-                aria-label="JSON view"
-                name={'tableViewMode'}
-                value={'JSON'}
-                appearance={'transparent'}
-                className={styles.viewModeButton}
-            >
-                JSON
-            </ToolbarRadioButton>
-            <ToolbarDivider />
-            <ToolbarRadioButton
-                aria-label="Table view"
-                name={'tableViewMode'}
-                value={'Table'}
-                appearance={'transparent'}
-                className={styles.viewModeButton}
-            >
-                Table
-            </ToolbarRadioButton>
+        <Toolbar aria-label="Result view toolbar">
+            <Tooltip content="Add new document in separate tab" relationship="description" withArrow>
+                <ToolbarButton
+                    aria-label={'Add new document'}
+                    icon={<AddFilled />}
+                    onClick={() => void dispatcher.openDocument('add')}
+                />
+            </Tooltip>
+            <Tooltip content="View selected document in separate tab" relationship="description" withArrow>
+                <ToolbarButton
+                    aria-label={'View selected document'}
+                    icon={<EyeRegular />}
+                    onClick={() => void dispatcher.openDocuments('view', getSelectedDocuments())}
+                    disabled={!hasSelectedRows}
+                />
+            </Tooltip>
+            <Tooltip content="Edit selected document in separate tab" relationship="description" withArrow>
+                <ToolbarButton
+                    aria-label={'Edit selected document'}
+                    icon={<EditRegular />}
+                    onClick={() => void dispatcher.openDocuments('edit', getSelectedDocuments())}
+                    disabled={!hasSelectedRows}
+                />
+            </Tooltip>
+            <Tooltip content="Delete selected document" relationship="description" withArrow>
+                <ToolbarButton
+                    aria-label={'Delete selected document'}
+                    icon={<DeleteRegular />}
+                    onClick={() => void dispatcher.deleteDocuments(getSelectedDocuments())}
+                    disabled={!hasSelectedRows}
+                />
+            </Tooltip>
+
             <ToolbarDividerTransparent />
-            <ToolbarRadioButton
-                aria-label="View mode"
-                icon={<EyeRegular />}
-                name={'editMode'}
-                value={'View'}
-                appearance={'transparent'}
-                className={styles.editModeButton}
-            >
-                View
-            </ToolbarRadioButton>
-            <ToolbarDivider />
-            <ToolbarRadioButton
-                aria-label="Edit mode"
-                icon={<EditRegular />}
-                name={'editMode'}
-                value={'Edit'}
-                appearance={'transparent'}
-                className={styles.editModeButton}
-            >
-                Edit
-            </ToolbarRadioButton>
-            {isTableViewMode && (
-                <>
-                    <ToolbarDividerTransparent />
-                    <Tooltip content="View selected document in separate tab" relationship="description" withArrow>
-                        <ToolbarButton
-                            aria-label={'View selected document'}
-                            icon={<DocumentArrowDownRegular />}
-                            onClick={onViewDocumentClick}
-                        />
-                    </Tooltip>
-                    <Tooltip content="Add new document in separate tab" relationship="description" withArrow>
-                        <ToolbarButton
-                            aria-label={'Add new document'}
-                            icon={<DocumentAddRegular />}
-                            onClick={onNewDocumentClick}
-                            disabled={!isEditMode}
-                        />
-                    </Tooltip>
-                    <Tooltip content="Edit selected document in separate tab" relationship="description" withArrow>
-                        <ToolbarButton
-                            aria-label={'Edit selected document'}
-                            icon={<DocumentEditRegular />}
-                            onClick={onEditDocumentClick}
-                            disabled={!isEditMode}
-                        />
-                    </Tooltip>
-                    <Tooltip content="Delete selected document" relationship="description" withArrow>
-                        <ToolbarButton
-                            aria-label={'Delete selected document'}
-                            icon={<DocumentDismissRegular />}
-                            onClick={onDeleteDocumentClick}
-                            disabled={!isEditMode}
-                        />
-                    </Tooltip>
-                </>
-            )}
+
+            <Tooltip content="Change view mode" relationship="description" withArrow>
+                <Dropdown
+                    onOptionSelect={(_event, data) => onOptionSelect(data)}
+                    style={{ minWidth: '100px', maxWidth: '100px' }}
+                    defaultValue={state.tableViewMode}
+                    defaultSelectedOptions={[state.tableViewMode]}
+                    {...restoreFocusTargetAttribute}
+                >
+                    <Option key="Tree" value={'Tree'}>
+                        Tree
+                    </Option>
+                    <Option key="JSON" value={'JSON'}>
+                        JSON
+                    </Option>
+                    <Option key="Table" value={'Table'}>
+                        Table
+                    </Option>
+                </Dropdown>
+            </Tooltip>
         </Toolbar>
     );
 };

--- a/src/webviews/QueryEditor/ResultPanel/ResultTabViewTable.tsx
+++ b/src/webviews/QueryEditor/ResultPanel/ResultTabViewTable.tsx
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import debounce from 'lodash.debounce';
-import { useEffect } from 'react';
 import { SlickgridReact, type GridOption, type OnSelectedRowsChangedEventArgs } from 'slickgrid-react';
 import { type TableData } from '../../utils';
 import { useQueryEditorDispatcher } from '../state/QueryEditorContext';
@@ -29,13 +28,6 @@ export const ResultTabViewTable = ({ headers, dataset }: ResultTabViewTableProps
     const onSelectedRowsChanged = debounce((args: OnSelectedRowsChangedEventArgs) => {
         dispatcher.setSelectedRows(args.rows);
     }, 100);
-
-    useEffect(() => {
-        return () => {
-            // Clean selected document ids when the component is unmounted
-            dispatcher.setSelectedRows([]);
-        };
-    }, []);
 
     const gridOptions: GridOption = {
         autoResize: {

--- a/src/webviews/QueryEditor/state/QueryEditorContextProvider.tsx
+++ b/src/webviews/QueryEditor/state/QueryEditorContextProvider.tsx
@@ -14,7 +14,7 @@ import {
 import { type Channel } from '../../../panels/Communication/Channel/Channel';
 import { type OpenDocumentMode } from '../../Document/state/DocumentState';
 import { BaseContextProvider } from '../../utils/context/BaseContextProvider';
-import { type DispatchAction, type EditMode, type TableViewMode } from './QueryEditorState';
+import { type DispatchAction, type TableViewMode } from './QueryEditorState';
 
 const DEFAULT_RESULT_VIEW_METADATA: ResultViewMetadata = {
     countPerPage: DEFAULT_PAGE_SIZE,
@@ -75,16 +75,6 @@ export class QueryEditorContextProvider extends BaseContextProvider {
     public setTableViewMode(mode: TableViewMode) {
         void this.reportWebviewEvent('setTableViewMode', { mode });
         this.dispatch({ type: 'setTableViewMode', mode });
-        this.dispatch({ type: 'setEditMode', mode: 'View' });
-    }
-    public setEditMode(mode: EditMode) {
-        void this.reportWebviewEvent('setEditMode', { mode });
-        this.dispatch({ type: 'setEditMode', mode });
-
-        if (mode === 'Edit') {
-            // While in edit mode, switch to table view
-            this.dispatch({ type: 'setTableViewMode', mode: 'Table' });
-        }
     }
     public setSelectedRows(selectedRows: number[]) {
         void this.reportWebviewEvent('setSelectedDocumentIds', { count: selectedRows.length.toString() });

--- a/src/webviews/QueryEditor/state/QueryEditorState.tsx
+++ b/src/webviews/QueryEditor/state/QueryEditorState.tsx
@@ -10,7 +10,6 @@ export const DEFAULT_QUERY_VALUE = `SELECT * FROM c`;
 export const QUERY_HISTORY_SIZE = 10;
 
 export type TableViewMode = 'Tree' | 'JSON' | 'Table';
-export type EditMode = 'View' | 'Edit';
 
 export type DispatchAction =
     | {
@@ -55,10 +54,6 @@ export type DispatchAction =
           mode: TableViewMode;
       }
     | {
-          type: 'setEditMode';
-          mode: EditMode;
-      }
-    | {
           type: 'setSelectedRows';
           selectedRows: number[];
       };
@@ -83,7 +78,6 @@ export type QueryEditorState = {
     selectedRows: number[];
 
     tableViewMode: TableViewMode;
-    editMode: EditMode;
 };
 
 export const defaultState: QueryEditorState = {
@@ -105,8 +99,7 @@ export const defaultState: QueryEditorState = {
     currentQueryResult: null,
     selectedRows: [],
 
-    tableViewMode: 'Tree',
-    editMode: 'View',
+    tableViewMode: 'Table',
 };
 
 export function dispatch(state: QueryEditorState, action: DispatchAction): QueryEditorState {
@@ -154,8 +147,6 @@ export function dispatch(state: QueryEditorState, action: DispatchAction): Query
             return { ...state, currentQueryResult: action.result, pageNumber: action.currentPage };
         case 'setTableViewMode':
             return { ...state, tableViewMode: action.mode };
-        case 'setEditMode':
-            return { ...state, editMode: action.mode };
         case 'setSelectedRows':
             return { ...state, selectedRows: action.selectedRows };
     }

--- a/src/webviews/theme/vscode-to-slickgrid2.scss
+++ b/src/webviews/theme/vscode-to-slickgrid2.scss
@@ -51,8 +51,8 @@ $slick-cell-odd-active-background-color:                    var(--vscode-diffEdi
 /* row */
 $slick-row-mouse-hover-color:                               var(--vscode-diffEditor-insertedLineBackground);
 $slick-row-mouse-hover-box-shadow:                          none;
-$slick-row-selected-color:                                  var(--vscode-list-activeSelectionBackground);
-$slick-row-highlight-background-color:                      var(--vscode-list-activeSelectionBackground);
+$slick-row-selected-color:                                  var(--vscode-editor-findMatchBackground);
+$slick-row-highlight-background-color:                      var(--vscode-editor-selectionHighlightBackground);
 $slick-row-checkbox-selector-background:                    inherit;
 $slick-row-checkbox-selector-border:                        none;
 


### PR DESCRIPTION
This pull request includes several changes to the `QueryEditor` and `ResultPanel` components to improve the user interface and functionality. The most important changes include modifications to the styles, the addition of a new toolbar, and the removal of the `EditMode` feature.

### Style Adjustments:
* [`src/webviews/Document/DocumentPanel.tsx`](diffhunk://#diff-0fcab1b22e15a6415b69b5fa02920458728ab54bedeafcfbbfbc8c52563cda43L21-R22): Updated the `container` class to include a `marginTop` of `10px` and adjusted the height calculation.
* [`src/webviews/QueryEditor/QueryEditor.tsx`](diffhunk://#diff-49a3df4f62a34225e18df43ae5225278c32a02cb2de9c56a4e7b848b488bfb55R20): Added a `minWidth` of `900px` to the `root` class.
* [`src/webviews/QueryEditor/ResultPanel/ResultPanel.tsx`](diffhunk://#diff-4f2fac2e5ac3f6e48abf1e20658765d2044a4e19fcc75075e7c58cb38e03e89cL23-R35): Fixed the `tabs` class to use `flexGrow` instead of a commented-out property and updated the `actionBar` class to use camelCase properties.
* [`src/webviews/QueryEditor/ResultPanel/ResultTab.tsx`](diffhunk://#diff-54b7751b984e0d49729ab2d7a472a1d5128db11e00a6428852cd6e357cbe70f9L45-L54): Simplified the `container` class by removing unnecessary styles and adjusting the height calculation.

### Toolbar Enhancements:
* [`src/webviews/QueryEditor/ResultPanel/ResultPanel.tsx`](diffhunk://#diff-4f2fac2e5ac3f6e48abf1e20658765d2044a4e19fcc75075e7c58cb38e03e89cR67): Added a new `ResultTabToolbar` component to the `ResultPanel` component.
* [`src/webviews/QueryEditor/ResultPanel/ResultTabToolbar.tsx`](diffhunk://#diff-e5a7ae53b6f30b9d762a62a68544b6005202953526b94e6d396bb732b8dd61c4L6-R24): Refactored the `ResultTabToolbar` to remove the `EditMode` feature, add a `Dropdown` for changing view modes, and streamline toolbar buttons for document actions. [[1]](diffhunk://#diff-e5a7ae53b6f30b9d762a62a68544b6005202953526b94e6d396bb732b8dd61c4L6-R24) [[2]](diffhunk://#diff-e5a7ae53b6f30b9d762a62a68544b6005202953526b94e6d396bb732b8dd61c4L76-R105)

### Code Cleanup:
* [`src/webviews/QueryEditor/ResultPanel/ResultTabViewTable.tsx`](diffhunk://#diff-0f6c33b0dff81bca9818ce2f5443ba292b4446895b960579161d4e73b69aca29L33-L39): Removed unnecessary `useEffect` hook and cleaned up the component.
* [`src/webviews/QueryEditor/state/QueryEditorContextProvider.tsx`](diffhunk://#diff-32f2b16818c82c36457bcf475edaf304a0fb515c86ab8bef364412c12a53f052L78-L87): Removed the `setEditMode` method and related dispatch actions.
* [`src/webviews/QueryEditor/state/QueryEditorState.tsx`](diffhunk://#diff-94b8720ec4af468e5459a9f4f21acb6fd3090ee11382f2c562524f54bd251582L57-L60): Removed the `EditMode` type and related state management. [[1]](diffhunk://#diff-94b8720ec4af468e5459a9f4f21acb6fd3090ee11382f2c562524f54bd251582L57-L60) [[2]](diffhunk://#diff-94b8720ec4af468e5459a9f4f21acb6fd3090ee11382f2c562524f54bd251582L86) [[3]](diffhunk://#diff-94b8720ec4af468e5459a9f4f21acb6fd3090ee11382f2c562524f54bd251582L157-L158)

### Theme Adjustments:
* [`src/webviews/theme/vscode-to-slickgrid2.scss`](diffhunk://#diff-3d9ce328810f4c3f08ad43ec24bb6f03974eacaa5a8872ac54604032f9877dadL54-R55): Updated the `slick-row-selected-color` and `slick-row-highlight-background-color` to use different VSCode theme variables.