### PR TITLE
fix: handle serverless account detection by falling back to 'kind'

### DIFF
--- a/src/AzureDBExperiences.ts
+++ b/src/AzureDBExperiences.ts
@@ -72,6 +72,16 @@ export function tryGetExperience(resource: CosmosDBAccountModel | DatabaseAccoun
         }
     }
 
+    // Fallback to using 'kind' if capabilities/tags are not present
+    // Usually all newly created accounts used to have tags or capabilities,
+    // now newly created Serverless accounts lack the "Core (SQL)" tag as well as capabilities
+    // Let's just rely on 'kind' in that case and assume all non-SQL accounts still have capabilities/tags
+    if ('kind' in resource) {
+        if (resource.kind === DBAccountKind.GlobalDocumentDB) {
+            return CoreExperience;
+        }
+    }
+
     return undefined;
 }
 


### PR DESCRIPTION
With the [huge deprecation PR](https://github.com/microsoft/vscode-cosmosdb/pull/2866) something happened with API detection and Serverless NoSQL accounts:
<img width="330" height="92" alt="image" src="https://github.com/user-attachments/assets/6ac6d331-b4d0-41bd-94f5-94d6337de0ce" />


This PR fixes this by adding an additional fallback check, so that these accounts get properly classified again:
<img width="263" height="113" alt="image" src="https://github.com/user-attachments/assets/a8a399f5-a9b6-4560-831f-73220fc811c1" />
