### PR TITLE
Fix an issue where Mongo nodes did not have a local parent assigned

### DIFF
--- a/src/docdb/tree/DocDBCollectionTreeItem.ts
+++ b/src/docdb/tree/DocDBCollectionTreeItem.ts
@@ -33,7 +33,7 @@ import { type IDocDBTreeRoot } from './IDocDBTreeRoot';
 export class DocDBCollectionTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'cosmosDBDocumentCollection';
     public readonly contextValue: string = DocDBCollectionTreeItem.contextValue;
-    public readonly parent: DocDBDatabaseTreeItem;
+    public declare readonly parent: DocDBDatabaseTreeItem;
 
     public readonly documentsTreeItem: DocDBDocumentsTreeItem;
     private readonly _storedProceduresTreeItem: DocDBStoredProceduresTreeItem;
@@ -44,7 +44,6 @@ export class DocDBCollectionTreeItem extends AzExtParentTreeItem {
         private _container: ContainerDefinition & Resource,
     ) {
         super(parent);
-        this.parent = parent;
         this.documentsTreeItem = new DocDBDocumentsTreeItem(this);
         this._storedProceduresTreeItem = new DocDBStoredProceduresTreeItem(this);
         this._triggersTreeItem = new DocDBTriggersTreeItem(this);

--- a/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
+++ b/src/docdb/tree/DocDBDatabaseTreeItemBase.ts
@@ -35,12 +35,11 @@ const throughputStepSize = 100;
  * (DocumentDB is the base type for all Cosmos DB accounts)
  */
 export abstract class DocDBDatabaseTreeItemBase extends DocDBTreeItemBase<ContainerDefinition & Resource> {
-    public readonly parent: DocDBAccountTreeItemBase;
+    public declare readonly parent: DocDBAccountTreeItemBase;
     private readonly _database: DatabaseDefinition & Resource;
 
     constructor(parent: DocDBAccountTreeItemBase, database: DatabaseDefinition & Resource) {
         super(parent);
-        this.parent = parent;
         this._database = database;
         this.root = this.parent.root;
     }

--- a/src/docdb/tree/DocDBDocumentTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentTreeItem.ts
@@ -27,7 +27,7 @@ const hiddenFields: string[] = ['_rid', '_self', '_etag', '_attachments', '_ts']
 export class DocDBDocumentTreeItem extends AzExtTreeItem implements IEditableTreeItem {
     public static contextValue: string = 'cosmosDBDocument';
     public readonly contextValue: string = DocDBDocumentTreeItem.contextValue;
-    public readonly parent: DocDBDocumentsTreeItem;
+    public declare readonly parent: DocDBDocumentsTreeItem;
     public readonly cTime: number = Date.now();
     public mTime: number = Date.now();
     private _label: string;
@@ -35,7 +35,6 @@ export class DocDBDocumentTreeItem extends AzExtTreeItem implements IEditableTre
 
     constructor(parent: DocDBDocumentsTreeItem, document: ItemDefinition) {
         super(parent);
-        this.parent = parent;
         this._document = document;
         this._label = getDocumentTreeItemLabel(this._document);
         ext.fileSystem.fireChangedEvent(this);

--- a/src/docdb/tree/DocDBDocumentsTreeItem.ts
+++ b/src/docdb/tree/DocDBDocumentsTreeItem.ts
@@ -29,12 +29,11 @@ export class DocDBDocumentsTreeItem extends DocDBTreeItemBase<ItemDefinition> {
     public static contextValue: string = 'cosmosDBDocumentsGroup';
     public readonly contextValue: string = DocDBDocumentsTreeItem.contextValue;
     public readonly childTypeLabel: string = 'Documents';
-    public readonly parent: DocDBCollectionTreeItem;
+    public declare readonly parent: DocDBCollectionTreeItem;
     public suppressMaskLabel = true;
 
     constructor(parent: DocDBCollectionTreeItem) {
         super(parent);
-        this.parent = parent;
         this.root = this.parent.root;
     }
 

--- a/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProcedureTreeItem.ts
@@ -27,7 +27,7 @@ export class DocDBStoredProcedureTreeItem extends AzExtTreeItem implements IEdit
     public static contextValue: string = 'cosmosDBStoredProcedure';
     public readonly contextValue: string = DocDBStoredProcedureTreeItem.contextValue;
     public readonly cTime: number = Date.now();
-    public readonly parent: DocDBStoredProceduresTreeItem;
+    public declare readonly parent: DocDBStoredProceduresTreeItem;
     public mTime: number = Date.now();
 
     constructor(
@@ -35,7 +35,6 @@ export class DocDBStoredProcedureTreeItem extends AzExtTreeItem implements IEdit
         public procedure: StoredProcedureDefinition & Resource,
     ) {
         super(parent);
-        this.parent = parent;
         ext.fileSystem.fireChangedEvent(this);
         this.commandId = 'cosmosDB.openStoredProcedure';
     }

--- a/src/docdb/tree/DocDBStoredProceduresTreeItem.ts
+++ b/src/docdb/tree/DocDBStoredProceduresTreeItem.ts
@@ -28,12 +28,11 @@ export class DocDBStoredProceduresTreeItem extends DocDBTreeItemBase<StoredProce
     public static contextValue: string = 'cosmosDBStoredProceduresGroup';
     public readonly contextValue: string = DocDBStoredProceduresTreeItem.contextValue;
     public readonly childTypeLabel: string = 'Stored Procedure';
-    public readonly parent: DocDBCollectionTreeItem | GraphCollectionTreeItem;
+    public declare readonly parent: DocDBCollectionTreeItem | GraphCollectionTreeItem;
     public suppressMaskLabel = true;
 
     constructor(parent: DocDBCollectionTreeItem | GraphCollectionTreeItem) {
         super(parent);
-        this.parent = parent;
         this.root = this.parent.root;
     }
 

--- a/src/docdb/tree/DocDBTriggerTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggerTreeItem.ts
@@ -25,13 +25,12 @@ export class DocDBTriggerTreeItem extends AzExtTreeItem implements IEditableTree
     public static contextValue: string = 'cosmosDBTrigger';
     public readonly contextValue: string = DocDBTriggerTreeItem.contextValue;
     public readonly cTime: number = Date.now();
-    public readonly parent: DocDBTriggersTreeItem;
+    public declare readonly parent: DocDBTriggersTreeItem;
     public trigger: TriggerDefinition & Resource;
     public mTime: number = Date.now();
 
     constructor(parent: DocDBTriggersTreeItem, trigger: TriggerDefinition & Resource) {
         super(parent);
-        this.parent = parent;
         this.trigger = trigger;
         ext.fileSystem.fireChangedEvent(this);
         this.commandId = 'cosmosDB.openTrigger';

--- a/src/docdb/tree/DocDBTriggersTreeItem.ts
+++ b/src/docdb/tree/DocDBTriggersTreeItem.ts
@@ -35,12 +35,11 @@ export class DocDBTriggersTreeItem extends DocDBTreeItemBase<TriggerDefinition> 
     public static contextValue: string = 'cosmosDBTriggersGroup';
     public readonly contextValue: string = DocDBTriggersTreeItem.contextValue;
     public readonly childTypeLabel: string = 'Trigger';
-    public readonly parent: DocDBCollectionTreeItem | GraphCollectionTreeItem;
+    public declare readonly parent: DocDBCollectionTreeItem | GraphCollectionTreeItem;
     public suppressMaskLabel = true;
 
     constructor(parent: DocDBCollectionTreeItem | GraphCollectionTreeItem) {
         super(parent);
-        this.parent = parent;
         this.root = this.parent.root;
     }
 

--- a/src/graph/tree/GraphCollectionTreeItem.ts
+++ b/src/graph/tree/GraphCollectionTreeItem.ts
@@ -21,7 +21,7 @@ import { GraphTreeItem } from './GraphTreeItem';
 export class GraphCollectionTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'cosmosDBGraph';
     public readonly contextValue: string = GraphCollectionTreeItem.contextValue;
-    public readonly parent: GraphDatabaseTreeItem;
+    public declare readonly parent: GraphDatabaseTreeItem;
 
     private readonly _graphTreeItem: GraphTreeItem;
     private readonly _storedProceduresTreeItem: DocDBStoredProceduresTreeItem;

--- a/src/graph/tree/GraphTreeItem.ts
+++ b/src/graph/tree/GraphTreeItem.ts
@@ -15,7 +15,7 @@ const alternativeGraphVisualizationToolsDocLink = 'https://aka.ms/cosmosdb-graph
 export class GraphTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'cosmosDBGraphGraph';
     public readonly contextValue: string = GraphTreeItem.contextValue;
-    public readonly parent: GraphCollectionTreeItem;
+    public declare readonly parent: GraphCollectionTreeItem;
     public suppressMaskLabel = true;
 
     private readonly _collection: ContainerDefinition & Resource;

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -70,6 +70,7 @@ export class MongoCollectionTreeItem extends AzExtParentTreeItem implements IEdi
     // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
     constructor(parent: AzExtParentTreeItem, collection: Collection, findArgs?: Object[]) {
         super(parent);
+        this.parent = parent;
         this.collection = collection;
         this.findArgs = findArgs;
         if (findArgs && findArgs.length) {

--- a/src/mongo/tree/MongoCollectionTreeItem.ts
+++ b/src/mongo/tree/MongoCollectionTreeItem.ts
@@ -55,7 +55,7 @@ export class MongoCollectionTreeItem extends AzExtParentTreeItem implements IEdi
     public readonly contextValue: string = MongoCollectionTreeItem.contextValue;
     public readonly childTypeLabel: string = 'Document';
     public readonly collection: Collection;
-    public parent: AzExtParentTreeItem;
+    public declare parent: AzExtParentTreeItem;
     // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
     public findArgs?: Object[];
     public readonly cTime: number = Date.now();
@@ -70,7 +70,6 @@ export class MongoCollectionTreeItem extends AzExtParentTreeItem implements IEdi
     // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
     constructor(parent: AzExtParentTreeItem, collection: Collection, findArgs?: Object[]) {
         super(parent);
-        this.parent = parent;
         this.collection = collection;
         this.findArgs = findArgs;
         if (findArgs && findArgs.length) {

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -37,14 +37,13 @@ export class MongoDatabaseTreeItem extends AzExtParentTreeItem {
     public readonly childTypeLabel: string = 'Collection';
     public readonly connectionString: string;
     public readonly databaseName: string;
-    public readonly parent: MongoAccountTreeItem;
+    public declare readonly parent: MongoAccountTreeItem;
 
     private _previousShellPathSetting: string | undefined;
     private _cachedShellPathOrCmd: string | undefined;
 
     constructor(parent: MongoAccountTreeItem, databaseName: string, connectionString: string) {
         super(parent);
-        this.parent = parent;
         this.databaseName = databaseName;
         this.connectionString = addDatabaseToAccountConnectionString(connectionString, this.databaseName);
     }

--- a/src/mongo/tree/MongoDatabaseTreeItem.ts
+++ b/src/mongo/tree/MongoDatabaseTreeItem.ts
@@ -44,6 +44,7 @@ export class MongoDatabaseTreeItem extends AzExtParentTreeItem {
 
     constructor(parent: MongoAccountTreeItem, databaseName: string, connectionString: string) {
         super(parent);
+        this.parent = parent;
         this.databaseName = databaseName;
         this.connectionString = addDatabaseToAccountConnectionString(connectionString, this.databaseName);
     }

--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -44,6 +44,7 @@ export class MongoDocumentTreeItem extends AzExtTreeItem implements IEditableTre
 
     constructor(parent: MongoCollectionTreeItem, document: IMongoDocument) {
         super(parent);
+        this.parent = parent;
         this.document = document;
         this._label = getDocumentTreeItemLabel(this.document);
         this.commandId = 'cosmosDB.openDocument';

--- a/src/mongo/tree/MongoDocumentTreeItem.ts
+++ b/src/mongo/tree/MongoDocumentTreeItem.ts
@@ -36,7 +36,7 @@ export class MongoDocumentTreeItem extends AzExtTreeItem implements IEditableTre
     public static contextValue: string = 'MongoDocument';
     public readonly contextValue: string = MongoDocumentTreeItem.contextValue;
     public document: IMongoDocument;
-    public readonly parent: MongoCollectionTreeItem;
+    public declare readonly parent: MongoCollectionTreeItem;
     public readonly cTime: number = Date.now();
     public mTime: number = Date.now();
 
@@ -44,7 +44,6 @@ export class MongoDocumentTreeItem extends AzExtTreeItem implements IEditableTre
 
     constructor(parent: MongoCollectionTreeItem, document: IMongoDocument) {
         super(parent);
-        this.parent = parent;
         this.document = document;
         this._label = getDocumentTreeItemLabel(this.document);
         this.commandId = 'cosmosDB.openDocument';

--- a/src/postgres/tree/PostgresColumnTreeItem.ts
+++ b/src/postgres/tree/PostgresColumnTreeItem.ts
@@ -11,7 +11,7 @@ export class PostgresColumnTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'postgresColumn';
     public readonly contextValue: string = PostgresColumnTreeItem.contextValue;
     public readonly columnName: string;
-    public readonly parent: PostgresTableTreeItem;
+    public declare readonly parent: PostgresTableTreeItem;
 
     constructor(parent: PostgresTableTreeItem, columnName: string) {
         super(parent);

--- a/src/postgres/tree/PostgresDatabaseTreeItem.ts
+++ b/src/postgres/tree/PostgresDatabaseTreeItem.ts
@@ -30,7 +30,7 @@ export class PostgresDatabaseTreeItem extends AzExtParentTreeItem {
     public contextValue: string = PostgresDatabaseTreeItem.contextValue;
     public readonly childTypeLabel: string = 'Resource Type';
     public readonly databaseName: string;
-    public readonly parent: PostgresServerTreeItem;
+    public declare readonly parent: PostgresServerTreeItem;
     public autoSelectInTreeItemPicker: boolean = true;
     public isShowingPasswordWarning: boolean;
 

--- a/src/postgres/tree/PostgresFunctionTreeItem.ts
+++ b/src/postgres/tree/PostgresFunctionTreeItem.ts
@@ -12,7 +12,7 @@ import { type PostgresFunctionsTreeItem } from './PostgresFunctionsTreeItem';
 export class PostgresFunctionTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'postgresFunction';
     public readonly contextValue: string = PostgresFunctionTreeItem.contextValue;
-    public readonly parent: PostgresFunctionsTreeItem;
+    public declare readonly parent: PostgresFunctionsTreeItem;
     public readonly schema: string;
     public readonly name: string;
     public readonly args: string;

--- a/src/postgres/tree/PostgresResourcesTreeItemBase.ts
+++ b/src/postgres/tree/PostgresResourcesTreeItemBase.ts
@@ -9,7 +9,7 @@ import { type PostgresDatabaseTreeItem } from './PostgresDatabaseTreeItem';
 
 // Base class for Postgres tree items whose children are individual resources
 export abstract class PostgresResourcesTreeItemBase extends AzExtParentTreeItem {
-    public parent: PostgresDatabaseTreeItem;
+    public declare parent: PostgresDatabaseTreeItem;
     public clientConfig: ClientConfig;
     public resourcesAndSchemas: { [key: string]: string[] }; // Resource name to list of schemas
 

--- a/src/postgres/tree/PostgresStoredProcedureTreeItem.ts
+++ b/src/postgres/tree/PostgresStoredProcedureTreeItem.ts
@@ -12,7 +12,7 @@ import { type PostgresStoredProceduresTreeItem } from './PostgresStoredProcedure
 export class PostgresStoredProcedureTreeItem extends AzExtTreeItem {
     public static contextValue: string = 'postgresStoredProcedure';
     public readonly contextValue: string = PostgresStoredProcedureTreeItem.contextValue;
-    public readonly parent: PostgresStoredProceduresTreeItem;
+    public declare readonly parent: PostgresStoredProceduresTreeItem;
     public readonly schema: string;
     public readonly name: string;
     public readonly args: string;

--- a/src/postgres/tree/PostgresTableTreeItem.ts
+++ b/src/postgres/tree/PostgresTableTreeItem.ts
@@ -14,7 +14,7 @@ export class PostgresTableTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'postgresTable';
     public readonly contextValue: string = PostgresTableTreeItem.contextValue;
     public readonly table: IPostgresTable;
-    public readonly parent: PostgresTablesTreeItem;
+    public declare readonly parent: PostgresTablesTreeItem;
 
     private _isDuplicate: boolean;
 


### PR DESCRIPTION
This led to the following error:
```
Error: Internal error: 'branchDataProvider.getTreeItem' threw exception Internal error: Expected value to be neither null nor undefined: parent
```
![image](https://github.com/user-attachments/assets/f3fedb70-93ce-40e2-9fa3-45d4ee0ed524)

Which is now fixed:
![image](https://github.com/user-attachments/assets/015273e0-09b0-4686-92a3-1e47a94a2291)
