### PR TITLE
Rename workspace (local db accounts) entries

### DIFF
--- a/src/mongoClusters/tree/workspace/MongoDBAccountsWorkspaceItem.ts
+++ b/src/mongoClusters/tree/workspace/MongoDBAccountsWorkspaceItem.ts
@@ -48,7 +48,7 @@ export class MongoDBAccountsWorkspaceItem implements CosmosDBTreeElement, TreeEl
         return {
             id: this.id,
             contextValue: 'vscode.cosmosdb.workspace.mongoclusters.accounts',
-            label: 'MongoDB Cluster Accounts',
+            label: 'MongoDB Accounts',
             iconPath: new ThemeIcon('link'),
             collapsibleState: TreeItemCollapsibleState.Collapsed,
         };


### PR DESCRIPTION
Renamed `MongoDB Cluster Accounts` to `MongoDB Accounts`