### PR TITLE
FIX: adds support for launching `mongosh` when the user work with PS on Windows

### DIFF
--- a/src/commands/launchShell/launchShell.ts
+++ b/src/commands/launchShell/launchShell.ts
@@ -55,8 +55,23 @@ export async function launchShell(
     const username = connectionString.username;
     const password = connectionString.password;
 
-    connectionString.username = isWindows ? '%USERNAME%' : '$USERNAME';
-    connectionString.password = isWindows ? '%PASSWORD%' : '$PASSWORD';
+    // Check if PowerShell is being used on Windows
+    const isWindowsPowerShell =
+        isWindows &&
+        (vscode.workspace.getConfiguration('terminal.integrated.defaultProfile').get('windows') === 'PowerShell' ||
+            vscode.workspace.getConfiguration('terminal.integrated.defaultProfile').get('windows') === 'pwsh');
+
+    // Use correct variable syntax based on shell
+    if (isWindows && isWindowsPowerShell) {
+        connectionString.username = '$env:USERNAME';
+        connectionString.password = '$env:PASSWORD';
+    } else if (isWindows) {
+        connectionString.username = '%USERNAME%';
+        connectionString.password = '%PASSWORD%';
+    } else {
+        connectionString.username = '$USERNAME';
+        connectionString.password = '$PASSWORD';
+    }
 
     if ('databaseInfo' in node && node.databaseInfo?.name) {
         connectionString.pathname = node.databaseInfo.name;


### PR DESCRIPTION
This pull request updates the `launchShell` command to ensure compatibility with different terminal environments on Windows. The main change introduces logic to correctly handle environment variable syntax based on whether the terminal is PowerShell or another shell.

### Compatibility improvements for Windows terminals:

* [`src/commands/launchShell/launchShell.ts`](diffhunk://#diff-eab2a39f022b72c2579c2a4745ffc8ca8a1dd5194daf877365d63520bc8f0465L58-R74): Added a check to determine if the terminal is PowerShell (`PowerShell` or `pwsh`) and updated the `username` and `password` variable syntax accordingly. PowerShell now uses `$env:USERNAME` and `$env:PASSWORD`, while other Windows shells continue to use `%USERNAME%` and `%PASSWORD%`.