### PR TITLE
fix(deps): lock @swc/core version to 1.13.5 to support darwin builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@eslint/js": "~9.34.0",
         "@pmmmwh/react-refresh-webpack-plugin": "~0.6.1",
         "@swc/cli": "~0.7.8",
-        "@swc/core": "~1.13.5",
+        "@swc/core": "1.13.5",
         "@swc/jest": "~0.2.39",
         "@types/documentdb": "~1.10.13",
         "@types/jest": "~30.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@eslint/js": "~9.34.0",
     "@pmmmwh/react-refresh-webpack-plugin": "~0.6.1",
     "@swc/cli": "~0.7.8",
-    "@swc/core": "~1.13.5",
+    "@swc/core": "1.13.5",
     "@swc/jest": "~0.2.39",
     "@types/documentdb": "~1.10.13",
     "@types/jest": "~30.0.0",


### PR DESCRIPTION
On MacOS with Silicon the latest @swc/core-darwin-arm64 version 1.13.21 doesn't seem to be notarized or is simply broken and MacOS refuses to execute it on arm64. Locking to the min required 1.13.5 seems to fix the issue.