### PR TITLE
build(l10n): add LCL package inputs to OneLocBuild task

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -133,6 +133,9 @@ extends:
                               gitHubPrMergeMethod: 'squash'
                               packageSourceAuth: patAuth
                               dependencyPackageSource: 'https://msdata.pkgs.visualstudio.com/CosmosDB/_packaging/vscode-cosmosdb/nuget/v3/index.json'
+                              lclSource: lclFilesfromPackage
+                              lclPackageId: 'LCL-JUNO-PROD-VSCOSMOSDB'
+                              lclPackageSource: 'https://msdata.pkgs.visualstudio.com/CosmosDB/_packaging/vscode-cosmosdb/nuget/v3/index.json'
                               patVariable: '$(System.AccessToken)'
 
                         - task: Npm@1


### PR DESCRIPTION
During onboarding to localization we opted in to consuming LCL files from a package, since it's the only option that works for us without having to deal with loc conversions. Now to consume the package we need to specify the feed and package ID that was assigned to us by the LOC team.