### PR TITLE
Added "Create Database/Container" items to empty nodes.

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -140,6 +140,7 @@
   "Create collection": "Create collection",
   "Create Collection…": "Create Collection…",
   "Create container": "Create container",
+  "Create Container…": "Create Container…",
   "Create database": "Create database",
   "Create Database…": "Create Database…",
   "Create graph": "Create graph",

--- a/src/tree/cosmosdb/CosmosDBAccountAttachedResourceItem.ts
+++ b/src/tree/cosmosdb/CosmosDBAccountAttachedResourceItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RestError, type CosmosClient, type DatabaseDefinition, type Resource } from '@azure/cosmos';
+import { createGenericElement } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { type Experience } from '../../AzureDBExperiences';
@@ -42,6 +43,20 @@ export abstract class CosmosDBAccountAttachedResourceItem
         const databases = await withClaimsChallengeHandling(accountInfo, async (cosmosClient) =>
             this.getDatabases(accountInfo, cosmosClient),
         );
+
+        if (databases.length === 0) {
+            // no databases in there:
+            return [
+                createGenericElement({
+                    contextValue: this.contextValue,
+                    id: `${this.id}/no-databases`,
+                    label: l10n.t('Create Database…'),
+                    iconPath: new vscode.ThemeIcon('plus'),
+                    commandId: 'cosmosDB.createDatabase',
+                    commandArgs: [this],
+                }) as TreeElement,
+            ];
+        }
 
         return this.getChildrenImpl(accountInfo, databases);
     }

--- a/src/tree/cosmosdb/CosmosDBDatabaseResourceItem.ts
+++ b/src/tree/cosmosdb/CosmosDBDatabaseResourceItem.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type ContainerDefinition, type CosmosClient, type Resource } from '@azure/cosmos';
-import { createContextValue } from '@microsoft/vscode-azext-utils';
+import { createContextValue, createGenericElement } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
+import { l10n } from 'vscode';
 import { type Experience } from '../../AzureDBExperiences';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { countExperienceUsageForSurvey } from '../../utils/survey';
@@ -35,6 +36,19 @@ export abstract class CosmosDBDatabaseResourceItem
         );
         const sortedContainers = containers.sort((a, b) => a.id.localeCompare(b.id));
 
+        if (containers.length === 0) {
+            // no databases in there:
+            return [
+                createGenericElement({
+                    contextValue: this.contextValue,
+                    id: `${this.id}/no-containers`,
+                    label: l10n.t('Create Container…'),
+                    iconPath: new vscode.ThemeIcon('plus'),
+                    commandId: 'cosmosDB.createContainer',
+                    commandArgs: [this],
+                }) as TreeElement,
+            ];
+        }
         countExperienceUsageForSurvey(ExperienceKind.NoSQL, UsageImpact.Low);
         return this.getChildrenImpl(sortedContainers);
     }


### PR DESCRIPTION
Fixes #2823
This pull request improves the user experience in the CosmosDB resource tree by providing actionable prompts when no databases or containers are present. Now, instead of showing an empty list, users will see a "Create Database…" or "Create Container…" option, making it easier to get started.

**User experience improvements:**

* When there are no databases in a CosmosDB account, a "Create Database…" tree element is shown, allowing users to quickly initiate database creation.
* When there are no containers in a database, a "Create Container…" tree element is shown, enabling users to easily create a new container.

**Localization enhancements:**

* Added new localized strings for "Create Container…" to the `l10n/bundle.l10n.json` file to support internationalization.

**Dependency updates:**

* Imported `createGenericElement` from `@microsoft/vscode-azext-utils` in both `CosmosDBAccountAttachedResourceItem.ts` and `CosmosDBDatabaseResourceItem.ts` to support the new tree elements. [[1]](diffhunk://#diff-ebdfd45c24630c4fc29a68e1218482ad287fd28c8b7ac282a91435169bf1c91eR7) [[2]](diffhunk://#diff-ae0acaa6afbd3eb45296952bcb1dfadaf7768104f2bbb6bf003cf312a7733ca3L7-R9)
* Switched to using the `l10n` import from `vscode` in `CosmosDBDatabaseResourceItem.ts` for consistency in localization.