### PR TITLE
fix: Adds indicator that document is opened in read only mode

### DIFF
--- a/src/webviews/Document/DocumentPanel.tsx
+++ b/src/webviews/Document/DocumentPanel.tsx
@@ -109,6 +109,7 @@ export const DocumentPanel = () => {
                 </MessageBar>
             )}
             <DocumentToolbar />
+            {isReadOnly && <MessageBar intent={'info'}>This document is read-only.</MessageBar>}
             {inProgress && <ProgressBar />}
             <section className={classes.resultDisplay}>
                 <MonacoEditor


### PR DESCRIPTION
[3572638](https://msdata.visualstudio.com/CosmosDB/_workitems/edit/3572638)

Adds an indicator that the document is opened in read-only mode.

![image](https://github.com/user-attachments/assets/c306976f-ad7f-4c98-be6c-9f79b73d659a)
![image](https://github.com/user-attachments/assets/df932c73-724a-4abd-9048-341b14d8f874)
