### PR TITLE
fix: skip throughput step during container creation for serverless accounts

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -359,7 +359,7 @@
   "Index Spec": "Index Spec",
   "Indexes": "Indexes",
   "Info from the webview: ": "Info from the webview: ",
-  "Initial throughput capacity, between {0} and {1} inclusive in increments of {2}. Enter 0 if the account doesn't support throughput.": "Initial throughput capacity, between {0} and {1} inclusive in increments of {2}. Enter 0 if the account doesn't support throughput.",
+  "Initial throughput capacity, between {0} and {1} inclusive in increments of {2}.": "Initial throughput capacity, between {0} and {1} inclusive in increments of {2}.",
   "Initializing…": "Initializing…",
   "Input must be a number": "Input must be a number",
   "Inserted {0} document(s). See output for more details.": "Inserted {0} document(s). See output for more details.",

--- a/src/commands/createContainer/CosmosDBThroughputStep.ts
+++ b/src/commands/createContainer/CosmosDBThroughputStep.ts
@@ -16,7 +16,7 @@ export class CosmosDBThroughputStep extends AzureWizardPromptStep<CreateContaine
 
     public async prompt(context: CreateContainerWizardContext): Promise<void> {
         const prompt = l10n.t(
-            "Initial throughput capacity, between {0} and {1} inclusive in increments of {2}. Enter 0 if the account doesn't support throughput.",
+            'Initial throughput capacity, between {0} and {1} inclusive in increments of {2}.',
             minThroughput,
             maxThroughput,
             throughputStepSize,
@@ -39,10 +39,6 @@ export class CosmosDBThroughputStep extends AzureWizardPromptStep<CreateContaine
 
     public validateInput(throughput: string | undefined): string | undefined {
         throughput = throughput ? throughput.trim() : '';
-
-        if (throughput === '0') {
-            return undefined;
-        }
 
         try {
             const value = Number(throughput);


### PR DESCRIPTION
This pull request updates the Cosmos DB container creation flow to better handle serverless accounts and simplifies throughput input validation. The main improvements are focused on ensuring throughput is managed appropriately for serverless scenarios and cleaning up user prompts and validation logic.

**Serverless account handling:**

* Automatically sets the `throughput` to `0` in the wizard context when the Cosmos DB account is serverless, and skips the throughput prompt step in the wizard for such accounts (`src/commands/createContainer/createContainer.ts`). [[1]](diffhunk://#diff-3b53877c6c39e5437d6a0c21fdf0951d3a87cd0834b1f6788b2a64e72f4c656bR57-R68) [[2]](diffhunk://#diff-3b53877c6c39e5437d6a0c21fdf0951d3a87cd0834b1f6788b2a64e72f4c656bL73-R78)

**Prompt and validation cleanup:**

* Removes the instruction to enter `0` for throughput in the prompt message, since this is now handled automatically for serverless accounts (`src/commands/createContainer/CosmosDBThroughputStep.ts`).
* Removes the special case allowing `0` as valid throughput input in the validation logic, as this is no longer needed (`src/commands/createContainer/CosmosDBThroughputStep.ts`).

Fixes #1931