### PR TITLE
fix: mongo: #2474 reconnecting with incorrect auth data

### DIFF
--- a/src/mongoClusters/tree/MongoClusterItemBase.ts
+++ b/src/mongoClusters/tree/MongoClusterItemBase.ts
@@ -83,13 +83,15 @@ export abstract class MongoClusterItemBase
 
         // If authentication failed, return the error element
         if (!mongoClustersClient) {
+            ext.outputChannel.appendLine(`MongoDB Clusters: Failed to authenticate with "${this.mongoCluster.name}".`);
             return [
                 createGenericElement({
                     contextValue: 'error',
                     id: `${this.id}/error`,
                     label: 'Failed to authenticate (click to retry)',
                     iconPath: new vscode.ThemeIcon('error'),
-                    commandId: 'azureResourceGroups.refreshTree',
+                    commandId: 'azureDatabases.refresh',
+                    commandArgs: [this],
                 }) as CosmosDBTreeElement,
             ];
         }

--- a/src/mongoClusters/tree/MongoClusterResourceItem.ts
+++ b/src/mongoClusters/tree/MongoClusterResourceItem.ts
@@ -128,7 +128,10 @@ export class MongoClusterResourceItem extends MongoClusterItemBase {
                     mongoClustersClient = await MongoClustersClient.getClient(this.id).catch((error: Error) => {
                         ext.outputChannel.appendLine(`Error: ${error.message}`);
 
-                        void vscode.window.showErrorMessage(`Failed to connect: ${error.message}`);
+                        void vscode.window.showErrorMessage(`Failed to connect to "${this.mongoCluster.name}"`, {
+                            modal: true,
+                            detail: `Revisit connection details and try again.\n\nError: ${error.message}`,
+                        });
 
                         throw error;
                     });

--- a/src/mongoClusters/tree/workspace/MongoClusterWorkspaceItem.ts
+++ b/src/mongoClusters/tree/workspace/MongoClusterWorkspaceItem.ts
@@ -98,7 +98,10 @@ export class MongoClusterWorkspaceItem extends MongoClusterItemBase {
                         ext.outputChannel.appendLine('failed.');
                         ext.outputChannel.appendLine(`Error: ${error.message}`);
 
-                        void vscode.window.showErrorMessage(`Failed to connect: ${error.message}`);
+                        void vscode.window.showErrorMessage(`Failed to connect to "${this.mongoCluster.name}"`, {
+                            modal: true,
+                            detail: `Revisit connection details and try again.\n\nError: ${error.message}`,
+                        });
 
                         throw error;
                     });


### PR DESCRIPTION
In case of a failed connection due to incorrect auth data or inaccessible server, the action was a refresh of the entire tree resulting in long wait times and the user assuming that the operation has failed.

Changes:
1. In case of an error, the user can decide to reconnect, and only the selected cluster will be refreshed
2. The error is presented in a modal dialog so that it's easier to spot it and become aware of the authentication issue.

Improvements to error handling and user feedback:

* [`src/mongoClusters/tree/MongoClusterItemBase.ts`](diffhunk://#diff-3fe28caa41331f45255f96c2b006dd8447bade8595f061343ca18c9742314ba8R86-R94): Added a log message to the output channel when authentication fails and updated the command arguments for the error element to provide a more specific refresh command.
* [`src/mongoClusters/tree/MongoClusterResourceItem.ts`](diffhunk://#diff-0108bdb1cb31b0bf32159c61018b0c73808fd35aa19e81fa61e55c32ef5bfe0cL131-R134): Enhanced the error message shown to the user when connection to a MongoDB cluster fails by including the cluster name and providing additional details in a modal dialog.
* [`src/mongoClusters/tree/workspace/MongoClusterWorkspaceItem.ts`](diffhunk://#diff-34e27dfac27309b5b6fa2f5007c5633d443bdfba8495ef383d445599928a1185L101-R104): Improved the error message displayed to the user upon connection failure by adding the cluster name and detailed instructions in a modal dialog.