### PR TITLE
Fixes screen reader announcement in query editor.

### DIFF
--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryMonaco.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryMonaco.tsx
@@ -61,6 +61,10 @@ export const QueryMonaco = () => {
             value={state.queryValue}
             onChange={onChange}
             onMount={onMount}
+            options={{
+                accessibilitySupport: 'on',
+                accessibilityPageSize: 1,
+            }}
         />
     );
 };


### PR DESCRIPTION
This pull request introduces an accessibility improvement to the `QueryMonaco` component in the CosmosDB Query Editor.

Accessibility enhancements:

* [`src/webviews/cosmosdb/QueryEditor/QueryPanel/QueryMonaco.tsx`](diffhunk://#diff-b70fac3c80a578d735a4522175e1e65085313bbe31b5c23a0d5d21eadf91824bR64-R67): Added an `options` object to the `MonacoEditor` configuration with `accessibilitySupport` set to `'on'` and `accessibilityPageSize` set to `1` to improve screen reader support.

Fixes #2670
