### PR TITLE
Small throughput related improvements.

### DIFF
--- a/package.json
+++ b/package.json
@@ -504,6 +504,11 @@
             },
             {
                 "category": "NoSQL",
+                "command": "cosmosDB.viewDocDBDatabaseOffer",
+                "title": "View Database Offer"
+            },
+            {
+                "category": "NoSQL",
                 "command": "cosmosDB.writeNoSqlQuery",
                 "title": "Open Query Scrapbook"
             },
@@ -893,6 +898,11 @@
                 {
                     "command": "cosmosDB.viewDocDBCollectionOffer",
                     "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBDocumentCollection",
+                    "group": "1@5"
+                },
+                {
+                    "command": "cosmosDB.viewDocDBDatabaseOffer",
+                    "when": "view =~ /azure(ResourceGroups|Workspace|FocusView)/ && viewItem == cosmosDBDocumentDatabase",
                     "group": "1@5"
                 },
                 {

--- a/src/docdb/commands/viewDocDBCollectionOffer.ts
+++ b/src/docdb/commands/viewDocDBCollectionOffer.ts
@@ -15,6 +15,16 @@ export async function viewDocDBCollectionOffer(context: IActionContext, node?: D
         node = await pickDocDBAccount<DocDBCollectionTreeItem>(context, DocDBCollectionTreeItem.contextValue);
     }
     const client = node.root.getCosmosClient();
-    const offer = await node.getContainerClient(client).readOffer();
-    await vscodeUtil.showNewFile(JSON.stringify(offer.resource, undefined, 2), `offer of ${node.label}`, '.json');
+    let offer = await node.getContainerClient(client).readOffer();
+    if (!offer.resource) {
+        // collections with shared throughput will not have an offer, show the database offer instead
+        offer = await node.parent.getDatabaseClient(client).readOffer();
+        await vscodeUtil.showNewFile(
+            JSON.stringify(offer.resource, undefined, 2),
+            `offer of ${node.parent.label}`,
+            '.json',
+        );
+    } else {
+        await vscodeUtil.showNewFile(JSON.stringify(offer.resource, undefined, 2), `offer of ${node.label}`, '.json');
+    }
 }

--- a/src/docdb/commands/viewDocDBDatabaseOffer.ts
+++ b/src/docdb/commands/viewDocDBDatabaseOffer.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type IActionContext, type ITreeItemPickerContext } from '@microsoft/vscode-azext-utils';
+import * as vscodeUtil from '../../utils/vscodeUtils';
+import { DocDBDatabaseTreeItem } from '../tree/DocDBDatabaseTreeItem';
+import { pickDocDBAccount } from './pickDocDBAccount';
+
+export async function viewDocDBDatabaseOffer(context: IActionContext, node?: DocDBDatabaseTreeItem): Promise<void> {
+    const suppressCreateContext: ITreeItemPickerContext = context;
+    suppressCreateContext.suppressCreatePick = true;
+    if (!node) {
+        node = await pickDocDBAccount<DocDBDatabaseTreeItem>(context, DocDBDatabaseTreeItem.contextValue);
+    }
+    const client = node.root.getCosmosClient();
+    const offer = await node.getDatabaseClient(client).readOffer();
+    await vscodeUtil.showNewFile(JSON.stringify(offer.resource, undefined, 2), `offer of ${node.label}`, '.json');
+}

--- a/src/docdb/registerDocDBCommands.ts
+++ b/src/docdb/registerDocDBCommands.ts
@@ -25,6 +25,7 @@ import { openNoSqlQueryEditor } from './commands/openNoSqlQueryEditor';
 import { openStoredProcedure } from './commands/openStoredProcedure';
 import { openTrigger } from './commands/openTrigger';
 import { viewDocDBCollectionOffer } from './commands/viewDocDBCollectionOffer';
+import { viewDocDBDatabaseOffer } from './commands/viewDocDBDatabaseOffer';
 import { writeNoSqlQuery } from './commands/writeNoSqlQuery';
 import { NoSqlCodeLensProvider } from './NoSqlCodeLensProvider';
 
@@ -48,6 +49,7 @@ export function registerDocDBCommands(): void {
 
     registerCommandWithTreeNodeUnwrapping('cosmosDB.createDocDBCollection', createDocDBCollection);
     registerCommandWithTreeNodeUnwrapping('cosmosDB.deleteDocDBDatabase', deleteDocDBDatabase);
+    registerCommandWithTreeNodeUnwrapping('cosmosDB.viewDocDBDatabaseOffer', viewDocDBDatabaseOffer);
 
     // #endregion
 


### PR DESCRIPTION
If a container has shared throughput, show the database offer instead. Add a new command to show the database offer.