### PR TITLE
Fix Extension settings after rebranding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1162,41 +1162,6 @@
     ],
     "configuration": [
       {
-        "title": "Authentication",
-        "properties": {
-          "azureDatabases.cosmosDB.preferredAuthenticationMethod": {
-            "type": "string",
-            "enum": [
-              "auto",
-              "accountKey",
-              "entraId",
-              "managedIdentity"
-            ],
-            "enumItemLabels": [
-              "%cosmosdb.configuration.preferredAuthenticationMethod.auto%",
-              "%cosmosdb.configuration.preferredAuthenticationMethod.accountKey%",
-              "%cosmosdb.configuration.preferredAuthenticationMethod.entraId%",
-              "%cosmosdb.configuration.preferredAuthenticationMethod.managedIdentity%"
-            ],
-            "markdownEnumDescriptions": [
-              "%cosmosdb.configuration.preferredAuthenticationMethod.auto.description%",
-              "%cosmosdb.configuration.preferredAuthenticationMethod.accountKey.description%",
-              "%cosmosdb.configuration.preferredAuthenticationMethod.entraId.description%",
-              "%cosmosdb.configuration.preferredAuthenticationMethod.managedIdentity.description%"
-            ],
-            "markdownDescription": "%cosmosdb.configuration.preferredAuthenticationMethod%",
-            "default": "auto",
-            "order": 0
-          },
-          "azureDatabases.authentication.managedIdentity.clientID": {
-            "type": "string",
-            "markdownDescription": "%cosmosdb.configuration.authentication.managedIdentity.clientID%",
-            "default": null,
-            "order": 1
-          }
-        }
-      },
-      {
         "title": "Azure Cosmos DB",
         "properties": {
           "mongo.shell.path": {
@@ -1302,6 +1267,41 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "%cosmosdb.configuration.manage-llm-assets%"
+          }
+        }
+      },
+      {
+        "title": "Authentication",
+        "properties": {
+          "azureDatabases.cosmosDB.preferredAuthenticationMethod": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "accountKey",
+              "entraId",
+              "managedIdentity"
+            ],
+            "enumItemLabels": [
+              "%cosmosdb.configuration.preferredAuthenticationMethod.auto%",
+              "%cosmosdb.configuration.preferredAuthenticationMethod.accountKey%",
+              "%cosmosdb.configuration.preferredAuthenticationMethod.entraId%",
+              "%cosmosdb.configuration.preferredAuthenticationMethod.managedIdentity%"
+            ],
+            "markdownEnumDescriptions": [
+              "%cosmosdb.configuration.preferredAuthenticationMethod.auto.description%",
+              "%cosmosdb.configuration.preferredAuthenticationMethod.accountKey.description%",
+              "%cosmosdb.configuration.preferredAuthenticationMethod.entraId.description%",
+              "%cosmosdb.configuration.preferredAuthenticationMethod.managedIdentity.description%"
+            ],
+            "markdownDescription": "%cosmosdb.configuration.preferredAuthenticationMethod%",
+            "default": "auto",
+            "order": 0
+          },
+          "azureDatabases.authentication.managedIdentity.clientID": {
+            "type": "string",
+            "markdownDescription": "%cosmosdb.configuration.authentication.managedIdentity.clientID%",
+            "default": null,
+            "order": 1
           }
         }
       }


### PR DESCRIPTION
It seems VS Code expects either the first configuration section to be the default (title equals the extension name) or at least the first configuration in the first section to match the extension title. It was the case for the first configuration in the `Authentication` section being `azureDatabases.cosmosDB.preferredAuthenticationMethod`, so the first setting in the first section started with the extension name, so everything was fine.

However after rebranding we didn't want to adjust the configuration IDs (migration is complicated with VS Code) and so now the first setting didn't match the extension name any longer and this cofused VS Code in a way that ALL extension settings were missing in the Settings tab. One could only find them by searching for the setting name or ID, but not navigate to them initially.

The fix seems to be simple by just moving the "non default" Authentication section below the default one that matches the extension name. However we should look into unifying the preferences with a solid migration path.

Fixes #2826