### PR TITLE
Fix an issue where an internal error is not meaningful

### DIFF
--- a/src/resolver/AppResolver.ts
+++ b/src/resolver/AppResolver.ts
@@ -46,6 +46,8 @@ export class DatabaseResolver implements AppResourceResolver {
             try {
                 const resourceGroupName = getResourceGroupFromId(nonNullProp(resource, 'id'));
                 const name = nonNullProp(resource, 'name');
+                context.valuesToMask.push(resource.id);
+                context.valuesToMask.push(resource.name);
                 let postgresServer: PostgresAbstractServer;
                 let dbChild: AzExtTreeItem;
 

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -163,8 +163,8 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     ): Promise<AzExtTreeItem> {
         const experience = tryGetExperience(databaseAccount);
         const id: string = nonNullProp(databaseAccount, 'id');
-        const name: string = nonNullProp(databaseAccount, 'name');
-        const documentEndpoint: string = nonNullProp(databaseAccount, 'documentEndpoint');
+        const name: string = nonNullProp(databaseAccount, 'name', `of the database account ${databaseAccount.id}`);
+        const documentEndpoint: string = nonNullProp(databaseAccount, 'documentEndpoint', `of the database account ${databaseAccount.id}`);
 
         const resourceGroup: string = getResourceGroupFromId(id);
         const accountKindLabel = getExperienceLabel(databaseAccount);

--- a/src/utils/nonNull.ts
+++ b/src/utils/nonNull.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isNullOrUndefined } from 'util';
-
 /**
  * Retrieves a property by name from an object and checks that it's not null and not undefined.  It is strongly typed
  * for the property and will give a compile error if the given name is not a property of the source.
@@ -12,8 +10,12 @@ import { isNullOrUndefined } from 'util';
 export function nonNullProp<TSource, TKey extends keyof TSource>(
     source: TSource,
     name: TKey,
+    message?: string,
 ): NonNullable<TSource[TKey]> {
     const value: NonNullable<TSource[TKey]> = <NonNullable<TSource[TKey]>>source[name];
+    if (message) {
+        return nonNullValue(value, `${<string>name}, ${message}`);
+    }
     return nonNullValue(value, <string>name);
 }
 
@@ -21,7 +23,7 @@ export function nonNullProp<TSource, TKey extends keyof TSource>(
  * Validates that a given value is not null and not undefined.
  */
 export function nonNullValue<T>(value: T | undefined | null, propertyNameOrMessage?: string): T {
-    if (isNullOrUndefined(value)) {
+    if (value === undefined || value === null) {
         throw new Error(
             'Internal error: Expected value to be neither null nor undefined' +
                 (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''),


### PR DESCRIPTION
There are several scenarios where loading database resources might fail. This change adds an optional message to a commonly used nonNullValue check function and improves database resource resolution error handling. Additioally the resource ID and Name gets now masked when reporting errors to telemetry and GitHub issues.