### PR TITLE
Fix issue #2660: Resolve l10n issue in QueryPanel run button menu.

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -510,6 +510,7 @@
   "Session is disposed": "Session is disposed",
   "Session is not running! Please run the session first": "Session is not running! Please run the session first",
   "Setting up credentials for server \"{0}\"…": "Setting up credentials for server \"{0}\"…",
+  "Show history of previous queries": "Show history of previous queries",
   "Showing Results": "Showing Results",
   "Sign in to Azure...": "Sign in to Azure...",
   "Signing out programmatically is not supported. You must sign out by selecting the account in the Accounts menu and choosing Sign Out.": "Signing out programmatically is not supported. You must sign out by selecting the account in the Accounts menu and choosing Sign Out.",

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
@@ -87,7 +87,10 @@ const RunQueryButton = forwardRef((props: OverflowToolbarItemProps, ref: Forward
                             icon={<PlayRegular />}
                             disabled={state.isExecuting || !state.isConnected}
                             appearance={'primary'}
-                            menuButton={triggerProps}
+                            menuButton={{
+                                ...triggerProps,
+                                'aria-label': l10n.t('Show history of previous queries'),
+                            }}
                             primaryActionButton={{ onClick: () => runQuery() }}
                         >
                             {l10n.t('Run')}


### PR DESCRIPTION
This pull request makes a small but meaningful change to improve accessibility in the `RunQueryButton` component. Specifically, it adds an `aria-label` to the `menuButton` to provide a more descriptive label for screen readers.

* [`src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx`](diffhunk://#diff-b1f4c6160d06097fa41d9e2563c8650bec9c7f6610309f984aa82e1c8b49e5b9L90-R93): Updated the `menuButton` props in the `RunQueryButton` component to include an `aria-label` with the text "Show history of previous queries" for better accessibility.