### PR TITLE
Fix issue #2663: Improve arial labels for "Learn more…" links.

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -347,6 +347,8 @@
   "Learn": "Learn",
   "Learn more": "Learn more",
   "Learn more about enabling TLS/SSL for the MongoDB Emulator.": "Learn more about enabling TLS/SSL for the MongoDB Emulator.",
+  "Learn more about index metrics…": "Learn more about index metrics…",
+  "Learn more about query metrics…": "Learn more about query metrics…",
   "Learn more about the Azure Cosmos DB (NoSQL) Emulator.": "Learn more about the Azure Cosmos DB (NoSQL) Emulator.",
   "Learn more about the Azure Cosmos DB Emulator for MongoDB.": "Learn more about the Azure Cosmos DB Emulator for MongoDB.",
   "Learn more…": "Learn more…",

--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx
@@ -41,7 +41,10 @@ export const IndexMetricsView: React.FC<{ indexMetricsStr: string; topLabelStyle
         <>
             <div className={topLabelStyle}>
                 <Label size={'large'}>{parsed.title}</Label> (
-                <Link href={INDEX_METRICS_DOC_URL}>{l10n.t('Learn more…')}</Link>)
+                <Link href={INDEX_METRICS_DOC_URL} arial-label={l10n.t('Learn more about index metrics…')}>
+                    {l10n.t('Learn more…')}
+                </Link>
+                )
             </div>
 
             <Table arial-label={l10n.t('Index metrics table')} style={{ minWidth: '510px' }}>

--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/StatsTab.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/StatsTab.tsx
@@ -79,7 +79,10 @@ export const StatsTab = () => {
                 <div className={styles.panel1}>
                     <div className={styles.topLabel}>
                         <Label size={'large'}>{l10n.t('Query metrics')}</Label> (
-                        <Link href={QUERY_METRICS_DOC_URL}>{l10n.t('Learn more…')}</Link>)
+                        <Link href={QUERY_METRICS_DOC_URL} arial-label={l10n.t('Learn more about query metrics…')}>
+                            {l10n.t('Learn more…')}
+                        </Link>
+                        )
                     </div>
                     <Table arial-label={l10n.t('Stats table')} style={{ minWidth: '510px' }}>
                         <TableHeader>


### PR DESCRIPTION
This pull request adds more descriptive text for "Learn more" links and updating the localization file to support these changes.

### Localization improvements:
* [`l10n/bundle.l10n.json`](diffhunk://#diff-829b512e02461234524c007941f3260e67a43b109f48bedf257ab8e8033cc527R350-R351): Added new localized strings for "Learn more about index metrics…" and "Learn more about query metrics…" to provide more descriptive context for links.

### Accessibility enhancements:
* [`src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx`](diffhunk://#diff-5b0779b73027ea1cf9f5fff462b9b46d635305f2981fa81eacad0a46f651a9fcL44-R47): Updated the "Learn more" link for index metrics to include an `aria-label` with a more descriptive message, improving accessibility.
* [`src/webviews/cosmosdb/QueryEditor/ResultPanel/StatsTab.tsx`](diffhunk://#diff-4b01f3f72965fa3a085d8f69779b5b9c633c6478a15b1ac880fe05937dacdbccL82-R85): Updated the "Learn more" link for query metrics to include an `aria-label` with a more descriptive message, improving accessibility.