### PR TITLE
feat: Add AlertDialog component for confirmation before deleting documents

### DIFF
--- a/src/webviews/common/AlertDialog.tsx
+++ b/src/webviews/common/AlertDialog.tsx
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogBody,
+    DialogContent,
+    DialogSurface,
+    DialogTitle,
+    DialogTrigger,
+} from '@fluentui/react-components';
+import { type DialogOpenChangeEventHandler } from '@fluentui/react-dialog';
+import * as React from 'react';
+import { useCallback } from 'react';
+export interface AlertDialogProps {
+    isOpen: boolean;
+    onClose: (confirmed: boolean) => void;
+    title: string;
+    content: React.ReactNode;
+    confirmButtonText: string;
+    cancelButtonText: string;
+    reverseButtonOrder?: boolean;
+}
+
+export const AlertDialog: React.FC<AlertDialogProps> = ({
+    isOpen,
+    onClose,
+    title,
+    content,
+    confirmButtonText,
+    cancelButtonText,
+    reverseButtonOrder = false,
+}) => {
+    const handleOpenChange = useCallback<DialogOpenChangeEventHandler>(
+        (_event, data) => {
+            if (!data.open) {
+                onClose(false); // Closed without confirmation (via escape key, clicking outside, etc.)
+            }
+        },
+        [onClose],
+    );
+
+    const handleConfirm = useCallback(() => {
+        onClose(true); // Closed with confirmation
+    }, [onClose]);
+
+    // Render buttons in the specified order
+    const renderButtons = () => {
+        const confirmButton = (
+            <Button appearance="primary" onClick={handleConfirm}>
+                {confirmButtonText}
+            </Button>
+        );
+
+        const cancelButton = (
+            <DialogTrigger disableButtonEnhancement>
+                <Button appearance="secondary">{cancelButtonText}</Button>
+            </DialogTrigger>
+        );
+
+        return reverseButtonOrder ? (
+            <>
+                {cancelButton}
+                {confirmButton}
+            </>
+        ) : (
+            <>
+                {confirmButton}
+                {cancelButton}
+            </>
+        );
+    };
+
+    return (
+        <Dialog modalType="alert" open={isOpen} onOpenChange={handleOpenChange}>
+            <DialogSurface>
+                <DialogBody>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogContent>{content}</DialogContent>
+                    <DialogActions>{renderButtons()}</DialogActions>
+                </DialogBody>
+            </DialogSurface>
+        </Dialog>
+    );
+};

--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx
@@ -7,8 +7,9 @@ import { type OptionOnSelectData } from '@fluentui/react-combobox';
 import { Dropdown, Option, Toolbar, ToolbarButton, Tooltip, useRestoreFocusTarget } from '@fluentui/react-components';
 import { AddFilled, DeleteRegular, EditRegular, EyeRegular } from '@fluentui/react-icons';
 import * as l10n from '@vscode/l10n';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { type CosmosDBRecordIdentifier } from '../../../../cosmosdb/types/queryResult';
+import { AlertDialog } from '../../../common/AlertDialog';
 import { getDocumentId, isSelectStar } from '../../../utils';
 import { useQueryEditorDispatcher, useQueryEditorState } from '../state/QueryEditorContext';
 import { type TableViewMode } from '../state/QueryEditorState';
@@ -23,111 +24,140 @@ export const ResultTabToolbar = ({ selectedTab }: ResultToolbarProps) => {
     const state = useQueryEditorState();
     const dispatcher = useQueryEditorDispatcher();
     const restoreFocusTargetAttribute = useRestoreFocusTarget();
+    const [isOpen, setIsOpen] = useState(false);
 
     const isEditMode = useMemo<boolean>(() => {
         return state.isExecuting
             ? isSelectStar(state.querySelectedValue || state.queryValue || '')
             : isSelectStar(state.currentQueryResult?.query ?? '');
-    }, [state.currentQueryResult, state.isExecuting]);
+    }, [state.currentQueryResult, state.isExecuting, state.querySelectedValue, state.queryValue]);
 
     const visibility = state.isExecuting ? 'hidden' : 'visible';
     const hasSelectedRows = state.selectedRows.length > 0;
 
-    const getSelectedDocuments = () => {
+    const getSelectedDocuments = useCallback(() => {
         return state.selectedRows
             .map((rowIndex): CosmosDBRecordIdentifier | undefined => {
                 const document = state.currentQueryResult?.documents[rowIndex];
                 return document ? getDocumentId(document, state.partitionKey) : undefined;
             })
             .filter((document) => document !== undefined);
-    };
+    }, [state.selectedRows, state.currentQueryResult?.documents, state.partitionKey]);
 
-    const onOptionSelect = (data: OptionOnSelectData) => {
-        if (data.optionValue) dispatcher.setTableViewMode(data.optionValue as TableViewMode);
-    };
+    const onOptionSelect = useCallback(
+        (data: OptionOnSelectData) => {
+            if (data.optionValue) dispatcher.setTableViewMode(data.optionValue as TableViewMode);
+        },
+        [dispatcher],
+    );
+
+    const handleDialogClose = useCallback(
+        (confirmed: boolean) => {
+            if (confirmed) {
+                const selectedDocuments = getSelectedDocuments();
+                void dispatcher.deleteDocuments(selectedDocuments);
+            }
+            setIsOpen(false);
+        },
+        [dispatcher, getSelectedDocuments],
+    );
+
+    const handleDeleteClick = useCallback(() => {
+        setIsOpen(true);
+    }, []);
 
     if (selectedTab === 'stats__tab') {
         return <></>;
     }
 
     return (
-        <Toolbar size="small">
-            {isEditMode && (
-                <>
-                    <Tooltip content={l10n.t('Add new item in separate tab')} relationship="description" withArrow>
-                        <ToolbarButton
-                            aria-label={l10n.t('Add new item')}
-                            icon={<AddFilled />}
-                            onClick={() => void dispatcher.openDocument('add')}
-                            style={{ visibility }}
-                        />
-                    </Tooltip>
-                    <Tooltip
-                        content={l10n.t('View selected item in separate tab')}
-                        relationship="description"
-                        withArrow
-                    >
-                        <ToolbarButton
-                            aria-label={l10n.t('View selected item')}
-                            icon={<EyeRegular />}
-                            onClick={() => void dispatcher.openDocuments('view', getSelectedDocuments())}
-                            disabled={!hasSelectedRows}
-                            style={{ visibility }}
-                        />
-                    </Tooltip>
-                    <Tooltip
-                        content={l10n.t('Edit selected item in separate tab')}
-                        relationship="description"
-                        withArrow
-                    >
-                        <ToolbarButton
-                            aria-label={l10n.t('Edit selected item')}
-                            icon={<EditRegular />}
-                            onClick={() => void dispatcher.openDocuments('edit', getSelectedDocuments())}
-                            disabled={!hasSelectedRows}
-                            style={{ visibility }}
-                        />
-                    </Tooltip>
-                    <Tooltip content={l10n.t('Delete selected item')} relationship="description" withArrow>
-                        <ToolbarButton
-                            aria-label={l10n.t('Delete selected item')}
-                            icon={<DeleteRegular />}
-                            onClick={() => void dispatcher.deleteDocuments(getSelectedDocuments())}
-                            disabled={!hasSelectedRows}
-                            style={{ visibility }}
-                        />
-                    </Tooltip>
+        <>
+            <AlertDialog
+                isOpen={isOpen}
+                onClose={handleDialogClose}
+                title={l10n.t('Confirm deletion')}
+                content={l10n.t('Are you sure you want to delete selected item(s)? This action cannot be undone.')}
+                confirmButtonText={l10n.t('Delete')}
+                cancelButtonText={l10n.t('Cancel')}
+            />
+            <Toolbar size="small">
+                {isEditMode && (
+                    <>
+                        <Tooltip content={l10n.t('Add new item in separate tab')} relationship="description" withArrow>
+                            <ToolbarButton
+                                aria-label={l10n.t('Add new item')}
+                                icon={<AddFilled />}
+                                onClick={() => void dispatcher.openDocument('add')}
+                                style={{ visibility }}
+                            />
+                        </Tooltip>
+                        <Tooltip
+                            content={l10n.t('View selected item in separate tab')}
+                            relationship="description"
+                            withArrow
+                        >
+                            <ToolbarButton
+                                aria-label={l10n.t('View selected item')}
+                                icon={<EyeRegular />}
+                                onClick={() => void dispatcher.openDocuments('view', getSelectedDocuments())}
+                                disabled={!hasSelectedRows}
+                                style={{ visibility }}
+                            />
+                        </Tooltip>
+                        <Tooltip
+                            content={l10n.t('Edit selected item in separate tab')}
+                            relationship="description"
+                            withArrow
+                        >
+                            <ToolbarButton
+                                aria-label={l10n.t('Edit selected item')}
+                                icon={<EditRegular />}
+                                onClick={() => void dispatcher.openDocuments('edit', getSelectedDocuments())}
+                                disabled={!hasSelectedRows}
+                                style={{ visibility }}
+                            />
+                        </Tooltip>
+                        <Tooltip content={l10n.t('Delete selected item')} relationship="description" withArrow>
+                            <ToolbarButton
+                                aria-label={l10n.t('Delete selected item')}
+                                icon={<DeleteRegular />}
+                                onClick={handleDeleteClick}
+                                disabled={!hasSelectedRows}
+                                style={{ visibility }}
+                            />
+                        </Tooltip>
 
-                    <ToolbarDividerTransparent />
-                </>
-            )}
+                        <ToolbarDividerTransparent />
+                    </>
+                )}
 
-            <Tooltip content={l10n.t('Change view mode')} relationship="description" withArrow>
-                <Dropdown
-                    onOptionSelect={(_event, data) => onOptionSelect(data)}
-                    style={{ minWidth: '100px', maxWidth: '100px' }}
-                    // The value is always set "as is"
-                    value={
-                        state.tableViewMode === 'Tree'
-                            ? l10n.t('Tree')
-                            : state.tableViewMode === 'JSON'
-                              ? l10n.t('JSON')
-                              : l10n.t('Table')
-                    }
-                    defaultSelectedOptions={[state.tableViewMode]}
-                    {...restoreFocusTargetAttribute}
-                >
-                    <Option key="Tree" value="Tree">
-                        {l10n.t('Tree')}
-                    </Option>
-                    <Option key="JSON" value="JSON">
-                        {l10n.t('JSON')}
-                    </Option>
-                    <Option key="Table" value="Table">
-                        {l10n.t('Table')}
-                    </Option>
-                </Dropdown>
-            </Tooltip>
-        </Toolbar>
+                <Tooltip content={l10n.t('Change view mode')} relationship="description" withArrow>
+                    <Dropdown
+                        onOptionSelect={(_event, data) => onOptionSelect(data)}
+                        style={{ minWidth: '100px', maxWidth: '100px' }}
+                        // The value is always set "as is"
+                        value={
+                            state.tableViewMode === 'Tree'
+                                ? l10n.t('Tree')
+                                : state.tableViewMode === 'JSON'
+                                  ? l10n.t('JSON')
+                                  : l10n.t('Table')
+                        }
+                        defaultSelectedOptions={[state.tableViewMode]}
+                        {...restoreFocusTargetAttribute}
+                    >
+                        <Option key="Tree" value="Tree">
+                            {l10n.t('Tree')}
+                        </Option>
+                        <Option key="JSON" value="JSON">
+                            {l10n.t('JSON')}
+                        </Option>
+                        <Option key="Table" value="Table">
+                            {l10n.t('Table')}
+                        </Option>
+                    </Dropdown>
+                </Tooltip>
+            </Toolbar>
+        </>
     );
 };


### PR DESCRIPTION
This pull request introduces a reusable `AlertDialog` component and integrates it into various parts of the CosmosDB Query Editor. The changes improve code reusability, simplify dialog management, and enhance the user experience by standardizing alert dialogs. Below are the key changes grouped by theme:

### New `AlertDialog` Component
* Added a new `AlertDialog` component in `src/webviews/common/AlertDialog.tsx`. This component is a reusable, customizable modal dialog for confirmation prompts, supporting configurable titles, content, and button order.

### Refactoring to Use `AlertDialog`
* Replaced the inline `AlertDialog` implementation in `src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultPanelToolbarOverflow.tsx` with the new reusable `AlertDialog` component. Updated dialog-related props (`setOpen`/`setDoAction`) to `setIsOpen`/`setAction` for better clarity. [[1]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L9-L15) [[2]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L49-R50) [[3]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L593-L604) [[4]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L668-R657)
* Integrated the new `AlertDialog` component into `ResultTabToolbar` in `src/webviews/cosmosdb/QueryEditor/ResultPanel/ResultTabToolbar.tsx` to handle delete confirmation dialogs. Added state and handlers for dialog visibility and actions. [[1]](diffhunk://#diff-5cdf9f37b21ee76f767b33bc6d49af1c805250506c1d46eedb89dea7e5ea64bbL10-R12) [[2]](diffhunk://#diff-5cdf9f37b21ee76f767b33bc6d49af1c805250506c1d46eedb89dea7e5ea64bbR27-R82) [[3]](diffhunk://#diff-5cdf9f37b21ee76f767b33bc6d49af1c805250506c1d46eedb89dea7e5ea64bbL95-R124)

### Code Simplification
* Removed the old inline `AlertDialog` implementation and associated state management logic from `ResultPanelToolbarOverflow`. This reduces redundancy and centralizes dialog functionality. [[1]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L49-R50) [[2]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L618-R573)
* Updated various button components (`ReloadQueryButton`, `ChangePageSizeButton`) to use the new dialog props (`setIsOpen`/`setAction`) for consistency. [[1]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L102-R66) [[2]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L260-R219) [[3]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L269-R229) [[4]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L690-R670) [[5]](diffhunk://#diff-c128b1a5dade1fa53b33a1df356e88d39834d06b5b8fd9057153d56a4005c078L703-R683)

### Enhanced User Experience
* Standardized confirmation dialogs across the Query Editor using the new `AlertDialog` component, ensuring a consistent look and feel. For example, the delete confirmation dialog in `ResultTabToolbar` now uses the same design as other dialogs. [[1]](diffhunk://#diff-5cdf9f37b21ee76f767b33bc6d49af1c805250506c1d46eedb89dea7e5ea64bbL10-R12) [[2]](diffhunk://#diff-5cdf9f37b21ee76f767b33bc6d49af1c805250506c1d46eedb89dea7e5ea64bbL95-R124) [[3]](diffhunk://#diff-5cdf9f37b21ee76f767b33bc6d49af1c805250506c1d46eedb89dea7e5ea64bbR161)

These changes improve maintainability, consistency, and user experience across the CosmosDB Query Editor.