### PR TITLE
Add support for NoSQL Emulator without SSL/TLS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -563,9 +563,9 @@
             "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
         },
         "node_modules/@azure/cosmos": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.1.1.tgz",
-            "integrity": "sha512-EKcRHZy3enhz7hU/qlwW2urcoF7haFkQRbLhR+rUaAtzDaN6+F/rH4xJtNc94NjOEoeHUI+bkze63ZA55Gca0A==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.2.0.tgz",
+            "integrity": "sha512-acfAQTYLxgB/iZK7XvTVYe9NPk6DECEgcIXDQhyn7Uo4dGxeeW5D3YqLjLJrrzND5Iawer3eUQ5/iiLWvTGAxQ==",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.7.1",

--- a/src/docdb/getCosmosClient.ts
+++ b/src/docdb/getCosmosClient.ts
@@ -48,12 +48,13 @@ export function getCosmosClientByConnection(
     const connectionPolicy = {
         enableEndpointDiscovery: enableEndpointDiscovery === undefined ? true : enableEndpointDiscovery,
     };
+    const agent = endpoint.startsWith('https:')
+        ? new https.Agent({ rejectUnauthorized: isEmulator ? !isEmulator : vscodeStrictSSL })
+        : undefined;
     const commonProperties: CosmosClientOptions = {
         endpoint,
         userAgentSuffix: appendExtensionUserAgent(),
-        agent: new https.Agent({
-            rejectUnauthorized: isEmulator ? !isEmulator : vscodeStrictSSL,
-        }),
+        agent: agent,
         connectionPolicy,
     };
 
@@ -92,10 +93,13 @@ export function getCosmosClient(
     const keyCred = getCosmosKeyCredential(credentials);
     const authCred = getCosmosAuthCredential(credentials);
 
+    const agent = endpoint.startsWith('https:')
+        ? new https.Agent({ rejectUnauthorized: isEmulator ? !isEmulator : vscodeStrictSSL })
+        : undefined;
     const commonProperties = {
         endpoint,
         userAgentSuffix: appendExtensionUserAgent(),
-        agent: new https.Agent({ rejectUnauthorized: isEmulator ? !isEmulator : vscodeStrictSSL }),
+        agent: agent,
         connectionPolicy,
     };
     // @todo: Add telemetry to monitor usage of each credential type

--- a/src/tree/docdb/DocumentDBAccountAttachedResourceItem.ts
+++ b/src/tree/docdb/DocumentDBAccountAttachedResourceItem.ts
@@ -37,8 +37,10 @@ export abstract class DocumentDBAccountAttachedResourceItem extends CosmosDBAcco
 
     public getTreeItem(): TreeItem {
         let tooltipMessage: string | undefined = undefined;
+        let description: string | undefined = undefined;
 
         if (this.account.isEmulator && this.account.connectionString.includes('http://')) {
+            description = '⚠ TLS/SSL Disabled';
             tooltipMessage = '⚠️ **Security:** TLS/SSL Disabled';
         } else {
             tooltipMessage = '✅ **Security:** TLS/SSL Enabled';
@@ -51,6 +53,7 @@ export abstract class DocumentDBAccountAttachedResourceItem extends CosmosDBAcco
 
         return {
             ...treeItem,
+            description: description,
             tooltip: new vscode.MarkdownString(tooltipMessage),
             iconPath: this.account.isEmulator
                 ? new vscode.ThemeIcon('plug')

--- a/src/tree/docdb/DocumentDBAccountAttachedResourceItem.ts
+++ b/src/tree/docdb/DocumentDBAccountAttachedResourceItem.ts
@@ -29,7 +29,7 @@ export abstract class DocumentDBAccountAttachedResourceItem extends CosmosDBAcco
 
     public async getChildren(): Promise<CosmosDBTreeElement[]> {
         const accountInfo = await getAccountInfo(this.account);
-        const cosmosClient = getCosmosClient(accountInfo.endpoint, accountInfo.credentials, false);
+        const cosmosClient = getCosmosClient(accountInfo.endpoint, accountInfo.credentials, accountInfo.isEmulator);
         const databases = await this.getDatabases(accountInfo, cosmosClient);
 
         return this.getChildrenImpl(accountInfo, databases);
@@ -37,7 +37,10 @@ export abstract class DocumentDBAccountAttachedResourceItem extends CosmosDBAcco
 
     public getTreeItem(): TreeItem {
         let tooltipMessage: string | undefined = undefined;
-        if (this.account.isEmulator) {
+
+        if (this.account.isEmulator && this.account.connectionString.includes('http://')) {
+            tooltipMessage = '⚠️ **Security:** TLS/SSL Disabled';
+        } else {
             tooltipMessage = '✅ **Security:** TLS/SSL Enabled';
         }
 


### PR DESCRIPTION
Update @azure/cosmos to 4.2.0 including support for http connections and add checks to configure CosmosClient accordingly.

This allows connecting to the NoSQL emulator with `--protocol http`.