### PR TITLE
Update version to 0.26.0-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cosmosdb",
-  "version": "0.25.2-alpha",
+  "version": "0.26.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cosmosdb",
-      "version": "0.25.2-alpha",
+      "version": "0.26.0-alpha",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@azure/arm-cosmosdb": "16.0.0-beta.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cosmosdb",
-  "version": "0.25.2-alpha",
+  "version": "0.26.0-alpha",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "publisher": "ms-azuretools",
   "displayName": "Azure Databases",


### PR DESCRIPTION
We don't plan any more 0.25.x releases from main. Any new 0.25.x releases should be based on latest [`rel/0.25.2`](https://github.com/microsoft/vscode-cosmosdb/compare/main...rel/0.25.2) branch.