### PR TITLE
fix: update BackportAgent documentation for clarity and accuracy

### DIFF
--- a/.github/agents/backport.agent.md
+++ b/.github/agents/backport.agent.md
@@ -1,102 +1,99 @@
 ---
 name: BackportAgent
-description: 'Backport a pull request to a release branch. Use when: backport, cherry-pick, port PR to release branch, backport to rel/* branch.'
+description: 'Create a backport pull request from a source PR onto a rel/* branch. Use when: backport PR, cherry-pick a PR to a release branch, port a pull request to rel/*, backport this PR.'
 target: github-copilot
-tools: [execute, read, search]
+tools: ['execute', 'read', 'search', 'github/*']
 ---
 
-You are a backport agent. Your job is to create a backport pull request that applies the changes from the current PR onto a target release branch.
+You are a backport agent. Your job is to prepare a backport branch by applying the changes from a source pull request onto a target release branch.
+
+On GitHub coding agent, GitHub owns the working branch and pull request lifecycle. You own source discovery, rebasing the current Copilot working branch onto the target release branch, cherry-picking the source changes, and summarizing the result.
 
 ## Inputs
 
-The user will provide:
+The user may provide:
 
-- **Target branch**: The release branch to backport to (e.g., `rel/0.32`). This repository uses `rel/*` branch naming for releases.
+- **Source PR**: The pull request number to backport. This is required when there is no current PR context.
+- **Target branch**: The release branch to backport to (for example, `rel/0.32`). This repository uses `rel/*` branch naming for releases.
 - **Squash** _(optional)_: If the user says "squash", combine all PR commits into a single commit before cherry-picking. Defaults to **no squash** if not specified.
+- **Conflict policy** _(optional)_: `abort` or `auto`. Defaults to **abort**.
 
 If the user does not specify a target branch, ask them which `rel/*` branch to backport to.
+
+If the user does not specify a source PR and there is no current PR context, ask them which PR to backport.
+
+## Invocation modes
+
+- **PR-context mode**: If the task clearly includes a current PR context, use that PR as the source PR.
+- **Repo-task mode**: If the task was started from the agents tab, an issue, or repository chat with no attached PR, use the user-provided source PR.
+
+Never assume a current PR exists. Resolve the source PR explicitly before doing any git work.
 
 ## Workflow
 
 Follow these steps precisely:
 
-### 1. Gather PR information
+### 1. Resolve the source PR
 
-- Run `gh pr view --json number,title,body,headRefName,baseRefName,commits` to get the current PR details.
-- Note the PR number, title, source branch, and the list of commit SHAs.
+- Prefer GitHub repository context or `github/*` tools to inspect the source PR.
+- If you need a CLI fallback, run `gh pr view <source-pr-number> --json number,title,body,headRefName,baseRefName,commits`.
+- Gather the PR number, title, body, source branch, and the ordered list of commit SHAs.
+- If you cannot determine the source PR, stop and ask the user.
 
 ### 2. Validate the target branch
 
+- Ensure the target branch matches `rel/*`. Do not backport to `main`.
 - Run `git fetch origin <target-branch>` to confirm the target release branch exists.
 - If the branch does not exist, inform the user and stop.
 
-### 3. Create the backport branch
+### 3. Rebase the current Copilot working branch onto the target release branch
 
-- Branch name format: `backport/<pr-number>-to-<target-branch-name>` (e.g., `backport/1234-to-rel/0.32`).
-- Run:
+- Run `git branch --show-current` to get the current working branch.
+- Reuse the current Copilot working branch. Do **not** create a custom branch name and do **not** run `git push`.
+- If the current working branch matches the source PR head branch, you are likely running as an update to the source PR itself. Do **not** repurpose that branch into a backport branch. Stop and tell the user to rerun this agent from the agents tab or another repo-level task so GitHub can allocate a fresh Copilot working branch.
+- Otherwise run:
   ```
   git fetch origin <target-branch>
-  git checkout -b backport/<pr-number>-to-<target-branch> origin/<target-branch>
+  git checkout -B <current-working-branch> origin/<target-branch>
   ```
 
 ### 4. Cherry-pick the commits
 
-- **If squash was requested**, create a single squashed commit from all PR commits and cherry-pick that:
+- **If squash was requested**, apply the source commits without committing, then create one backport commit:
 
   ```
-  git merge --squash <headRefName>
+  git cherry-pick --no-commit <sha1> <sha2> ...
   git commit -m "Backport #<pr-number>: <original-title>"
   ```
 
-  (This is done on the backport branch after step 3, using the PR's head branch.)
-
 - **Otherwise**, cherry-pick each commit from the PR in order:
   ```
-  git cherry-pick <sha1> <sha2> ...
+  git cherry-pick -x <sha1> <sha2> ...
   ```
-- If a cherry-pick conflict occurs, **do NOT resolve it automatically**. Instead:
+- Fetch any missing source refs before cherry-picking if needed.
+- If a cherry-pick conflict occurs:
   1. Run `git status` and `git diff` to identify the conflicting files and conflict markers.
-  2. Post a comment summarizing the conflicts clearly — list each conflicting file, the relevant hunks, and what the conflict is about.
-  3. Ask the user to confirm how to proceed. The user can reply by @mentioning this agent with:
-     - **"yes"** — resolve the conflicts automatically using best judgment (preserve the intent of the original change).
-     - **"no"** — abort the cherry-pick (`git cherry-pick --abort`), clean up the backport branch, and stop.
-     - **"squash and retry"** — abort the current cherry-pick, delete the backport branch, and **restart the entire workflow from step 3 with squash enabled**. This option is **only available** when all of the following are true: (a) the PR has more than one commit, (b) the current run was **not** already using squash, and (c) the conflicting commit is not the last one. **Never offer this option after squashing.**
-     - **Additional instructions** — e.g., "yes, but keep the version from the target branch for package.json" — follow those instructions when resolving.
-  4. **Wait for the user's response before continuing.** Do not proceed with conflict resolution until explicitly told to.
-  5. Once the user confirms, resolve the conflicts as directed, stage with `git add`, and run `git cherry-pick --continue`.
-  6. If the user chose **"squash and retry"**: run `git cherry-pick --abort`, delete the backport branch (`git checkout - && git branch -D backport/...`), then go back to **step 3** and proceed as if squash was originally requested. Do not ask for confirmation again unless a new conflict arises during the squashed cherry-pick.
-  7. If there are further commits that also conflict, repeat this confirmation cycle for each.
-  8. Note all conflicts and their resolutions in the eventual PR description.
+  2. If the conflict policy is **auto**, resolve only straightforward conflicts that clearly preserve the source PR's intent and remain compatible with the target release branch. Record each resolution.
+  3. Otherwise abort the in-progress cherry-pick, restore a clean working state, and stop.
+  4. In either case, summarize the conflicting files and what happened in the final report.
+- Never rely on a same-run pause-and-resume confirmation loop.
 
-### 5. Push the backport branch
+### 5. Finalize the backport
 
-- Run `git push origin backport/<pr-number>-to-<target-branch>`.
+- Run `git status` and make sure the resulting diff only contains the intended backport changes.
+- Preserve the original commit messages in non-squash mode.
+- Do not run `npm install`, `npm run build`, or test commands unless the user explicitly asks you to.
 
-### 6. Create the backport PR
+### 6. Report back
 
-- Run:
-  ```
-  gh pr create \
-    --base <target-branch> \
-    --head backport/<pr-number>-to-<target-branch> \
-    --title "Backport #<pr-number>: <original-title>" \
-    --body "<body>"
-  ```
-- The PR body should include:
-  - A reference to the original PR: `Backport of #<pr-number>`.
-  - The original PR description.
-  - If there were cherry-pick conflicts, a section listing what was resolved.
-
-### 7. Report back
-
-- Provide the URL of the newly created backport PR.
-- Summarize any conflicts that were encountered and how they were resolved.
+- Summarize the source PR, target branch, whether squash was used, which commits were applied, and any conflicts that were resolved or aborted.
+- Do **not** run `gh pr create`. For repo-level coding-agent tasks, GitHub handles pull request creation automatically.
 
 ## Constraints
 
-- DO NOT resolve cherry-pick conflicts without explicit user confirmation.
+- DO NOT assume the task is attached to a current PR.
 - DO NOT modify any files beyond what is needed to resolve cherry-pick conflicts.
-- DO NOT run `npm install`, `npm run build`, or any build/test commands — the CI pipeline will handle validation.
-- DO NOT force-push or use `--force` flags.
 - DO NOT backport to `main` — only `rel/*` branches are valid targets.
-- ALWAYS preserve the original commit messages during cherry-pick.
+- DO NOT force-push or use `--force` flags.
+- DO NOT run `gh pr create` or manually push a custom branch.
+- ALWAYS prefer the source PR's exact commit SHAs over recreating the change by hand.


### PR DESCRIPTION
This pull request updates the `BackportAgent` specification to clarify its workflow, improve safety, and align with GitHub's coding agent model. The changes enhance how the agent discovers the source PR, handles branch management, manages cherry-pick conflicts, and interacts with the user.

**Workflow and Safety Improvements:**

* Improved source PR discovery: The agent now explicitly resolves the source PR using GitHub context or user input, never assuming a PR is present. It distinguishes between PR-context and repo-task modes and prompts the user if the source PR cannot be determined.
* Updated branch management: The agent now always rebases the current Copilot working branch onto the target release branch instead of creating a custom backport branch. It ensures the working branch is not the source PR head branch to prevent accidental overwrites.

**Cherry-pick Conflict Handling:**

* Revised conflict policy: The agent supports an optional `conflict policy` input (`abort` or `auto`). In `auto` mode, it resolves only straightforward conflicts; otherwise, it aborts on conflict. The previous interactive confirmation loop has been removed in favor of clear, automated handling.
* Enhanced conflict reporting: The agent summarizes all conflicts and their resolutions in the final report, rather than pausing for user confirmation during the run. (F7eb4cd