### PR TITLE
Fix issue #2661: Resolve l10n issue in QueryPanel

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -107,7 +107,6 @@
   "Container name is required.": "Container name is required.",
   "Continue": "Continue",
   "Copy all results from the current page to clipboard": "Copy all results from the current page to clipboard",
-  "Copy into new tab": "Copy into new tab",
   "Copy selected items to clipboard": "Copy selected items to clipboard",
   "Copy to clipboard": "Copy to clipboard",
   "Cosmos DB Graph extension has been retired.": "Cosmos DB Graph extension has been retired.",

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx
@@ -192,7 +192,7 @@ const DuplicateTabButton = forwardRef(
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 ref={ref}
-                aria-label={l10n.t('Copy into new tab')}
+                aria-label={l10n.t('Duplicate')}
                 icon={<TabDesktopMultipleRegular />}
                 onClick={() => void dispatcher.duplicateTab(state.queryValue)}
                 disabled={!state.isConnected}


### PR DESCRIPTION
This pull request includes a minor change to the `DuplicateTabButton` component in the `QueryToolbarOverflow` file. The `aria-label` for the button was updated to improve clarity and consistency.

* [`src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryToolbarOverflow.tsx`](diffhunk://#diff-b1f4c6160d06097fa41d9e2563c8650bec9c7f6610309f984aa82e1c8b49e5b9L195-R195): Updated the `aria-label` of the `DuplicateTabButton` from `'Copy into new tab'` to `'Duplicate'`.