### PR TITLE
fix: Default color for Run and Connect icons

### DIFF
--- a/src/webviews/QueryEditor/QueryPanel/QueryToolbar.tsx
+++ b/src/webviews/QueryEditor/QueryPanel/QueryToolbar.tsx
@@ -31,19 +31,13 @@ import {
 import { useQueryEditorDispatcher, useQueryEditorState } from '../state/QueryEditorContext';
 
 const useClasses = makeStyles({
-    iconPlay: {
-        color: tokens.colorStatusSuccessBorderActive,
-    },
     iconStop: {
         color: tokens.colorStatusDangerBorderActive,
-    },
-    iconConnect: {
-        color: tokens.colorStatusSuccessBorderActive,
     },
     iconDisconnect: {
         color: tokens.colorStatusDangerBorderActive,
     },
-});
+}); // #005aa1  #1765BF
 
 const BaseActionsSection = () => {
     const classes = useClasses();
@@ -72,7 +66,7 @@ const BaseActionsSection = () => {
                     {(triggerProps: MenuButtonProps) => (
                         <SplitButton
                             aria-label="Run"
-                            icon={<PlayRegular className={classes.iconPlay} />}
+                            icon={<PlayRegular />}
                             disabled={state.isExecuting || !state.isConnected}
                             appearance={'primary'}
                             menuButton={triggerProps}
@@ -185,14 +179,13 @@ const ConnectedActionsSection = () => {
 };
 
 const DisconnectedActionsSection = () => {
-    const classes = useClasses();
     const dispatcher = useQueryEditorDispatcher();
 
     return (
         <ToolbarButton
             aria-label="Connect"
             appearance={'primary'}
-            icon={<DatabasePlugConnectedRegular className={classes.iconConnect} />}
+            icon={<DatabasePlugConnectedRegular />}
             onClick={() => void dispatcher.connectToDatabase()}
         >
             Connect


### PR DESCRIPTION
- Default color always has high contrast ration with primary color

![image](https://github.com/user-attachments/assets/bf900729-e67a-4ad8-b6d7-95db9f62220c)
![image](https://github.com/user-attachments/assets/d1a69d82-eb66-482e-93a6-6a5e80c00e44)

The contrast ratio of the "Run" icon is greater than 3:1 in query editor.