### PR TITLE
Fix issue #2668: Corrected screen reader button announcement in ResultTabToolbar

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -471,7 +471,6 @@
   "Request timed out": "Request timed out",
   "Resource group \"{0}\" already exists in subscription \"{1}\".": "Resource group \"{0}\" already exists in subscription \"{1}\".",
   "Result": "Result",
-  "Result view toolbar": "Result view toolbar",
   "Results for page {pageNumber} already exists": "Results for page {pageNumber} already exists",
   "Retrieved document count": "Retrieved document count",
   "Retrieved document size": "Retrieved document size",

--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx
@@ -51,7 +51,7 @@ export const ResultTabToolbar = ({ selectedTab }: ResultToolbarProps) => {
     }
 
     return (
-        <Toolbar  size="small">
+        <Toolbar size="small">
             {isEditMode && (
                 <>
                     <Tooltip content={l10n.t('Add new item in separate tab')} relationship="description" withArrow>

--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx
@@ -51,7 +51,7 @@ export const ResultTabToolbar = ({ selectedTab }: ResultToolbarProps) => {
     }
 
     return (
-        <Toolbar aria-label={l10n.t('Result view toolbar')} size="small">
+        <Toolbar  size="small">
             {isEditMode && (
                 <>
                     <Tooltip content={l10n.t('Add new item in separate tab')} relationship="description" withArrow>


### PR DESCRIPTION
This pull request includes a minor change to the `ResultTabToolbar` component in the `ResultPanel` of the CosmosDB Query Editor. The `aria-label` attribute was removed from the `Toolbar` component fixing the not needed double announcement. Just the button text should be read.

* [`src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx`](diffhunk://#diff-5cdf9f37b21ee76f767b33bc6d49af1c805250506c1d46eedb89dea7e5ea64bbL54-R54): Removed the `aria-label` attribute (`l10n.t('Result view toolbar')`) from the `Toolbar` component.