### PR TITLE
Fix an issue where a MongoDB connection error might be hidden

### DIFF
--- a/src/mongo/tree/MongoAccountTreeItem.ts
+++ b/src/mongo/tree/MongoAccountTreeItem.ts
@@ -103,7 +103,7 @@ export class MongoAccountTreeItem extends AzExtParentTreeItem {
                 );
         } catch (error) {
             const message = parseError(error).message;
-            if (this._root.isEmulator && message.includes('ECONNREFUSED')) {
+            if (this.root?.isEmulator && message.includes('ECONNREFUSED')) {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 error.message = `Unable to reach emulator. See ${Links.LocalConnectionDebuggingTips} for debugging tips.\n${message}`;
             }


### PR DESCRIPTION
If the connection to a Mongo RU account fails, the actual error is not shown, instead there is another error:
![image](https://github.com/user-attachments/assets/d69cadf7-c9e3-4189-8049-346a04cc8ec4) since `this._root.isEmulator` might be undefined.

