### PR TITLE
Fix an issue where a Document shows as "undefined" if _id is not set

### DIFF
--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -109,7 +109,7 @@ export function getDocumentTreeItemLabel(document: IMongoDocument | ItemDefiniti
             }
         }
     }
-    return String(document._id);
+    return String(document._id ?? document.id);
 }
 
 function getDocumentLabelFields(): string[] {


### PR DESCRIPTION
This is likely to happen if "id" has been removed from the cosmosDB.documentLabelFields setting.

![image](https://github.com/user-attachments/assets/d51f1914-58e1-4a8e-847d-cb74b385f479)
