### PR TITLE
Add a Feedback button to NoSQL query editor

### DIFF
--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -14,7 +14,7 @@ import { DocumentSession } from '../docdb/session/DocumentSession';
 import { QuerySession } from '../docdb/session/QuerySession';
 import { type CosmosDbRecordIdentifier, type ResultViewMetadata } from '../docdb/types/queryResult';
 import { getNoSqlQueryConnection } from '../docdb/utils/NoSqlQueryConnection';
-import { promptAfterActionEventually } from '../utils/survey';
+import { getIsSurveyCandidate, openSurvey, promptAfterActionEventually } from '../utils/survey';
 import { ExperienceKind, UsageImpact } from '../utils/surveyTypes';
 import * as vscodeUtil from '../utils/vscodeUtils';
 import { BaseTab, type CommandPayload } from './BaseTab';
@@ -96,6 +96,11 @@ export class QueryEditorTab extends BaseTab {
                     params: [this.query],
                 });
             }
+            await this.channel.postMessage({
+                type: 'event',
+                name: 'isSurveyCandidateChanged',
+                params: [await getIsSurveyCandidate()],
+            });
         });
     }
 
@@ -132,6 +137,8 @@ export class QueryEditorTab extends BaseTab {
                 return this.openDocument(payload.params[0] as string, payload.params[1] as CosmosDbRecordIdentifier);
             case 'deleteDocument':
                 return this.deleteDocument(payload.params[0] as CosmosDbRecordIdentifier);
+            case 'provideFeedback':
+                return this.provideFeedback();
         }
 
         return super.getCommand(payload);
@@ -394,5 +401,10 @@ export class QueryEditorTab extends BaseTab {
         }
 
         return viewColumn;
+    }
+
+    private async provideFeedback(): Promise<void> {
+        openSurvey(ExperienceKind.NoSQL, 'cosmosDB.nosql.queryEditor.provideFeedback');
+        return Promise.resolve();
     }
 }

--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -14,7 +14,7 @@ import { DocumentSession } from '../docdb/session/DocumentSession';
 import { QuerySession } from '../docdb/session/QuerySession';
 import { type CosmosDbRecordIdentifier, type ResultViewMetadata } from '../docdb/types/queryResult';
 import { getNoSqlQueryConnection } from '../docdb/utils/NoSqlQueryConnection';
-import { getIsSurveyCandidate, openSurvey, promptAfterActionEventually } from '../utils/survey';
+import { getIsSurveyDisabledGlobally, openSurvey, promptAfterActionEventually } from '../utils/survey';
 import { ExperienceKind, UsageImpact } from '../utils/surveyTypes';
 import * as vscodeUtil from '../utils/vscodeUtils';
 import { BaseTab, type CommandPayload } from './BaseTab';
@@ -99,7 +99,7 @@ export class QueryEditorTab extends BaseTab {
             await this.channel.postMessage({
                 type: 'event',
                 name: 'isSurveyCandidateChanged',
-                params: [await getIsSurveyCandidate()],
+                params: [!getIsSurveyDisabledGlobally()],
             });
         });
     }

--- a/src/webviews/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
+++ b/src/webviews/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
@@ -29,6 +29,7 @@ import {
 } from '@fluentui/react-components';
 import {
     DatabasePlugConnectedRegular,
+    EmojiSmileSlightRegular,
     FolderOpenRegular,
     LibraryRegular,
     MoreHorizontal20Filled,
@@ -247,6 +248,39 @@ const LearnButton = forwardRef((props: OverflowToolbarItemProps, ref: ForwardedR
     );
 });
 
+const ProvideFeedbackButton = forwardRef((props: OverflowToolbarItemProps, ref: ForwardedRef<HTMLButtonElement>) => {
+    const dispatcher = useQueryEditorDispatcher();
+
+    if (props.type === 'button') {
+        return (
+            <Menu>
+                <MenuTrigger>
+                    <ToolbarButton
+                        ref={ref}
+                        aria-label="Provide Feedback"
+                        icon={<EmojiSmileSlightRegular />}
+                    ></ToolbarButton>
+                </MenuTrigger>
+                <MenuPopover>
+                    <MenuList>
+                        <MenuItem onClick={() => void dispatcher.provideFeedback()}>Provide Feedback</MenuItem>
+                    </MenuList>
+                </MenuPopover>
+            </Menu>
+        );
+    } else {
+        return (
+            <MenuItem
+                aria-label="Provide Feedback"
+                icon={<EmojiSmileSlightRegular />}
+                onClick={() => void dispatcher.provideFeedback()}
+            >
+                Provide Feedback
+            </MenuItem>
+        );
+    }
+});
+
 const ConnectionButton = forwardRef(
     (props: OverflowToolbarItemProps, ref: ForwardedRef<HTMLButtonElement | HTMLDivElement>) => {
         const classes = useClasses();
@@ -347,8 +381,13 @@ const OverflowMenu = () => {
                     <ToolbarOverflowMenuItem id="6">
                         <LearnButton type={'menuitem'} />
                     </ToolbarOverflowMenuItem>
+                    {useQueryEditorState().isSurveyCandidate && (
+                        <ToolbarOverflowMenuItem id="7">
+                            <ProvideFeedbackButton type={'menuitem'} />
+                        </ToolbarOverflowMenuItem>
+                    )}
                     <ToolbarMenuOverflowDivider id="2" />
-                    <ToolbarOverflowMenuItem id="7">
+                    <ToolbarOverflowMenuItem id="8">
                         <ConnectionButton type={'menuitem'} />
                     </ToolbarOverflowMenuItem>
                 </MenuList>
@@ -394,8 +433,13 @@ export const QueryToolbarOverflow = (props: Partial<ToolbarProps>) => {
                 <OverflowItem id={'6'} groupId={'2'}>
                     <LearnButton type={'button'} />
                 </OverflowItem>
+                {useQueryEditorState().isSurveyCandidate && (
+                    <OverflowItem id={'7'} groupId={'2'}>
+                        <ProvideFeedbackButton type={'button'} />
+                    </OverflowItem>
+                )}
                 <ToolbarOverflowDivider groupId="2" />
-                <OverflowItem id={'7'} groupId={'3'}>
+                <OverflowItem id={'8'} groupId={'3'}>
                     <ConnectionButton type={'button'} />
                 </OverflowItem>
                 <OverflowMenu />

--- a/src/webviews/QueryEditor/state/QueryEditorContextProvider.tsx
+++ b/src/webviews/QueryEditor/state/QueryEditorContextProvider.tsx
@@ -103,6 +103,9 @@ export class QueryEditorContextProvider extends BaseContextProvider {
             await this.deleteDocument(document);
         }
     }
+    public async provideFeedback(): Promise<void> {
+        await this.sendCommand('provideFeedback');
+    }
 
     protected initEventListeners() {
         super.initEventListeners();
@@ -132,6 +135,10 @@ export class QueryEditorContextProvider extends BaseContextProvider {
 
         this.channel.on('queryResults', (executionId: string, result: SerializedQueryResult, currentPage: number) => {
             this.dispatch({ type: 'updateQueryResult', executionId, result, currentPage });
+        });
+
+        this.channel.on('isSurveyCandidateChanged', (isSurveyCandidate: boolean) => {
+            this.dispatch({ type: 'setIsSurveyCandidate', isSurveyCandidate: isSurveyCandidate });
         });
 
         //TODO: there should be no queryError event that needs to show a toast,

--- a/src/webviews/QueryEditor/state/QueryEditorState.tsx
+++ b/src/webviews/QueryEditor/state/QueryEditorState.tsx
@@ -60,6 +60,10 @@ export type DispatchAction =
     | {
           type: 'setQuerySelectedValue';
           selectedValue: string;
+      }
+    | {
+          type: 'setIsSurveyCandidate';
+          isSurveyCandidate: boolean;
       };
 
 export type QueryEditorState = {
@@ -74,6 +78,8 @@ export type QueryEditorState = {
     isExecuting: boolean;
     startExecutionTime: number; // Time when the query execution started
     endExecutionTime: number; // Time when the query execution ended
+
+    isSurveyCandidate: boolean; // Whether the user is a survey candidate
 
     // Result state
     pageNumber: number; // Current page number (Readonly, only server can change it) (Value exists on both client and server)
@@ -97,6 +103,8 @@ export const defaultState: QueryEditorState = {
     isExecuting: false,
     startExecutionTime: 0,
     endExecutionTime: 0,
+
+    isSurveyCandidate: false,
 
     // Result state
     pageNumber: 1,
@@ -157,5 +165,7 @@ export function dispatch(state: QueryEditorState, action: DispatchAction): Query
             return { ...state, selectedRows: action.selectedRows };
         case 'setQuerySelectedValue':
             return { ...state, querySelectedValue: action.selectedValue };
+        case 'setIsSurveyCandidate':
+            return { ...state, isSurveyCandidate: action.isSurveyCandidate };
     }
 }

--- a/src/webviews/api/configuration/appRouter.ts
+++ b/src/webviews/api/configuration/appRouter.ts
@@ -10,7 +10,7 @@ import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils
 import * as vscode from 'vscode';
 import { z } from 'zod';
 import { type API } from '../../../AzureDBExperiences';
-import { promptAfterActionEventually } from '../../../utils/survey';
+import { openSurvey, promptAfterActionEventually } from '../../../utils/survey';
 import { ExperienceKind, UsageImpact } from '../../../utils/surveyTypes';
 import { collectionsViewRouter as collectionViewRouter } from '../../mongoClusters/collectionView/collectionViewRouter';
 import { documentsViewRouter as documentViewRouter } from '../../mongoClusters/documentView/documentsViewRouter';
@@ -120,6 +120,16 @@ const commonRouter = router({
         )
         .mutation(({ input }) => {
             void promptAfterActionEventually(input.experienceKind, input.usageImpact);
+        }),
+    surveyOpen: publicProcedure
+        .input(
+            z.object({
+                experienceKind: z.nativeEnum(ExperienceKind),
+                triggerAction: z.string(), // Optional action that triggered the survey for telemetry
+            }),
+        )
+        .mutation(({ input }) => {
+            void openSurvey(input.experienceKind, input.triggerAction);
         }),
 });
 

--- a/src/webviews/mongoClusters/collectionView/collectionView.scss
+++ b/src/webviews/mongoClusters/collectionView/collectionView.scss
@@ -27,11 +27,15 @@
 
         display: flex;
         flex-direction: row;
-        justify-content: space-between;
         align-items: center;
         gap: 10px;
 
         text-wrap: nowrap;
+
+        // Push all elements after the first one to the right
+        > :first-child {
+            margin-right: auto; // This ensures space is created between the first and remaining elements.
+        }
     }
 
     .resultsActionBar {

--- a/src/webviews/mongoClusters/collectionView/components/toolbar/ToolbarMainView.tsx
+++ b/src/webviews/mongoClusters/collectionView/components/toolbar/ToolbarMainView.tsx
@@ -3,18 +3,58 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger, Toolbar, ToolbarButton } from '@fluentui/react-components';
-import { ArrowClockwiseRegular, ArrowExportRegular, ArrowImportRegular, PlayRegular } from '@fluentui/react-icons';
+import {
+    Menu,
+    MenuItem,
+    MenuList,
+    MenuPopover,
+    MenuTrigger,
+    Toolbar,
+    ToolbarButton,
+    ToolbarDivider,
+} from '@fluentui/react-components';
+import {
+    ArrowClockwiseRegular,
+    ArrowExportRegular,
+    ArrowImportRegular,
+    EmojiSmileSlightRegular,
+    PlayRegular,
+} from '@fluentui/react-icons';
 import { useContext, type JSX } from 'react';
+import { ExperienceKind } from '../../../../../utils/surveyTypes';
 import { useTrpcClient } from '../../../../api/webview-client/useTrpcClient';
 import { CollectionViewContext } from '../../collectionViewContext';
 import { ToolbarDividerTransparent } from './ToolbarDividerTransparent';
 
 export const ToolbarMainView = (): JSX.Element => {
+    const { trpcClient } = useTrpcClient();
+
     return (
         <>
             <ToolbarQueryOperations />
             <ToolbarDataOperations />
+            <ToolbarDivider />
+            <Menu>
+                <MenuTrigger>
+                    <ToolbarButton aria-label="Provide Feedback" icon={<EmojiSmileSlightRegular />}></ToolbarButton>
+                </MenuTrigger>
+                <MenuPopover>
+                    <MenuList>
+                        <MenuItem
+                            onClick={() => {
+                                trpcClient.common.surveyOpen
+                                    .mutate({
+                                        experienceKind: ExperienceKind.Mongo,
+                                        triggerAction: 'cosmosDB.mongo.collectionView.provideFeedback',
+                                    })
+                                    .catch(() => {});
+                            }}
+                        >
+                            Provide Feedback
+                        </MenuItem>
+                    </MenuList>
+                </MenuPopover>
+            </Menu>
         </>
     );
 };


### PR DESCRIPTION
Adds a "Provide Feedback" button to the NoSQL query editor if the user has been identified as a survey candidate. Usage scores will be ignored, hence the button is always visible if the user has not opted out from surveys.

The "smiley" button opens a dropdown with the option to provide feedback:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/fa89c656-1552-48f6-af11-61cff944e810" />
if the toolbar is collapsed, the button turns to a simple menu item without a second step.
<img width="578" alt="image" src="https://github.com/user-attachments/assets/6ee9f654-343a-476f-9064-d2f0f5866a54" />

