### PR TITLE
fix: Supports hasMore property

### DIFF
--- a/src/docdb/session/QuerySession.ts
+++ b/src/docdb/session/QuerySession.ts
@@ -147,6 +147,10 @@ export class QuerySession {
                 throw new Error('Cannot fetch next page if all records have been fetched before');
             }
 
+            if (this.sessionResult.getResult(this.currentIteration)?.hasMoreResults === false) {
+                throw new Error('Cannot fetch next page if current page is the last page');
+            }
+
             await this.wrappedFetch(context, async () => {
                 if (this.currentIteration + 1 > this.sessionResult.iterationsCount) {
                     const response = await this.iterator!.fetchNext();

--- a/src/docdb/session/QuerySessionResult.ts
+++ b/src/docdb/session/QuerySessionResult.ts
@@ -62,6 +62,7 @@ export class QuerySessionResult {
             queryMetrics: (response.queryMetrics as unknown as QueryMetrics[])['0'],
             requestCharge: response.requestCharge,
             roundTrips: 1, // TODO: Is it required field? Query Pages Until Content Present
+            hasMoreResults: response.hasMoreResults,
         });
         this.hasMoreResults = response.hasMoreResults;
     }
@@ -74,13 +75,21 @@ export class QuerySessionResult {
         const result = this.queryResults.get(pageNumber);
 
         if (result) {
-            return {
+            const serializedResult: SerializedQueryResult = {
                 activityId: result.activityId,
                 documents: result.documents ?? [],
                 iteration: result.iteration,
                 metadata: this.metadata,
                 indexMetrics: result.indexMetrics,
-                queryMetrics: {
+                requestCharge: result.requestCharge,
+                roundTrips: result.roundTrips,
+                hasMoreResults: result.hasMoreResults,
+
+                query: this.query,
+            };
+
+            if (result.queryMetrics) {
+                serializedResult.queryMetrics = {
                     documentLoadTime: result.queryMetrics.documentLoadTime.totalMilliseconds(),
                     documentWriteTime: result.queryMetrics.documentWriteTime.totalMilliseconds(),
                     indexHitDocumentCount: result.queryMetrics.indexHitDocumentCount,
@@ -99,12 +108,10 @@ export class QuerySessionResult {
                             result.queryMetrics.runtimeExecutionTimes.userDefinedFunctionExecutionTime.totalMilliseconds(),
                     },
                     totalQueryExecutionTime: result.queryMetrics.totalQueryExecutionTime.totalMilliseconds(),
-                },
-                requestCharge: result.requestCharge,
-                roundTrips: result.roundTrips,
+                };
+            }
 
-                query: this.query,
-            };
+            return serializedResult;
         }
 
         return undefined;

--- a/src/docdb/types/queryResult.ts
+++ b/src/docdb/types/queryResult.ts
@@ -47,9 +47,10 @@ export type QueryResult = {
     iteration: number;
     metadata: ResultViewMetadata;
     indexMetrics: string;
-    queryMetrics: QueryMetrics;
+    queryMetrics?: QueryMetrics;
     requestCharge: number;
     roundTrips: number;
+    hasMoreResults: boolean;
 };
 
 export type SerializedQueryMetrics = {
@@ -76,9 +77,10 @@ export type SerializedQueryResult = {
     iteration: number;
     metadata: ResultViewMetadata;
     indexMetrics: string;
-    queryMetrics: SerializedQueryMetrics;
+    queryMetrics?: SerializedQueryMetrics;
     requestCharge: number;
     roundTrips: number;
+    hasMoreResults: boolean;
 
     query: string; // The query that was executed
 };

--- a/src/utils/convertors.ts
+++ b/src/utils/convertors.ts
@@ -353,7 +353,7 @@ export const queryResultToTable = (
 };
 
 export const queryMetricsToTable = (queryResult: SerializedQueryResult | null): StatsItem[] => {
-    if (!queryResult) {
+    if (!queryResult || queryResult?.queryMetrics === undefined) {
         return [];
     }
 

--- a/src/webviews/QueryEditor/ResultPanel/ResultPanelToolbar.tsx
+++ b/src/webviews/QueryEditor/ResultPanel/ResultPanelToolbar.tsx
@@ -227,6 +227,18 @@ export const ResultPanelToolbar = ({ selectedTab }: ResultToolbarProps) => {
     const dispatcher = useQueryEditorDispatcher();
     const restoreFocusTargetAttribute = useRestoreFocusTarget();
 
+    const hasMoreResults = state.currentQueryResult?.hasMoreResults ?? false;
+    const toFirstPageDisabled =
+        state.pageNumber === 1 || !state.isConnected || state.isExecuting || !state.currentExecutionId;
+    const toPrevPageDisabled =
+        state.pageNumber === 1 || !state.isConnected || state.isExecuting || !state.currentExecutionId;
+    const toNextPageDisabled =
+        state.pageSize === -1 || // Disable if page size is set to 'All'
+        !state.isConnected ||
+        state.isExecuting ||
+        !state.currentExecutionId ||
+        !hasMoreResults;
+
     const [open, setOpen] = useState(false);
     const [doAction, setDoAction] = useState<() => Promise<void>>(() => async () => {});
 
@@ -290,12 +302,7 @@ export const ResultPanelToolbar = ({ selectedTab }: ResultToolbarProps) => {
                         onClick={() => void firstPage()}
                         aria-label="Go to start"
                         icon={<ArrowPreviousFilled />}
-                        disabled={
-                            state.pageNumber === 1 ||
-                            !state.isConnected ||
-                            state.isExecuting ||
-                            !state.currentExecutionId
-                        }
+                        disabled={toFirstPageDisabled}
                     />
                 </Tooltip>
 
@@ -304,12 +311,7 @@ export const ResultPanelToolbar = ({ selectedTab }: ResultToolbarProps) => {
                         onClick={() => void prevPage()}
                         aria-label="Go to previous page"
                         icon={<ArrowLeftFilled />}
-                        disabled={
-                            state.pageNumber === 1 ||
-                            !state.isConnected ||
-                            state.isExecuting ||
-                            !state.currentExecutionId
-                        }
+                        disabled={toPrevPageDisabled}
                     />
                 </Tooltip>
 
@@ -318,12 +320,7 @@ export const ResultPanelToolbar = ({ selectedTab }: ResultToolbarProps) => {
                         onClick={() => void nextPage()}
                         aria-label="Go to next page"
                         icon={<ArrowRightFilled />}
-                        disabled={
-                            state.pageSize === -1 ||
-                            !state.isConnected ||
-                            state.isExecuting ||
-                            !state.currentExecutionId
-                        } // Disable if page size is set to 'All'
+                        disabled={toNextPageDisabled}
                     />
                 </Tooltip>
 


### PR DESCRIPTION
Fixes #2438
- Button 'Go to next page' is disabled if hasMore is false
- No error if queryMetrics is empty