### PR TITLE
Propagate errors from DocumentSession to the caller

### DIFF
--- a/src/cosmosdb/session/DocumentSession.ts
+++ b/src/cosmosdb/session/DocumentSession.ts
@@ -136,6 +136,7 @@ export class DocumentSession {
 
     public async read(documentId: CosmosDBRecordIdentifier): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.document.session.read', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -269,6 +270,7 @@ export class DocumentSession {
         documentId: CosmosDBRecordIdentifier,
     ): Promise<CosmosDBRecordIdentifier | undefined> {
         return callWithTelemetryAndErrorHandling('cosmosDB.nosql.document.session.update', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -384,6 +386,7 @@ export class DocumentSession {
 
     public async delete(documentId: CosmosDBRecordIdentifier): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.document.session.delete', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -450,6 +453,7 @@ export class DocumentSession {
 
     public async bulkDelete(documentIds: CosmosDBRecordIdentifier[]): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.document.session.bulkDelete', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -562,6 +566,7 @@ export class DocumentSession {
         await callWithTelemetryAndErrorHandling(
             'cosmosDB.nosql.document.session.setNewDocumentTemplate',
             async (context) => {
+                context.errorHandling.rethrow = true;
                 this.setTelemetryProperties(context);
 
                 if (this.isDisposed) {
@@ -658,7 +663,8 @@ export class DocumentSession {
             return this.partitionKey;
         }
 
-        return callWithTelemetryAndErrorHandling('cosmosDB.nosql.document.session.getPartitionKey', async () => {
+        return callWithTelemetryAndErrorHandling('cosmosDB.nosql.document.session.getPartitionKey', async (context) => {
+            context.errorHandling.rethrow = true;
             const container = await withClaimsChallengeHandling(this.connection, async (client) =>
                 client.database(this.databaseId).container(this.containerId).read(),
             );

--- a/src/cosmosdb/session/QuerySession.ts
+++ b/src/cosmosdb/session/QuerySession.ts
@@ -64,6 +64,7 @@ export class QuerySession {
 
     public async run(): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.queryEditor.session.run', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -115,6 +116,7 @@ export class QuerySession {
 
     public async fetchAll(): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.queryEditor.session.fetchAll', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -135,6 +137,7 @@ export class QuerySession {
 
     public async nextPage(): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.queryEditor.session.nextPage', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -166,6 +169,7 @@ export class QuerySession {
 
     public async prevPage(): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.queryEditor.session.prevPage', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -192,6 +196,7 @@ export class QuerySession {
 
     public async firstPage(): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.queryEditor.session.firstPage', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {
@@ -210,6 +215,7 @@ export class QuerySession {
 
     public async stop(): Promise<void> {
         await callWithTelemetryAndErrorHandling('cosmosDB.nosql.queryEditor.session.stop', async (context) => {
+            context.errorHandling.rethrow = true;
             this.setTelemetryProperties(context);
 
             if (this.isDisposed) {


### PR DESCRIPTION
Fixes #2803

This pull request improves error handling consistency in both the `DocumentSession` and `QuerySession` classes by ensuring that errors are rethrown during telemetry-wrapped operations. This change allows errors to propagate correctly, making debugging and error tracking more reliable throughout the CosmosDB extension.

**Error handling improvements:**

* Added `context.errorHandling.rethrow = true;` to all telemetry-wrapped methods in `DocumentSession` (including `read`, `update`, `delete`, `bulkDelete`, `setNewDocumentTemplate`, and `getPartitionKey`) to ensure errors are not silently swallowed and are properly propagated. [[1]](diffhunk://#diff-2fb79783974e66910933012f3b9cd17657ee6aec135e555c54112adb7fa56f07R139) [[2]](diffhunk://#diff-2fb79783974e66910933012f3b9cd17657ee6aec135e555c54112adb7fa56f07R273) [[3]](diffhunk://#diff-2fb79783974e66910933012f3b9cd17657ee6aec135e555c54112adb7fa56f07R389) [[4]](diffhunk://#diff-2fb79783974e66910933012f3b9cd17657ee6aec135e555c54112adb7fa56f07R456) [[5]](diffhunk://#diff-2fb79783974e66910933012f3b9cd17657ee6aec135e555c54112adb7fa56f07R569) [[6]](diffhunk://#diff-2fb79783974e66910933012f3b9cd17657ee6aec135e555c54112adb7fa56f07L661-R667)
* Applied the same error rethrowing pattern to all relevant methods in `QuerySession` (`run`, `fetchAll`, `nextPage`, `prevPage`, `firstPage`, and `stop`) for consistent error handling across session types. [[1]](diffhunk://#diff-0d6d161a0e2431fe42ae515b557752e856f6d278105ec17c614fbf5f2c9ce51dR67) [[2]](diffhunk://#diff-0d6d161a0e2431fe42ae515b557752e856f6d278105ec17c614fbf5f2c9ce51dR119) [[3]](diffhunk://#diff-0d6d161a0e2431fe42ae515b557752e856f6d278105ec17c614fbf5f2c9ce51dR140) [[4]](diffhunk://#diff-0d6d161a0e2431fe42ae515b557752e856f6d278105ec17c614fbf5f2c9ce51dR172) [[5]](diffhunk://#diff-0d6d161a0e2431fe42ae515b557752e856f6d278105ec17c614fbf5f2c9ce51dR199) [[6]](diffhunk://#diff-0d6d161a0e2431fe42ae515b557752e856f6d278105ec17c614fbf5f2c9ce51dR218)