### PR TITLE
Fix the missing "Create Resource" icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
         {
           "command": "azureDatabases.createServer",
           "title": "%cosmosdb.command.account.create%",
-          "type": "microsoft.documentdb/databaseaccounts",
+          "type": "AzureCosmosDb",
           "detail": "%cosmosdb.command.account.create.description%"
         }
       ],


### PR DESCRIPTION
This fixes the Icon when creating a new resource (#2767):

<img width="605" height="113" alt="image" src="https://github.com/user-attachments/assets/7d6147bb-20c6-4427-ac3b-4c196fbcbcb2" />

The problem was that we were sending the actual Azure resource type string instead of the [AzExtResourceType](https://github.com/microsoft/vscode-azureresourcegroups/blob/main/api/src/AzExtResourceType.ts#L13) value that Azure Resources expects in
https://github.com/microsoft/vscode-azureresourcegroups/blob/main/src/commands/createResource.ts#L41


Fixes #2767