### PR TITLE
build(l10n): enable nightly scheduled build and force runs

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -7,13 +7,13 @@ trigger:
 pr: none
 
 # Scheduled nightly build of `main`
-#schedules:
-#    - cron: '0 0 * * *'
-#      displayName: Nightly scheduled build
-#      always: false # Don't rebuild if there haven't been changes
-#      branches:
-#          include:
-#              - main
+schedules:
+    - cron: '0 0 * * *'
+      displayName: Nightly scheduled build
+      always: true # rebuild even if there are no code changes, required to keep localization files up to date
+      branches:
+          include:
+              - main
 
 parameters:
     - name: 'debug'


### PR DESCRIPTION
Uncomment the schedules in the build pipeline and set always: true so nightly builds run even when there are no code changes. This ensures localization files are kept up to date.