### PR TITLE
Fixed throughput buckets submenu.

### DIFF
--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
@@ -131,7 +131,7 @@ export const RunQueryButton = forwardRef(function RunQueryButton(
                                         : ['0'],
                             }}
                             onCheckedValueChange={(_, data) => {
-                                const value = data.checkedItems[0];
+                                const value = data.checkedItems?.[0];
                                 if (value !== undefined) {
                                     const bucketNumber = parseInt(value, 10);
                                     dispatcher.selectBucket(bucketNumber);

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
@@ -121,33 +121,34 @@ export const RunQueryButton = forwardRef(function RunQueryButton(
                 {state.throughputBuckets !== null && state.throughputBuckets !== undefined && (
                     <>
                         <MenuDivider />
-                        <Menu
-                            key={`bucket-menu-${state.selectedThroughputBucket}`}
-                            checkedValues={{
-                                throughputBucket:
-                                    state.selectedThroughputBucket !== null &&
-                                    state.selectedThroughputBucket !== undefined
-                                        ? [state.selectedThroughputBucket.toString()]
-                                        : ['0'],
-                            }}
-                            onCheckedValueChange={(_, data) => {
-                                const value = data.checkedItems?.[0];
-                                if (value !== undefined) {
-                                    const bucketNumber = parseInt(value, 10);
-                                    dispatcher.selectBucket(bucketNumber);
-                                }
-                            }}
-                        >
-                            <MenuTrigger>
-                                <MenuItem hasSubmenu>{l10n.t('Throughput Bucket')}</MenuItem>
-                            </MenuTrigger>
-                            <MenuPopover>
-                                <MenuList>
+                        <MenuList>
+                            <Menu
+                                key={`bucket-menu-${state.selectedThroughputBucket ?? 0}`}
+                                defaultCheckedValues={{ throughputBucket: ['0'] }}
+                                checkedValues={{
+                                    throughputBucket:
+                                        state.selectedThroughputBucket !== null &&
+                                        state.selectedThroughputBucket !== undefined
+                                            ? [state.selectedThroughputBucket.toString()]
+                                            : ['0'],
+                                }}
+                                onCheckedValueChange={(_, data) => {
+                                    const value = data.checkedItems?.[0];
+                                    if (value !== undefined) {
+                                        const bucketNumber = parseInt(value, 10);
+                                        dispatcher.selectBucket(bucketNumber);
+                                    }
+                                }}
+                            >
+                                <MenuTrigger>
+                                    <MenuItem hasSubmenu>{l10n.t('Throughput Bucket')}</MenuItem>
+                                </MenuTrigger>
+                                <MenuPopover>
                                     {state.throughputBuckets.length === 0 && (
                                         <MenuItem disabled>{l10n.t('No buckets')}</MenuItem>
                                     )}
                                     {state.throughputBuckets.length > 0 && (
-                                        <MenuItemRadio name="throughputBucket" value="0">
+                                        <MenuItemRadio key="throughputBucket-0" name="throughputBucket" value="0">
                                             {l10n.t('No bucket')}
                                         </MenuItemRadio>
                                     )}
@@ -162,9 +163,9 @@ export const RunQueryButton = forwardRef(function RunQueryButton(
                                                 {l10n.t('Bucket {0}', index + 1)}
                                             </MenuItemRadio>
                                         ))}
-                                </MenuList>
-                            </MenuPopover>
-                        </Menu>
+                                </MenuPopover>
+                            </Menu>
+                        </MenuList>
                     </>
                 )}
             </MenuPopover>

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
@@ -8,7 +8,7 @@ import {
     type MenuButtonProps,
     MenuDivider,
     MenuItem,
-    MenuItemCheckbox,
+    MenuItemRadio,
     MenuList,
     MenuPopover,
     MenuTrigger,
@@ -122,14 +122,24 @@ export const RunQueryButton = forwardRef(function RunQueryButton(
                     <>
                         <MenuDivider />
                         <Menu
+                            key={`bucket-menu-${state.selectedThroughputBucket}`}
                             checkedValues={{
-                                throughputBucket: state.selectedThroughputBucket
-                                    ? [state.selectedThroughputBucket.toString()]
-                                    : ['0'],
+                                throughputBucket:
+                                    state.selectedThroughputBucket !== null &&
+                                    state.selectedThroughputBucket !== undefined
+                                        ? [state.selectedThroughputBucket.toString()]
+                                        : ['0'],
+                            }}
+                            onCheckedValueChange={(_, data) => {
+                                const value = data.checkedItems[0];
+                                if (value !== undefined) {
+                                    const bucketNumber = parseInt(value, 10);
+                                    dispatcher.selectBucket(bucketNumber);
+                                }
                             }}
                         >
                             <MenuTrigger>
-                                <MenuItem>{l10n.t('Throughput Bucket')}</MenuItem>
+                                <MenuItem hasSubmenu>{l10n.t('Throughput Bucket')}</MenuItem>
                             </MenuTrigger>
                             <MenuPopover>
                                 <MenuList>
@@ -137,25 +147,20 @@ export const RunQueryButton = forwardRef(function RunQueryButton(
                                         <MenuItem disabled>{l10n.t('No buckets')}</MenuItem>
                                     )}
                                     {state.throughputBuckets.length > 0 && (
-                                        <MenuItemCheckbox
-                                            name="throughputBucket"
-                                            value="0"
-                                            onClick={() => dispatcher.selectBucket(0)}
-                                        >
+                                        <MenuItemRadio name="throughputBucket" value="0">
                                             {l10n.t('No bucket')}
-                                        </MenuItemCheckbox>
+                                        </MenuItemRadio>
                                     )}
                                     {state.throughputBuckets.length > 0 &&
                                         state.throughputBuckets.map((isActive, index) => (
-                                            <MenuItemCheckbox
+                                            <MenuItemRadio
                                                 key={`throughputBucket-${index + 1}`}
                                                 name="throughputBucket"
                                                 value={(index + 1).toString()}
                                                 disabled={!isActive}
-                                                onClick={() => dispatcher.selectBucket(index + 1)}
                                             >
                                                 {l10n.t('Bucket {0}', index + 1)}
-                                            </MenuItemCheckbox>
+                                            </MenuItemRadio>
                                         ))}
                                 </MenuList>
                             </MenuPopover>

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx
@@ -126,11 +126,9 @@ export const RunQueryButton = forwardRef(function RunQueryButton(
                                 key={`bucket-menu-${state.selectedThroughputBucket ?? 0}`}
                                 defaultCheckedValues={{ throughputBucket: ['0'] }}
                                 checkedValues={{
-                                    throughputBucket:
-                                        state.selectedThroughputBucket !== null &&
-                                        state.selectedThroughputBucket !== undefined
-                                            ? [state.selectedThroughputBucket.toString()]
-                                            : ['0'],
+                                    throughputBucket: state.selectedThroughputBucket
+                                        ? [state.selectedThroughputBucket.toString()]
+                                        : ['0'],
                                 }}
                                 onCheckedValueChange={(_, data) => {
                                     const value = data.checkedItems?.[0];
@@ -144,25 +142,27 @@ export const RunQueryButton = forwardRef(function RunQueryButton(
                                     <MenuItem hasSubmenu>{l10n.t('Throughput Bucket')}</MenuItem>
                                 </MenuTrigger>
                                 <MenuPopover>
-                                    {state.throughputBuckets.length === 0 && (
-                                        <MenuItem disabled>{l10n.t('No buckets')}</MenuItem>
-                                    )}
-                                    {state.throughputBuckets.length > 0 && (
-                                        <MenuItemRadio key="throughputBucket-0" name="throughputBucket" value="0">
-                                            {l10n.t('No bucket')}
-                                        </MenuItemRadio>
-                                    )}
-                                    {state.throughputBuckets.length > 0 &&
-                                        state.throughputBuckets.map((isActive, index) => (
-                                            <MenuItemRadio
-                                                key={`throughputBucket-${index + 1}`}
-                                                name="throughputBucket"
-                                                value={(index + 1).toString()}
-                                                disabled={!isActive}
-                                            >
-                                                {l10n.t('Bucket {0}', index + 1)}
+                                    <MenuList>
+                                        {state.throughputBuckets.length === 0 && (
+                                            <MenuItem disabled>{l10n.t('No buckets')}</MenuItem>
+                                        )}
+                                        {state.throughputBuckets.length > 0 && (
+                                            <MenuItemRadio key="throughputBucket-0" name="throughputBucket" value="0">
+                                                {l10n.t('No bucket')}
                                             </MenuItemRadio>
-                                        ))}
+                                        )}
+                                        {state.throughputBuckets.length > 0 &&
+                                            state.throughputBuckets.map((isActive, index) => (
+                                                <MenuItemRadio
+                                                    key={`throughputBucket-${index + 1}`}
+                                                    name="throughputBucket"
+                                                    value={(index + 1).toString()}
+                                                    disabled={!isActive}
+                                                >
+                                                    {l10n.t('Bucket {0}', index + 1)}
+                                                </MenuItemRadio>
+                                            ))}
+                                    </MenuList>
                                 </MenuPopover>
                             </Menu>
                         </MenuList>


### PR DESCRIPTION
Fixes #2675

This pull request updates the `RunQueryButton` component in the CosmosDB Query Editor to improve menu behavior and code clarity. The most significant changes involve replacing `MenuItemCheckbox` with `MenuItemRadio` for better semantics, adding a key to the `Menu` component for React rendering optimization, and enhancing state management for throughput bucket selection.

### Menu behavior updates:
* Replaced `MenuItemCheckbox` with `MenuItemRadio` to ensure correct behavior for mutually exclusive menu options. (`src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx`, [[1]](diffhunk://#diff-f6409d4acd7793ae0efb7e29b1384081157d98c5ec77d2c673943d4b73baf374L11-R11) [[2]](diffhunk://#diff-f6409d4acd7793ae0efb7e29b1384081157d98c5ec77d2c673943d4b73baf374R125-R163)
* Added `hasSubmenu` to the `MenuItem` in the `MenuTrigger` to indicate the presence of a submenu. (`src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx`, [src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsxR125-R163](diffhunk://#diff-f6409d4acd7793ae0efb7e29b1384081157d98c5ec77d2c673943d4b73baf374R125-R163))

### State management improvements:
* Enhanced `checkedValues` initialization to handle `null` or `undefined` `selectedThroughputBucket` values, defaulting to `['0']` in such cases. (`src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx`, [src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsxR125-R163](diffhunk://#diff-f6409d4acd7793ae0efb7e29b1384081157d98c5ec77d2c673943d4b73baf374R125-R163))
* Implemented `onCheckedValueChange` to handle throughput bucket selection dynamically and update the state via the dispatcher. (`src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx`, [src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsxR125-R163](diffhunk://#diff-f6409d4acd7793ae0efb7e29b1384081157d98c5ec77d2c673943d4b73baf374R125-R163))

### Code quality enhancements:
* Added a unique `key` to the `Menu` component to optimize React's rendering and reconciliation process. (`src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx`, [src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsxR125-R163](diffhunk://#diff-f6409d4acd7793ae0efb7e29b1384081157d98c5ec77d2c673943d4b73baf374R125-R163))