### PR TITLE
chore(grammar): remove Mongo/JS grammar contributions from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,17 +241,6 @@
         ]
       }
     ],
-    "grammars": [
-      {
-        "language": "mongo",
-        "scopeName": "source.mongo.js",
-        "path": "./grammar/JavaScript.tmLanguage.json"
-      },
-      {
-        "scopeName": "source.mongo.js.regexp",
-        "path": "./grammar/Regular Expressions (JavaScript).tmLanguage"
-      }
-    ],
     "commands": [
       {
         "category": "Azure Cosmos DB",


### PR DESCRIPTION
Remove the bundled "grammars" contribution entries for the mongo language and JavaScript regular expressions from package.json.

Fixes #2794