### PR TITLE
Improve server names when creating a new resource

### DIFF
--- a/src/AzureDBExperiences.ts
+++ b/src/AzureDBExperiences.ts
@@ -106,12 +106,13 @@ export function getExperienceQuickPickForAttached(api: API): IAzureQuickPickItem
 
 // Mongo is distinguished by having kind="MongoDB". All others have kind="GlobalDocumentDB"
 // Table and Gremlin are distinguished from SQL by their capabilities
+// Tags reflect the defaultExperience tag in the portal and should not be changed unless they are changed in the portal
 export const CoreExperience: Experience = {
     api: API.Core,
     longName: 'Azure Cosmos DB NoSQL',
     shortName: 'NoSQL',
     kind: DBAccountKind.GlobalDocumentDB,
-    tag: 'Azure Cosmos DB NoSQL',
+    tag: 'Core (SQL)',
 } as const;
 export const MongoExperience: Experience = {
     api: API.MongoDB,

--- a/src/AzureDBExperiences.ts
+++ b/src/AzureDBExperiences.ts
@@ -109,21 +109,21 @@ export function getExperienceQuickPickForAttached(api: API): IAzureQuickPickItem
 // Tags reflect the defaultExperience tag in the portal and should not be changed unless they are changed in the portal
 export const CoreExperience: Experience = {
     api: API.Core,
-    longName: 'Azure Cosmos DB NoSQL',
+    longName: 'Cosmos DB for NoSQL',
     shortName: 'NoSQL',
     kind: DBAccountKind.GlobalDocumentDB,
     tag: 'Core (SQL)',
 } as const;
 export const MongoExperience: Experience = {
     api: API.MongoDB,
-    longName: 'Azure Cosmos DB for MongoDB API',
+    longName: 'Cosmos DB for MongoDB',
     shortName: 'MongoDB',
     kind: DBAccountKind.MongoDB,
     tag: 'Azure Cosmos DB for MongoDB API',
 } as const;
 export const TableExperience: Experience = {
     api: API.Table,
-    longName: 'Azure Table',
+    longName: 'Cosmos DB for Table',
     shortName: 'Table',
     kind: DBAccountKind.GlobalDocumentDB,
     capability: 'EnableTable',
@@ -131,8 +131,8 @@ export const TableExperience: Experience = {
 } as const;
 export const GremlinExperience: Experience = {
     api: API.Graph,
-    longName: 'Gremlin',
-    description: '(graph)',
+    longName: 'Cosmos DB for Gremlin',
+    description: '(Graph)',
     shortName: 'Gremlin',
     kind: DBAccountKind.GlobalDocumentDB,
     capability: 'EnableGremlin',

--- a/src/tree/AzureDBAPIStep.ts
+++ b/src/tree/AzureDBAPIStep.ts
@@ -33,7 +33,7 @@ export class AzureDBAPIStep extends AzureWizardPromptStep<IPostgresServerWizardC
         const picks: IAzureQuickPickItem<Experience>[] = getExperienceQuickPicks();
 
         const result: IAzureQuickPickItem<Experience> = await context.ui.showQuickPick(picks, {
-            placeHolder: localize('selectDBServerMsg', 'Select an Azure Database Server.'),
+            placeHolder: localize('selectDBServerMsg', 'Select an Azure Database Server'),
         });
 
         context.defaultExperience = result.data;


### PR DESCRIPTION
When creating a new database resource it currently looks like this:
![image](https://github.com/user-attachments/assets/ade45d36-c953-4fa9-9e46-19e67bfc1f75)

This change unifies Cosmos DB naming to align better with branding and documentation:
![image](https://github.com/user-attachments/assets/8d9f6929-9a6c-4721-8612-9fcb820ba506)
