### PR TITLE
Fixed aria labels in query editor stats & result tab.

### DIFF
--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx
@@ -117,7 +117,11 @@ export const IndexMetricsView: React.FC<{ indexMetricsStr: string; topLabelStyle
                 </TableHeader>
                 <TableBody>
                     {parsed.sections.map((section, index) => (
-                        <TableRow key={`${section.title}-${index}`}>
+                        <TableRow
+                            key={`${section.title}-${index}`}
+                            aria-label={section.title + ' ' + Object.values(section.indexes).join(' ')}
+                            tabIndex={0}
+                        >
                             <TableCell>{section.title}</TableCell>
                             <TableCell>
                                 {section.indexes && section.indexes.length > 0 ? (

--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/StatsTab.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/StatsTab.tsx
@@ -97,7 +97,11 @@ export const StatsTab = ({ className }: StatsTabProps) => {
                         </TableHeader>
                         <TableBody>
                             {items.map((item) => (
-                                <TableRow key={item.metric}>
+                                <TableRow
+                                    key={item.metric}
+                                    aria-label={item.tooltip + ' ' + item.formattedValue}
+                                    tabIndex={0}
+                                >
                                     <TableCell>
                                         <TableCellLayout>{item.metric}</TableCellLayout>
                                     </TableCell>


### PR DESCRIPTION
This pull request improves accessibility in the CosmosDB Query Editor by adding ARIA labels and keyboard navigation support to table rows in the `IndexMetricsView` and `StatsTab` components.

### Accessibility improvements:

* **`IndexMetricsView` component (`src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx`)**:
  - Added `aria-label` attributes to table rows, combining section titles and index values for better screen reader support.
  - Enabled keyboard navigation by adding `tabIndex={0}` to table rows.

* **`StatsTab` component (`src/webviews/cosmosdb/QueryEditor/ResultPanel/StatsTab.tsx`)**:
  - Added `aria-label` attributes to table rows, combining tooltip text and formatted metric values for accessibility.
  - Enabled keyboard navigation by adding `tabIndex={0}` to table rows.

Fixes #2669