### PR TITLE
feat: The use can open document for editing if document was open as read-only

### DIFF
--- a/src/webviews/Document/DocumentPanel.tsx
+++ b/src/webviews/Document/DocumentPanel.tsx
@@ -6,6 +6,7 @@
 import { type JSONObject, type PartitionKeyDefinition } from '@azure/cosmos';
 import { makeStyles, MessageBar, MessageBarBody, MessageBarTitle, ProgressBar } from '@fluentui/react-components';
 import { parse as parseJson } from '@prantlf/jsonlint';
+import { useEffect } from 'react';
 import { extractPartitionKey } from '../../utils/document';
 import { MonacoEditor } from '../MonacoEditor';
 import { DocumentToolbar } from './DocumentToolbar';
@@ -97,6 +98,11 @@ export const DocumentPanel = () => {
 
         dispatcher.setValid(errors.length === 0, errors);
     };
+
+    // TODO: Hack, remove this when DocumentPanel will be moved to CustomTextEditor.
+    useEffect(() => {
+        void dispatcher?.notifyDirty?.(state.isDirty);
+    }, [dispatcher, state.isDirty]);
 
     return (
         <section className={classes.container}>

--- a/src/webviews/Document/DocumentToolbar.tsx
+++ b/src/webviews/Document/DocumentToolbar.tsx
@@ -16,7 +16,7 @@ import {
     ToolbarButton,
     Tooltip,
 } from '@fluentui/react-components';
-import { ArrowClockwiseRegular, SaveRegular } from '@fluentui/react-icons';
+import { ArrowClockwiseRegular, EditRegular, SaveRegular } from '@fluentui/react-icons';
 import { useState } from 'react';
 import { useDocumentDispatcher, useDocumentState } from './state/DocumentContext';
 
@@ -73,6 +73,11 @@ export const DocumentToolbar = () => {
         void dispatcher.saveDocument(state.currentDocumentContent);
     };
 
+    const onEditRequest = () => {
+        // Open document for editing
+        void dispatcher.setMode('edit');
+    };
+
     const onRefreshRequest = () => {
         // Reload original document from the database
         if (state.isDirty) {
@@ -90,17 +95,31 @@ export const DocumentToolbar = () => {
         <>
             <AlertDialog open={open} setOpen={setOpen} doAction={doAction} />
             <Toolbar>
-                <Tooltip content="Save document to the database" relationship="description" withArrow>
-                    <ToolbarButton
-                        onClick={onSaveRequest}
-                        aria-label="Save document to the database"
-                        icon={<SaveRegular />}
-                        appearance={'primary'}
-                        disabled={isReadOnly || inProgress || !isDirty || !state.isValid}
-                    >
-                        Save
-                    </ToolbarButton>
-                </Tooltip>
+                {!isReadOnly && (
+                    <Tooltip content="Save document to the database" relationship="description" withArrow>
+                        <ToolbarButton
+                            onClick={onSaveRequest}
+                            aria-label="Save document to the database"
+                            icon={<SaveRegular />}
+                            appearance={'primary'}
+                            disabled={inProgress || !isDirty || !state.isValid}
+                        >
+                            Save
+                        </ToolbarButton>
+                    </Tooltip>
+                )}
+                {isReadOnly && (
+                    <Tooltip content="Open document for editing" relationship="description" withArrow>
+                        <ToolbarButton
+                            onClick={onEditRequest}
+                            aria-label="Open document for editing"
+                            icon={<EditRegular />}
+                            appearance={'primary'}
+                        >
+                            Edit
+                        </ToolbarButton>
+                    </Tooltip>
+                )}
 
                 <ToolbarDividerTransparent />
 

--- a/src/webviews/Document/state/DocumentContextProvider.tsx
+++ b/src/webviews/Document/state/DocumentContextProvider.tsx
@@ -42,6 +42,13 @@ export class DocumentContextProvider extends BaseContextProvider {
         }
     }
 
+    public setMode(mode: OpenDocumentMode): Promise<void> {
+        return this.sendCommand('setMode', mode);
+    }
+    public async notifyDirty(isDirty: boolean): Promise<void> {
+        await this.sendCommand('setDirty', isDirty);
+    }
+
     protected initEventListeners(): void {
         super.initEventListeners();
 
@@ -61,6 +68,10 @@ export class DocumentContextProvider extends BaseContextProvider {
                 this.dispatch({ type: 'initState', mode, databaseId, containerId, documentId, partitionKey });
             },
         );
+
+        this.channel.on('modeChanged', (mode: OpenDocumentMode) => {
+            this.dispatch({ type: 'setMode', mode });
+        });
 
         this.channel.on(
             'setDocument',

--- a/src/webviews/Document/state/DocumentState.tsx
+++ b/src/webviews/Document/state/DocumentState.tsx
@@ -32,6 +32,10 @@ export type DispatchAction =
           documentContent: string;
       }
     | {
+          type: 'setMode';
+          mode: OpenDocumentMode;
+      }
+    | {
           type: 'setValid';
           isValid: boolean;
       }
@@ -111,6 +115,8 @@ export function dispatch(state: DocumentState, action: DispatchAction): Document
                 partitionKey: action.partitionKey,
                 isDirty: false,
             };
+        case 'setMode':
+            return { ...state, mode: action.mode };
         case 'setValid':
             return { ...state, isValid: action.isValid };
         case 'setDirty':


### PR DESCRIPTION
This pull request includes significant updates to the `DocumentTab` and related components to support a new edit mode and handle document dirty state. The changes involve adding new properties and methods to manage the edit mode and dirty state, as well as updating the UI components to reflect these changes.

### Enhancements to DocumentTab functionality:

* [`src/panels/DocumentTab.ts`](diffhunk://#diff-26716e98f3c226c5be3af5279ed324a6963ffdca6eeba9ee210ff130ae8fdd0fL24-R25): Introduced `_mode` and `isDirty` properties, along with corresponding getter and setter for `mode`. The setter includes logic to prevent switching from 'edit' to 'view' if the document is dirty. Added new commands `setMode` and `setDirty` to handle mode changes and dirty state. [[1]](diffhunk://#diff-26716e98f3c226c5be3af5279ed324a6963ffdca6eeba9ee210ff130ae8fdd0fL24-R25) [[2]](diffhunk://#diff-26716e98f3c226c5be3af5279ed324a6963ffdca6eeba9ee210ff130ae8fdd0fL38-R39) [[3]](diffhunk://#diff-26716e98f3c226c5be3af5279ed324a6963ffdca6eeba9ee210ff130ae8fdd0fR83) [[4]](diffhunk://#diff-26716e98f3c226c5be3af5279ed324a6963ffdca6eeba9ee210ff130ae8fdd0fR106-R123) [[5]](diffhunk://#diff-26716e98f3c226c5be3af5279ed324a6963ffdca6eeba9ee210ff130ae8fdd0fR150-R155)

### Updates to UI components:

* [`src/webviews/Document/DocumentPanel.tsx`](diffhunk://#diff-0fcab1b22e15a6415b69b5fa02920458728ab54bedeafcfbbfbc8c52563cda43R9): Added a `useEffect` hook to notify the dispatcher when the document's dirty state changes. [[1]](diffhunk://#diff-0fcab1b22e15a6415b69b5fa02920458728ab54bedeafcfbbfbc8c52563cda43R9) [[2]](diffhunk://#diff-0fcab1b22e15a6415b69b5fa02920458728ab54bedeafcfbbfbc8c52563cda43R102-R106)
* [`src/webviews/Document/DocumentToolbar.tsx`](diffhunk://#diff-8dd45d8cf96fd717d1fcee076f8ec50f141f100bb55dd775390766add5510114L19-R19): Added an `Edit` button to enable edit mode and updated the `Save` button to be hidden when in read-only mode. [[1]](diffhunk://#diff-8dd45d8cf96fd717d1fcee076f8ec50f141f100bb55dd775390766add5510114L19-R19) [[2]](diffhunk://#diff-8dd45d8cf96fd717d1fcee076f8ec50f141f100bb55dd775390766add5510114R76-R80) [[3]](diffhunk://#diff-8dd45d8cf96fd717d1fcee076f8ec50f141f100bb55dd775390766add5510114R98-R122)

### Dispatcher and state management updates:

* [`src/webviews/Document/state/DocumentContextProvider.tsx`](diffhunk://#diff-f3dc6c06427060dea608e7e41a6c05be613e3be59779ba41192b09c38a8f2e07R45-R51): Added `setMode` and `notifyDirty` methods to send commands for mode changes and dirty state updates. Added an event listener for `modeChanged` to update the state accordingly. [[1]](diffhunk://#diff-f3dc6c06427060dea608e7e41a6c05be613e3be59779ba41192b09c38a8f2e07R45-R51) [[2]](diffhunk://#diff-f3dc6c06427060dea608e7e41a6c05be613e3be59779ba41192b09c38a8f2e07R72-R75)
* [`src/webviews/Document/state/DocumentState.tsx`](diffhunk://#diff-9f64fed02926c6489d19343719ed5967058ce3fc520c6b40d6013c834e8367a6R34-R37): Updated the state reducer to handle the new `setMode` action. [[1]](diffhunk://#diff-9f64fed02926c6489d19343719ed5967058ce3fc520c6b40d6013c834e8367a6R34-R37) [[2]](diffhunk://#diff-9f64fed02926c6489d19343719ed5967058ce3fc520c6b40d6013c834e8367a6R118-R119)