### PR TITLE
build(l10n): add 'qps-ploc' to supported languages and enable pseudo languages

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -94,6 +94,7 @@ extends:
                           inputs:
                               locProj: 'l10n/LocProject.json'
                               outDir: '$(Build.ArtifactStagingDirectory)'
+                              isEnablePseudoLanguagesSelected: true
                               isCreatePrSelected: true
                               isAutoCompletePrSelected: false
                               isSetAutoCompletePrSelected: true

--- a/webpack.config.ext.js
+++ b/webpack.config.ext.js
@@ -11,7 +11,22 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
 const excludeRegion = /<!-- region exclude-from-marketplace -->.*?<!-- endregion exclude-from-marketplace -->/gis;
-const supportedLanguages = ['cs', 'de', 'es', 'fr', 'it', 'ja', 'ko', 'pl', 'pt-BR', 'ru', 'tr', 'zh-Hans', 'zh-Hant']; // From VSCode L10n
+const supportedLanguages = [
+    'cs',
+    'de',
+    'es',
+    'fr',
+    'it',
+    'ja',
+    'ko',
+    'pl',
+    'pt-BR',
+    'ru',
+    'tr',
+    'zh-Hans',
+    'zh-Hant',
+    'qps-ploc',
+]; // From VSCode L10n
 
 module.exports = (env, { mode }) => {
     const isDev = mode === 'development';


### PR DESCRIPTION
The main changes enable pseudo-language processing and update the list of supported languages to include pseudo-localization, allowing to test localization without actual language support.

Requirements:
* Install the [Pseudo Language Language Pack](https://marketplace.visualstudio.com/items?itemName=MS-CEINTL.vscode-language-pack-qps-ploc) extension
* Run VS Code with the pseudo language locale "code --locale=qps-ploc" (you can also switch with the "Configure Display Language" command, but that's a persistent user setting making it difficult to switch back)

The automatically generated PR https://github.com/microsoft/vscode-cosmosdb/pull/2782/ includes also a `qps-plocm` variant which is not supported with VS Code, hence we package only the `qps-ploc` variant. Unfortunately we can't choose with the OneLocBuild step which pseudo languages to generate and must commit both.

Here is how it looks like when testing localization with this locale:

<img width="402" height="315" alt="image" src="https://github.com/user-attachments/assets/b70918d2-c89e-45f6-abe7-6247539f2317" />
<img width="1446" height="491" alt="image" src="https://github.com/user-attachments/assets/6e94a163-d8db-4c3b-95e6-73c47d8c5461" />
<img width="1441" height="926" alt="image" src="https://github.com/user-attachments/assets/136bf107-8f88-4204-97b6-e8d64563a61b" />

It seems we have still some unlocalized strings...