### PR TITLE
Remove the obsolete showExplorer setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1269,11 +1269,6 @@
                     "description": "The batch size to be used when querying Azure Database resources.",
                     "default": 50
                 },
-                "azureDatabases.showExplorer": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Show or hide the Azure Databases Explorer"
-                },
                 "azureDatabases.useCosmosOAuth": {
                     "type": "boolean",
                     "markdownDescription": "Always authenticate using Entra ID RBAC when connecting to Cosmos DB NoSQL Accounts. [Enable RBAC and assign Roles](https://aka.ms/cosmos-native-rbac).",


### PR DESCRIPTION
This setting is not used anywhere and it's not clear what it's meant to be used for.
Fixes #2398