### PR TITLE
Fixed aria label of copy to clipboard button.

### DIFF
--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/CopyToClipboardButton.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/CopyToClipboardButton.tsx
@@ -86,7 +86,7 @@ export const CopyToClipboardButton = forwardRef(function CopyToClipboardButton(
                     >
                         <ToolbarButton
                             ref={ref}
-                            aria-label={l10n.t('Copy to clipboard')}
+                            aria-label={tooltipClipboardContent}
                             icon={<DocumentCopyRegular />}
                             disabled={!state.isConnected}
                         />


### PR DESCRIPTION
This pull request updates the `CopyToClipboardButton` component to enhance accessibility by dynamically setting the `aria-label` attribute based on the `tooltipClipboardContent` variable.

Accessibility improvement:

* [`src/webviews/cosmosdb/QueryEditor/ResultPanel/CopyToClipboardButton.tsx`](diffhunk://#diff-341721f9cd5a9f9ee75801c741c3b0c6daaa293a99ecf93b3ac63ba4a7f38861L89-R89): Updated the `aria-label` property of the `ToolbarButton` to use the `tooltipClipboardContent` variable, replacing the static text. This ensures the label is contextually relevant and improves accessibility.
 
Fixes #2667