### PR TITLE
Add vCore to Mongo Capacity Mode selection

### DIFF
--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountCapacityStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountCapacityStep.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, type IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import { AzureWizardPromptStep, UserCancelledError, type IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import { API } from '../../AzureDBExperiences';
 import { localize } from '../../utils/localize';
 import { openUrl } from '../../utils/openUrl';
 import { type ICosmosDBWizardContext } from './ICosmosDBWizardContext';
@@ -30,6 +31,18 @@ export class CosmosDBAccountCapacityStep extends AzureWizardPromptStep<ICosmosDB
                 data: true,
             },
         ];
+        const vcore: IAzureQuickPickItem<boolean | undefined> = {
+            label: localize('vCoreOption', '$(link-external) vCore cluster'),
+            detail: localize(
+                'vCoreOptionDescription',
+                'Fully managed MongoDB-compatible database service',
+            ),
+            description: localize('vCoreOptionPortalHint', '(Create in Azure Portal...)'),
+            data: false,
+        };
+        if (context.defaultExperience?.api === API.MongoDB) {
+            picks.push(vcore);
+        }
         const learnMore: IAzureQuickPickItem = {
             label: localize('learnMore', '$(link-external) Learn more...'),
             data: undefined,
@@ -51,6 +64,11 @@ export class CosmosDBAccountCapacityStep extends AzureWizardPromptStep<ICosmosDB
         if (pick.data) {
             context.isServerless = pick.data;
             context.telemetry.properties.isServerless = pick.data ? 'true' : 'false';
+        }
+        if (pick === vcore) {
+            await openUrl("https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/quickstart-portal");
+            context.telemetry.properties.isvCore = 'true';
+            throw new UserCancelledError();
         }
     }
 

--- a/src/tree/CosmosDBAccountWizard/CosmosDBAccountCapacityStep.ts
+++ b/src/tree/CosmosDBAccountWizard/CosmosDBAccountCapacityStep.ts
@@ -10,10 +10,25 @@ import { type ICosmosDBWizardContext } from './ICosmosDBWizardContext';
 
 export class CosmosDBAccountCapacityStep extends AzureWizardPromptStep<ICosmosDBWizardContext> {
     public async prompt(context: ICosmosDBWizardContext): Promise<void> {
-        const placeHolder: string = localize('selectDBServerMsg', 'Select a capacity model.');
+        const learnMoreLink: string = 'https://aka.ms/cosmos-models';
+        const placeHolder: string = localize('selectDBServerMsg', 'Select a capacity model');
         const picks: IAzureQuickPickItem<boolean | undefined>[] = [
-            { label: localize('provisionedOption', 'Provisioned Throughput'), data: false },
-            { label: localize('serverlessOption', 'Serverless'), data: true },
+            {
+                label: localize('provisionedOption', 'Provisioned Throughput'),
+                detail: localize(
+                    'provisionedOptionDescription',
+                    'Workloads with sustained traffic requiring predictable performance',
+                ),
+                data: false,
+            },
+            {
+                label: localize('serverlessOption', 'Serverless'),
+                detail: localize(
+                    'serverlessOptionDescription',
+                    'Workloads with intermittent or unpredictable traffic and low average-to-peak traffic ratio',
+                ),
+                data: true,
+            },
         ];
         const learnMore: IAzureQuickPickItem = {
             label: localize('learnMore', '$(link-external) Learn more...'),
@@ -23,9 +38,13 @@ export class CosmosDBAccountCapacityStep extends AzureWizardPromptStep<ICosmosDB
         let pick: IAzureQuickPickItem<boolean | undefined>;
 
         do {
-            pick = await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true });
+            pick = await context.ui.showQuickPick(picks, {
+                placeHolder,
+                suppressPersistence: true,
+                learnMoreLink: learnMoreLink,
+            });
             if (pick === learnMore) {
-                await openUrl('https://aka.ms/cosmos-models');
+                await openUrl(learnMoreLink);
             }
         } while (pick === learnMore);
 


### PR DESCRIPTION
This is based on #2386 and adds an additional "vCore" item to the capacity mode selection step when creating a new Mongo server:

![image](https://github.com/user-attachments/assets/0abe771e-20f4-49be-97a6-08b35d40d8ab)

* Selecting the new item opens https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/quickstart-portal in the browser and closes the wizard.
* In addition an isvCore = 'true' property is added to telemetry