### PR TITLE
fix: handle _id with a 'null' value in the mongo tree view

### DIFF
--- a/src/utils/slickgrid/mongo/toSlickGridTree.ts
+++ b/src/utils/slickgrid/mongo/toSlickGridTree.ts
@@ -76,9 +76,20 @@ export function documentToSlickGridTree(document: WithId<Document>, idPrefix?: s
      */
 
     const rootId = `${idPrefix}${localEntryId}`; // localEntryId is always a 0 here
+
+    // Handle document._id which could be null
+    let idFieldValue: string;
+    if (document._id === null) {
+        idFieldValue = 'null';
+    } else if (document._id?._bsontype === 'ObjectId') {
+        idFieldValue = document._id.toString();
+    } else {
+        idFieldValue = JSON.stringify(document._id);
+    }
+
     tree.push({
         id: rootId,
-        field: document._id._bsontype === 'ObjectId' ? document._id.toString() : JSON.stringify(document._id),
+        field: idFieldValue,
         value: '{...}',
         type: 'Document',
         parentId: null,


### PR DESCRIPTION
Resolves https://github.com/microsoft/vscode-cosmosdb/issues/2515

This pull request includes a change to handle cases where `document._id` could be null in the `documentToSlickGridTree` function. The most important changes involve checking the `_id` field and assigning an appropriate string value based on its type.

Handling null and different types for `document._id`:

* [`src/utils/slickgrid/mongo/toSlickGridTree.ts`](diffhunk://#diff-a9c32ac0218485fcad007201423fb973ad40b11198e30c1bfbb969c62c127886R79-R92): Added logic to check if `document._id` is null, if it is of `ObjectId` type, or if it is another type, and assign the appropriate string value to `idFieldValue`.