### PR TITLE
fix: remove unnecessary code since patch fix was applied in upstream repo

### DIFF
--- a/src/webviews/QueryEditor/ResultPanel/ResultTabViewTree.tsx
+++ b/src/webviews/QueryEditor/ResultPanel/ResultTabViewTree.tsx
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { useEffect } from 'react';
 import { FieldType, Formatters, SlickgridReact, type GridOption } from 'slickgrid-react';
 
 type ResultTabViewTreeProps = {
@@ -61,23 +60,6 @@ export const ResultTabViewTree = ({ data }: ResultTabViewTreeProps) => {
         enableHeaderButton: false,
         enableHeaderMenu: false,
     };
-
-    useEffect(() => {
-        return () => {
-            /**
-             * The following code is required to undo modifications made to the data
-             * by the SlickGrid Tree Data plugin. If you don't do this, the data
-             * will start to duplicate as the 'children' property is filled with
-             * new nodes on each mount. This leads to duplicates and the tree view crashing.
-             *
-             * This is a known issue with the SlickGrid Tree Data plugin and is being discussed here:
-             * https://github.com/ghiscoding/slickgrid-universal/discussions/1655
-             */
-            data.forEach((item) => {
-                delete item.children;
-            });
-        };
-    }, []);
 
     return (
         <SlickgridReact

--- a/src/webviews/mongoClusters/collectionView/components/DataViewPanelTree.tsx
+++ b/src/webviews/mongoClusters/collectionView/components/DataViewPanelTree.tsx
@@ -77,27 +77,6 @@ export const DataViewPanelTree = ({ liveData }: Props): React.JSX.Element => {
         enableHeaderMenu: false,
     };
 
-    React.useEffect(() => {
-        console.log('Tree View has mounted');
-
-        return () => {
-            console.log('Tree View will unmount');
-
-            /**
-             * The folowing code is required to undo modifications made to the data
-             * by the SlickGrid Tree Data plugin. If you don't do this, the data
-             * will start to duplicate as the 'children' property is filled with
-             * new nodes on each mount. This leads to duplicates and the tree view crashing.
-             *
-             * This is a known issue with the SlickGrid Tree Data plugin and is being discussed here:
-             * https://github.com/ghiscoding/slickgrid-universal/discussions/1655
-             */
-            liveData.forEach((item) => {
-                delete item.children;
-            });
-        };
-    }, []);
-
     // Empty dependency array means this runs only once, like componentDidMount
 
     return (


### PR DESCRIPTION
- this was fixed a while ago in upstream repos, which I maintain, Slickgrid-React v5.7 (Slickgrid-Universal) via these 2 PRs 
  - https://github.com/ghiscoding/slickgrid-universal/issues/1658
  - https://github.com/ghiscoding/slickgrid-universal/pull/1675
- this was discussed in this upstream [Discussion](https://github.com/ghiscoding/slickgrid-universal/discussions/1655) 

cc @tnaum-ms

Side note: I don't have any Azure DBs, so I can't really test this myself. 