### PR TITLE
Prevent duplicate columns in query results table

### DIFF
--- a/src/utils/convertors.ts
+++ b/src/utils/convertors.ts
@@ -226,7 +226,9 @@ export const getTableHeadersWithRecordIdentifyColumns = (
         partitionKeyPaths.unshift('id');
     }
 
-    return [...partitionKeyPaths, ...columns, ...serviceColumns];
+    // Remove duplicates while keeping order
+    const uniqueHeaders = new Set<string>([...partitionKeyPaths, ...columns, ...serviceColumns]);
+    return Array.from(uniqueHeaders);
 };
 
 /**


### PR DESCRIPTION
The column `id` shows up twice for some containers, because it could originally be in the `columns` (the query results), and then added again in `partitionKeyPaths`.
While this issue probably is just specific to `id` and we could also check if `id` exists in `columns` before adding to `partitionKeyPaths`, this PR ensure that we don't have any other duplicates between the 3 variables that we concatenate.