### PR TITLE
fix: an activation event wasn't labeled as such

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -308,6 +308,7 @@ export async function isVCoreAndRURolloutEnabled(): Promise<boolean | undefined>
         // Suppress error display and don't rethrow - this is feature detection that should fail gracefully
         context.errorHandling.suppressDisplay = true;
         context.errorHandling.rethrow = false;
+        context.telemetry.properties.isActivationEvent = 'true';
 
         const azureResourcesExtensionApi = await apiUtils.getAzureExtensionApi<
             AzureResourcesExtensionApi & { isDocumentDbExtensionSupportEnabled: () => boolean }


### PR DESCRIPTION
This pull request introduces a minor telemetry improvement to the extension activation logic. Specifically, it sets a telemetry property to indicate that the function is being called as part of an activation event.

* Telemetry Enhancement:
  * [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R311): Added `context.telemetry.properties.isActivationEvent = 'true';` to record activation event status in telemetry during feature detection.