### PR TITLE
chore(survey): add CodeQL justification comment for MD5 usage in A/B selection

### DIFF
--- a/src/utils/survey.ts
+++ b/src/utils/survey.ts
@@ -289,7 +289,7 @@ async function initSurvey(): Promise<void> {
             try {
                 // Deterministic machine ID selection using MD5 (faster than SHA-256)
                 // MD5 is sufficient for non-security random distribution needs
-                const buffer = crypto.createHash('md5').update(env.machineId).digest();
+                const buffer = crypto.createHash('md5').update(env.machineId).digest(); // CodeQL [SM04514] the weak hashing algorithm MD5 is used here for non-security random distribution purposes only
 
                 // Read a 32-bit unsigned integer from the buffer directly
                 // (Using the first 4 bytes gives a full 32-bit range)


### PR DESCRIPTION
MD5 hash usage flagged by CodeQL can be suppressed in this use case.