### PR TITLE
Enable Attach Emulator on Linux and MacOS

### DIFF
--- a/src/commands/attachEmulator/attachEmulator.ts
+++ b/src/commands/attachEmulator/attachEmulator.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, type IActionContext } from '@microsoft/vscode-azext-utils';
-import { isLinux, isWindows } from '../../constants';
+import { isEmulatorSupported } from '../../constants';
 import { type CosmosDBAttachEmulatorResourceItem } from '../../tree/attached/CosmosDBAttachEmulatorResourceItem';
 import { localize } from '../../utils/localize';
 import { type AttachEmulatorWizardContext } from './AttachEmulatorWizardContext';
@@ -13,9 +13,14 @@ import { PromptExperienceStep } from './PromptExperienceStep';
 import { PromptPortStep } from './PromptPortStep';
 
 export async function attachEmulator(context: IActionContext, node: CosmosDBAttachEmulatorResourceItem) {
-    if (!isWindows && !isLinux) {
+    if (!isEmulatorSupported) {
         context.errorHandling.suppressReportIssue = true;
-        throw new Error(localize('emulatorNotSupported', 'The Cosmos DB emulator is only supported on Windows.'));
+        throw new Error(
+            localize(
+                'emulatorNotSupported',
+                'The Cosmos DB emulator is only supported on Windows, Linux and MacOS (Intel).',
+            ),
+        );
     }
 
     const wizardContext: AttachEmulatorWizardContext = { ...context, parentTreeElementId: node.parentId };

--- a/src/commands/attachEmulator/attachEmulator.ts
+++ b/src/commands/attachEmulator/attachEmulator.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, type IActionContext } from '@microsoft/vscode-azext-utils';
-import { platform } from 'os';
+import { isLinux, isWindows } from '../../constants';
 import { type CosmosDBAttachEmulatorResourceItem } from '../../tree/attached/CosmosDBAttachEmulatorResourceItem';
 import { localize } from '../../utils/localize';
 import { type AttachEmulatorWizardContext } from './AttachEmulatorWizardContext';
@@ -13,7 +13,7 @@ import { PromptExperienceStep } from './PromptExperienceStep';
 import { PromptPortStep } from './PromptPortStep';
 
 export async function attachEmulator(context: IActionContext, node: CosmosDBAttachEmulatorResourceItem) {
-    if (platform() !== 'win32') {
+    if (!isWindows && !isLinux) {
         context.errorHandling.suppressReportIssue = true;
         throw new Error(localize('emulatorNotSupported', 'The Cosmos DB emulator is only supported on Windows.'));
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@
 
 export const isWindows: boolean = /^win/.test(process.platform);
 export const isLinux: boolean = /^linux/.test(process.platform);
+export const isMacOS: boolean = /^darwin/.test(process.platform);
 
 import * as fs from 'fs';
 import assert from 'node:assert';
@@ -93,6 +94,8 @@ export const defaultTrigger = `function trigger() {
 
 export const emulatorPassword =
     'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==';
+
+export const isEmulatorSupported = isWindows || isLinux || (isMacOS && process.arch === 'x64');
 
 // https://docs.mongodb.com/manual/mongo/#working-with-the-mongo-shell
 export const testDb: string = 'test';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const isWindows: boolean = /^win/.test(process.platform);
+export const isLinux: boolean = /^linux/.test(process.platform);
 
 import * as fs from 'fs';
 import assert from 'node:assert';

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -14,7 +14,7 @@ import {
 import * as vscode from 'vscode';
 import { API, getExperienceFromApi } from '../AzureDBExperiences';
 import { removeTreeItemFromCache } from '../commands/api/apiCache';
-import { isWindows } from '../constants';
+import { isLinux, isWindows } from '../constants';
 import { ext } from '../extensionVariables';
 import { parsePostgresConnectionString } from '../postgres/postgresConnectionStrings';
 import { PostgresServerTreeItem } from '../postgres/tree/PostgresServerTreeItem';
@@ -39,7 +39,7 @@ export interface PersistedAccountWithConnectionString {
 export const AttachedAccountSuffix: string = 'Attached';
 
 export class AttachedAccountsTreeItem extends AzExtParentTreeItem {
-    public static contextValue: string = 'cosmosDBAttachedAccounts' + (isWindows ? 'WithEmulator' : 'WithoutEmulator');
+    public static contextValue: string = 'cosmosDBAttachedAccounts' + ((isWindows || isLinux) ? 'WithEmulator' : 'WithoutEmulator');
     public static readonly serviceName: string = 'ms-azuretools.vscode-cosmosdb.connectionStrings';
     public readonly contextValue: string = AttachedAccountsTreeItem.contextValue;
     public readonly label: string = 'Attached Database Accounts (Postgres)';

--- a/src/tree/AttachedAccountsTreeItem.ts
+++ b/src/tree/AttachedAccountsTreeItem.ts
@@ -14,7 +14,7 @@ import {
 import * as vscode from 'vscode';
 import { API, getExperienceFromApi } from '../AzureDBExperiences';
 import { removeTreeItemFromCache } from '../commands/api/apiCache';
-import { isLinux, isWindows } from '../constants';
+import { isEmulatorSupported } from '../constants';
 import { ext } from '../extensionVariables';
 import { parsePostgresConnectionString } from '../postgres/postgresConnectionStrings';
 import { PostgresServerTreeItem } from '../postgres/tree/PostgresServerTreeItem';
@@ -39,7 +39,8 @@ export interface PersistedAccountWithConnectionString {
 export const AttachedAccountSuffix: string = 'Attached';
 
 export class AttachedAccountsTreeItem extends AzExtParentTreeItem {
-    public static contextValue: string = 'cosmosDBAttachedAccounts' + ((isWindows || isLinux) ? 'WithEmulator' : 'WithoutEmulator');
+    public static contextValue: string =
+        'cosmosDBAttachedAccounts' + (isEmulatorSupported ? 'WithEmulator' : 'WithoutEmulator');
     public static readonly serviceName: string = 'ms-azuretools.vscode-cosmosdb.connectionStrings';
     public readonly contextValue: string = AttachedAccountsTreeItem.contextValue;
     public readonly label: string = 'Attached Database Accounts (Postgres)';

--- a/src/tree/attached/CosmosDBAttachedAccountsResourceItem.ts
+++ b/src/tree/attached/CosmosDBAttachedAccountsResourceItem.ts
@@ -6,7 +6,7 @@
 import { callWithTelemetryAndErrorHandling, createContextValue, nonNullValue } from '@microsoft/vscode-azext-utils';
 import { ThemeIcon, TreeItemCollapsibleState } from 'vscode';
 import { API, getExperienceFromApi } from '../../AzureDBExperiences';
-import { isWindows } from '../../constants';
+import { isLinux, isWindows } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { type PersistedAccount } from '../AttachedAccountsTreeItem';
 import { type CosmosDBTreeElement } from '../CosmosDBTreeElement';
@@ -37,7 +37,7 @@ export class CosmosDBAttachedAccountsResourceItem implements CosmosDBTreeElement
 
         const items = await SharedWorkspaceStorage.getItems(this.id);
         const children = await this.getChildrenImpl(items);
-        const auxItems = isWindows ? [attachDatabaseAccount, attachEmulator] : [attachDatabaseAccount];
+        const auxItems = (isWindows || isLinux) ? [attachDatabaseAccount, attachEmulator] : [attachDatabaseAccount];
 
         return [...children, ...auxItems];
     }

--- a/src/tree/attached/CosmosDBAttachedAccountsResourceItem.ts
+++ b/src/tree/attached/CosmosDBAttachedAccountsResourceItem.ts
@@ -6,7 +6,7 @@
 import { callWithTelemetryAndErrorHandling, createContextValue, nonNullValue } from '@microsoft/vscode-azext-utils';
 import { ThemeIcon, TreeItemCollapsibleState } from 'vscode';
 import { API, getExperienceFromApi } from '../../AzureDBExperiences';
-import { isLinux, isWindows } from '../../constants';
+import { isEmulatorSupported } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { type PersistedAccount } from '../AttachedAccountsTreeItem';
 import { type CosmosDBTreeElement } from '../CosmosDBTreeElement';
@@ -37,7 +37,7 @@ export class CosmosDBAttachedAccountsResourceItem implements CosmosDBTreeElement
 
         const items = await SharedWorkspaceStorage.getItems(this.id);
         const children = await this.getChildrenImpl(items);
-        const auxItems = (isWindows || isLinux) ? [attachDatabaseAccount, attachEmulator] : [attachDatabaseAccount];
+        const auxItems = isEmulatorSupported ? [attachDatabaseAccount, attachEmulator] : [attachDatabaseAccount];
 
         return [...children, ...auxItems];
     }

--- a/src/tree/docdb/AccountInfo.ts
+++ b/src/tree/docdb/AccountInfo.ts
@@ -171,8 +171,8 @@ async function getCredentialsForAttached(account: CosmosDBAttachedAccountModel):
         context.telemetry.properties.useCosmosOAuth = (forceOAuth ?? false).toString();
 
         let keyCred: CosmosDBKeyCredential | undefined = undefined;
-        // disable key auth if the user has opted in to OAuth (AAD/Entra ID)
-        if (!forceOAuth) {
+        // disable key auth if the user has opted in to OAuth (AAD/Entra ID), or if the account is the emulator
+        if (!forceOAuth || account.isEmulator) {
             let localAuthDisabled = false;
 
             const parsedCS = parseDocDBConnectionString(account.connectionString);

--- a/src/tree/docdb/DocumentDBAccountAttachedResourceItem.ts
+++ b/src/tree/docdb/DocumentDBAccountAttachedResourceItem.ts
@@ -3,18 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type CosmosClient, type DatabaseDefinition, type Resource } from '@azure/cosmos';
-import { type TreeItem } from 'vscode';
+import { RestError, type CosmosClient, type DatabaseDefinition, type Resource } from '@azure/cosmos';
+import vscode, { type TreeItem } from 'vscode';
 import { type Experience } from '../../AzureDBExperiences';
 import { getThemeAgnosticIconPath } from '../../constants';
 import { getCosmosAuthCredential, getCosmosClient } from '../../docdb/getCosmosClient';
 import { getSignedInPrincipalIdForAccountEndpoint } from '../../docdb/utils/azureSessionHelper';
 import { isRbacException, showRbacPermissionError } from '../../docdb/utils/rbacUtils';
+import { localize } from '../../utils/localize';
 import { rejectOnTimeout } from '../../utils/timeout';
 import { type CosmosDBAttachedAccountModel } from '../attached/CosmosDBAttachedAccountModel';
 import { CosmosDBAccountResourceItemBase } from '../CosmosDBAccountResourceItemBase';
 import { type CosmosDBTreeElement } from '../CosmosDBTreeElement';
-import { type AccountInfo, getAccountInfo } from './AccountInfo';
+import { getAccountInfo, type AccountInfo } from './AccountInfo';
 
 export abstract class DocumentDBAccountAttachedResourceItem extends CosmosDBAccountResourceItemBase {
     public declare readonly account: CosmosDBAttachedAccountModel;
@@ -63,12 +64,30 @@ export abstract class DocumentDBAccountAttachedResourceItem extends CosmosDBAcco
                 return await getResources();
             }
         } catch (e) {
-            if (e instanceof Error && isRbacException(e) && !this.hasShownRbacNotification) {
-                this.hasShownRbacNotification = true;
-                const tenantId = getCosmosAuthCredential(accountInfo.credentials)?.tenantId;
-                const principalId =
-                    (await getSignedInPrincipalIdForAccountEndpoint(accountInfo.endpoint, tenantId)) ?? '';
-                void showRbacPermissionError(this.id, principalId);
+            if (e instanceof Error) {
+                if (isRbacException(e) && !this.hasShownRbacNotification) {
+                    this.hasShownRbacNotification = true;
+                    const tenantId = getCosmosAuthCredential(accountInfo.credentials)?.tenantId;
+                    const principalId =
+                        (await getSignedInPrincipalIdForAccountEndpoint(accountInfo.endpoint, tenantId)) ?? '';
+                    void showRbacPermissionError(this.id, principalId);
+                }
+                if (this.account.isEmulator && e instanceof RestError && e.code === 'DEPTH_ZERO_SELF_SIGNED_CERT') {
+                    const message = localize(
+                        'keyPermissionErrorMsg',
+                        "The Cosmos DB emulator is using a self-signed certificate. To connect to the emulator, you must import the emulator's TLS/SSL certificate.", // or disable the 'http.proxyStrictSSL' setting but we don't recommend this for security reasons.
+                    );
+                    const readMoreItem = localize('learnMore', 'Learn More');
+                    void vscode.window.showErrorMessage(message, ...[readMoreItem]).then((item) => {
+                        if (item === readMoreItem) {
+                            void vscode.env.openExternal(
+                                vscode.Uri.parse(
+                                    'https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator?tabs=docker-linux%2Ccsharp&pivots=api-nosql#import-the-emulators-tlsssl-certificate',
+                                ),
+                            );
+                        }
+                    });
+                }
             }
             throw e; // rethrowing tells the resources extension to show the exception message in the tree
         }


### PR DESCRIPTION
This enables the Emulator support on Linux. Unfortunately I don't have a Linux setup right now, @mkrueger could you maybe help with this?

Note for investigation: this also enables it for Mongo, we should look into that as well since there is MongoDB for Linux, not sure how functional Emulator support is for that.

Addresses #2449 