### PR TITLE
fix(query): add tooltip and icon to Provide Feedback buttons

### DIFF
--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
@@ -23,11 +23,13 @@ import {
     ToolbarButton,
     ToolbarDivider,
     type ToolbarProps,
+    Tooltip,
     useIsOverflowGroupVisible,
     useIsOverflowItemVisible,
     useOverflowMenu,
 } from '@fluentui/react-components';
 import {
+    CommentCheckmarkRegular,
     DatabasePlugConnectedRegular,
     EmojiSmileSlightRegular,
     FolderOpenRegular,
@@ -256,15 +258,17 @@ const ProvideFeedbackButton = forwardRef((props: OverflowToolbarItemProps, ref: 
         return (
             <Menu>
                 <MenuTrigger>
-                    <ToolbarButton
-                        ref={ref}
-                        aria-label={l10n.t('Provide Feedback')}
-                        icon={<EmojiSmileSlightRegular />}
-                    ></ToolbarButton>
+                    <Tooltip content={l10n.t('Provide Feedback')} relationship="label">
+                        <ToolbarButton
+                            ref={ref}
+                            aria-label={l10n.t('Provide Feedback')}
+                            icon={<EmojiSmileSlightRegular />}
+                        ></ToolbarButton>
+                    </Tooltip>
                 </MenuTrigger>
                 <MenuPopover>
                     <MenuList>
-                        <MenuItem onClick={() => void dispatcher.provideFeedback()}>
+                        <MenuItem icon={<CommentCheckmarkRegular />} onClick={() => void dispatcher.provideFeedback()}>
                             {l10n.t('Provide Feedback')}
                         </MenuItem>
                     </MenuList>

--- a/src/webviews/documentdb/collectionView/components/toolbar/ToolbarMainView.tsx
+++ b/src/webviews/documentdb/collectionView/components/toolbar/ToolbarMainView.tsx
@@ -12,11 +12,13 @@ import {
     Toolbar,
     ToolbarButton,
     ToolbarDivider,
+    Tooltip,
 } from '@fluentui/react-components';
 import {
     ArrowClockwiseRegular,
     ArrowExportRegular,
     ArrowImportRegular,
+    CommentCheckmarkRegular,
     EmojiSmileSlightRegular,
     PlayRegular,
 } from '@fluentui/react-icons';
@@ -37,14 +39,17 @@ export const ToolbarMainView = (): JSX.Element => {
             <ToolbarDivider />
             <Menu>
                 <MenuTrigger>
-                    <ToolbarButton
-                        aria-label={l10n.t('Provide Feedback')}
-                        icon={<EmojiSmileSlightRegular />}
-                    ></ToolbarButton>
+                    <Tooltip content={l10n.t('Provide Feedback')} relationship="label">
+                        <ToolbarButton
+                            aria-label={l10n.t('Provide Feedback')}
+                            icon={<EmojiSmileSlightRegular />}
+                        ></ToolbarButton>
+                    </Tooltip>
                 </MenuTrigger>
                 <MenuPopover>
                     <MenuList>
                         <MenuItem
+                            icon={<CommentCheckmarkRegular />}
                             onClick={() => {
                                 trpcClient.common.surveyOpen
                                     .mutate({


### PR DESCRIPTION
Tooltips:
<img width="776" alt="image" src="https://github.com/user-attachments/assets/bad837a1-bd4b-47f0-9f11-07b037929419" />
<img width="783" alt="image" src="https://github.com/user-attachments/assets/ecfb6dbd-7ddf-418e-86df-533e54c8c7e5" />

Icon for the Submenu:
<img width="775" alt="image" src="https://github.com/user-attachments/assets/4a4b629e-8da5-44c0-bf08-55181fdd65da" />
<img width="771" alt="image" src="https://github.com/user-attachments/assets/27725020-c1d8-4d39-80ff-0c1223a972de" />
