### PR TITLE
fix: Workaround to prevent Monaco loose a focus and handle "tab" key as text modifier

### DIFF
--- a/src/webviews/MonacoEditor.tsx
+++ b/src/webviews/MonacoEditor.tsx
@@ -7,6 +7,7 @@ import Editor, { loader, useMonaco, type EditorProps } from '@monaco-editor/reac
 // eslint-disable-next-line import/no-internal-modules
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
+import { useUncontrolledFocus } from '@fluentui/react-components';
 import { useEffect } from 'react';
 import { useThemeState } from './theme/state/ThemeContext';
 
@@ -15,6 +16,7 @@ loader.config({ monaco: monacoEditor });
 export const MonacoEditor = (props: EditorProps) => {
     const monaco = useMonaco();
     const themeState = useThemeState();
+    const attr = useUncontrolledFocus();
 
     useEffect(() => {
         if (monaco) {
@@ -25,5 +27,14 @@ export const MonacoEditor = (props: EditorProps) => {
         }
     }, [monaco, themeState]);
 
-    return <Editor {...props} theme={themeState.monaco.themeName} /*onMount={handleEditorDidMount}*/ />;
+    return (
+        <section {...attr} style={{ width: '100%', height: '100%' }}>
+            <Editor {...props} theme={themeState.monaco.themeName} />
+            <input
+                style={{ position: 'absolute', width: '1px', height: '1px' }}
+                id="monaco-editor-aria-container"
+                aria-label="Element to prevent loosing focus from editor"
+            />
+        </section>
+    );
 };

--- a/src/webviews/MonacoEditor.tsx
+++ b/src/webviews/MonacoEditor.tsx
@@ -31,7 +31,7 @@ export const MonacoEditor = (props: EditorProps) => {
         <section {...attr} style={{ width: '100%', height: '100%' }}>
             <Editor {...props} theme={themeState.monaco.themeName} />
             <input
-                style={{ position: 'absolute', width: '1px', height: '1px' }}
+                style={{ position: 'absolute', width: '1px', height: '1px', top: '0px', zIndex: -999 }}
                 id="monaco-editor-aria-container"
                 aria-label="Element to prevent loosing focus from editor"
             />


### PR DESCRIPTION
Fixes #2431

This pull request includes changes to the `MonacoEditor` component in `src/webviews/MonacoEditor.tsx` to improve focus management and accessibility. The most important changes include importing a new hook, using the hook to manage focus, and updating the component's return structure to include an input element for accessibility.

Focus management improvements:

* [`src/webviews/MonacoEditor.tsx`](diffhunk://#diff-658c73b23462509bae5644a5ab3451996ec26c97b3e4231f2539e5aea0f1a60fR10): Imported the `useUncontrolledFocus` hook from `@fluentui/react-components`.
* [`src/webviews/MonacoEditor.tsx`](diffhunk://#diff-658c73b23462509bae5644a5ab3451996ec26c97b3e4231f2539e5aea0f1a60fR19): Utilized the `useUncontrolledFocus` hook within the `MonacoEditor` component to manage focus attributes.
* [`src/webviews/MonacoEditor.tsx`](diffhunk://#diff-658c73b23462509bae5644a5ab3451996ec26c97b3e4231f2539e5aea0f1a60fL28-R39): Updated the return structure of the `MonacoEditor` component to include a `section` element with focus attributes and an `input` element to prevent losing focus from the editor.