### PR TITLE
feat(workflow): improve PR triggers and build summary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,15 +233,43 @@ jobs:
                           "## ❌ Build Status`nSome checks failed. Please review the logs."
                       }
 
+                      # Build commit + PR markdown links
+                      $serverUrl = "${{ github.server_url }}"
+                      $repo = "${{ github.repository }}"
+                      $sha = "${{ github.sha }}"
+                      $shortSha = $sha.Substring(0, 7)
+                      $commitLink = "[``$shortSha``]($serverUrl/$repo/commit/$sha)"
+
+                      $prNumber = "${{ github.event.pull_request.number }}"
+                      $prLine = if ($prNumber) {
+                          $prTitle = @'
+                  ${{ github.event.pull_request.title }}
+                  '@
+                          # Escape characters that would break markdown link text
+                          $prTitleEscaped = $prTitle -replace '\\', '\\' -replace '\]', '\]'
+                          "- **Pull Request:** [#$prNumber $prTitleEscaped]($serverUrl/$repo/pull/$prNumber)"
+                      } else {
+                          $null
+                      }
+
+                      $sourceInfo = @(
+                          "## 🔗 Source"
+                          "- **Commit:** $commitLink"
+                      )
+                      if ($prLine) { $sourceInfo += $prLine }
+                      $sourceSection = $sourceInfo -join "`n"
+
                       $summary = @"
                   # 🎉 Build Summary
+
+                  $sourceSection
 
                   ## 📦 Package Information
                   - **Version:** $env:PACKAGE_VERSION
                   - **Preview:** $env:PACKAGE_PREVIEW
                   - **VSIX File:** $env:VSIX_FILE
                   - **VSIX Size:** $env:VSIX_SIZE MB
-                  - **Artifact Name:** $env:ARTIFACT_NAME
+                  - **Artifact Name:** $env:ARTIFACT_NAME.zip
 
                   ## 🧪 Test Results
                   - **Unit Tests:** $unitTestIcon $unitTestResult

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,17 +249,33 @@ jobs:
                   ${{ github.event.pull_request.title }}
                   '@
                       if (-not $prNumber) {
-                          try {
-                              $prJson = gh api "repos/$repo/commits/$sha/pulls" --jq '[.[] | select(.state == "open")] | first | {number, title}' 2>$null
-                              if ($LASTEXITCODE -eq 0 -and $prJson) {
-                                  $pr = $prJson | ConvertFrom-Json
-                                  if ($pr -and $pr.number) {
-                                      $prNumber = "$($pr.number)"
-                                      $prTitle = $pr.title
+                          # /commits/{sha}/pulls is eventually consistent — the PR <-> commit
+                          # association can lag a few seconds after a push. Retry briefly.
+                          $headers = @{
+                              Authorization          = "Bearer $env:GH_TOKEN"
+                              Accept                 = 'application/vnd.github+json'
+                              'X-GitHub-Api-Version' = '2022-11-28'
+                              'User-Agent'           = 'vscode-cosmosdb-ci'
+                          }
+                          $apiUrl = "${serverUrl}/api/v3/repos/$repo/commits/$sha/pulls"
+                          if ($serverUrl -eq 'https://github.com') {
+                              $apiUrl = "https://api.github.com/repos/$repo/commits/$sha/pulls"
+                          }
+
+                          for ($attempt = 1; $attempt -le 3; $attempt++) {
+                              try {
+                                  $prs = Invoke-RestMethod -Uri $apiUrl -Headers $headers -Method Get
+                                  $openPr = @($prs | Where-Object { $_.state -eq 'open' })[0]
+                                  if ($openPr) {
+                                      $prNumber = "$($openPr.number)"
+                                      $prTitle = $openPr.title
+                                      break
                                   }
+                                  Write-Output "ℹ️ Attempt ${attempt}: no open PR found for $sha yet."
+                              } catch {
+                                  Write-Output "⚠️ Attempt ${attempt}: PR lookup failed: $_"
                               }
-                          } catch {
-                              Write-Output "⚠️ Could not look up PR for commit ${sha}: $_"
+                              if ($attempt -lt 3) { Start-Sleep -Seconds 3 }
                           }
                       }
 
@@ -303,6 +319,8 @@ jobs:
                       if ($unitTestResult -ne "success" -or $integrationTestResult -ne "success") {
                           exit 1
                       }
+                      exit 0
                   } else {
                       Write-Output "⚠️ Skipping job summary - VSIX verification did not complete"
+                      exit 0
                   }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,14 @@ on:
     # Trigger when manually run
     workflow_dispatch:
 
-    # Trigger on pushes to `main` or `rel/*`
+    # Trigger on pushes to `main`, `rel/*`, or `dev/**`
     push:
         branches:
             - main
             - rel/*
+            - dev/**
 
-    # Trigger on pull requests to `main` or `rel/*`
+    # Trigger on pull requests to `main`, `rel/*`, or `dev/**`
     pull_request:
         branches:
             - main
@@ -23,6 +24,26 @@ on:
 jobs:
     Build:
         runs-on: ubuntu-latest
+
+        # A push to a branch with an open PR fires both `push` and `pull_request`
+        # events. Rather than cancelling one of them (a cancelled run reports
+        # as a failed required check on the PR's head SHA and blocks merge),
+        # we skip the `pull_request` run entirely for same-repo PRs — the
+        # `push` event already builds the head SHA and satisfies the required
+        # `Build` check. For PRs from forks, `push` does not fire in this repo,
+        # so we still let `pull_request` run.
+        if: >-
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.repository
+
+        # Concurrency only dedupes runs for the SAME branch across DIFFERENT
+        # commits (e.g. rapid pushes during a rebase). The cancelled older run
+        # is on a stale SHA that is no longer the PR head, so it does not
+        # block the PR. Push and pull_request events for the same SHA are
+        # already deduped by the `if` above, so they never collide here.
+        concurrency:
+            group: build-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+            cancel-in-progress: true
 
         defaults:
             run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,6 +183,7 @@ jobs:
                   "artifact_name=$artifactName" >> $env:GITHUB_OUTPUT
 
             - name: 📤 Upload VSIX
+              id: upload-vsix
               uses: actions/upload-artifact@v7
               with:
                   name: ${{ steps.verify-vsix.outputs.artifact_name }}
@@ -217,6 +218,7 @@ jobs:
                   VSIX_FILE: ${{ steps.verify-vsix.outputs.vsix_file }}
                   VSIX_SIZE: ${{ steps.verify-vsix.outputs.vsix_size }}
                   ARTIFACT_NAME: ${{ steps.verify-vsix.outputs.artifact_name }}
+                  ARTIFACT_URL: ${{ steps.upload-vsix.outputs.artifact-url }}
                   GH_TOKEN: ${{ github.token }}
               shell: pwsh
               run: |
@@ -304,7 +306,7 @@ jobs:
                   - **Preview:** $env:PACKAGE_PREVIEW
                   - **VSIX File:** $env:VSIX_FILE
                   - **VSIX Size:** $env:VSIX_SIZE MB
-                  - **Artifact Name:** $env:ARTIFACT_NAME.zip
+                  - **Artifact:** [$env:ARTIFACT_NAME.zip]($env:ARTIFACT_URL)
 
                   ## 🧪 Test Results
                   - **Unit Tests:** $unitTestIcon $unitTestResult

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Node PR Lint, Build and Test
 
 permissions:
     contents: read
+    pull-requests: read
 
 on:
     # Trigger when manually run
@@ -216,6 +217,7 @@ jobs:
                   VSIX_FILE: ${{ steps.verify-vsix.outputs.vsix_file }}
                   VSIX_SIZE: ${{ steps.verify-vsix.outputs.vsix_size }}
                   ARTIFACT_NAME: ${{ steps.verify-vsix.outputs.artifact_name }}
+                  GH_TOKEN: ${{ github.token }}
               shell: pwsh
               run: |
                   # Only generate summary if VSIX verification completed
@@ -240,11 +242,28 @@ jobs:
                       $shortSha = $sha.Substring(0, 7)
                       $commitLink = "[``$shortSha``]($serverUrl/$repo/commit/$sha)"
 
+                      # Resolve PR info: prefer the pull_request event payload, otherwise
+                      # ask the API which PR(s) contain this commit (works for push runs).
                       $prNumber = "${{ github.event.pull_request.number }}"
-                      $prLine = if ($prNumber) {
-                          $prTitle = @'
+                      $prTitle = @'
                   ${{ github.event.pull_request.title }}
                   '@
+                      if (-not $prNumber) {
+                          try {
+                              $prJson = gh api "repos/$repo/commits/$sha/pulls" --jq '[.[] | select(.state == "open")] | first | {number, title}' 2>$null
+                              if ($LASTEXITCODE -eq 0 -and $prJson) {
+                                  $pr = $prJson | ConvertFrom-Json
+                                  if ($pr -and $pr.number) {
+                                      $prNumber = "$($pr.number)"
+                                      $prTitle = $pr.title
+                                  }
+                              }
+                          } catch {
+                              Write-Output "⚠️ Could not look up PR for commit ${sha}: $_"
+                          }
+                      }
+
+                      $prLine = if ($prNumber) {
                           # Escape characters that would break markdown link text
                           $prTitleEscaped = $prTitle -replace '\\', '\\' -replace '\]', '\]'
                           "- **Pull Request:** [#$prNumber $prTitleEscaped]($serverUrl/$repo/pull/$prNumber)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,7 @@ jobs:
               run: npm run package
 
             - name: 🔍 Verify VSIX File
+              id: verify-vsix
               shell: pwsh
               run: |
                   # Find VSIX file
@@ -155,20 +156,38 @@ jobs:
 
                   Write-Output "✅ VSIX filename is correct: $vsixFileName"
 
-                  # Set output for job summary
-                  echo "VSIX_FILE=$vsixFileName" >> $env:GITHUB_ENV
-                  echo "VSIX_SIZE=$vsixFileSize" >> $env:GITHUB_ENV
-                  echo "PACKAGE_VERSION=$($packageJson.version)" >> $env:GITHUB_ENV
-                  echo "PACKAGE_PREVIEW=$($packageJson.preview)" >> $env:GITHUB_ENV
+                  # Compute a short commit SHA (7 chars) and a filesystem-safe branch slug.
+                  # Use head_ref for pull_request events, otherwise ref_name.
+                  $rawRef = if ("${{ github.event_name }}" -eq "pull_request") { "${{ github.head_ref }}" } else { "${{ github.ref_name }}" }
+                  $branchSlug = ($rawRef -replace '[^A-Za-z0-9._-]', '-').Trim('-')
+                  $shortSha = "${{ github.sha }}".Substring(0, 7)
 
-            - name: 📤 Upload Artifacts
+                  # Artifact name convention:
+                  # - main / rel/* : <name>-<version>-<sha7>
+                  # - everything else: <branch-slug>-<version>-<sha7>
+                  $isRelease = ($rawRef -eq 'main') -or ($rawRef -like 'rel/*')
+                  if ($isRelease) {
+                      $artifactName = "$($packageJson.name)-$($packageJson.version)-$shortSha"
+                  } else {
+                      $artifactName = "$branchSlug-$($packageJson.version)-$shortSha"
+                  }
+
+                  Write-Output "📛 Artifact name: $artifactName"
+
+                  # Expose values as step outputs for downstream steps
+                  "vsix_file=$vsixFileName" >> $env:GITHUB_OUTPUT
+                  "vsix_size=$vsixFileSize" >> $env:GITHUB_OUTPUT
+                  "package_version=$($packageJson.version)" >> $env:GITHUB_OUTPUT
+                  "package_preview=$($packageJson.preview)" >> $env:GITHUB_OUTPUT
+                  "artifact_name=$artifactName" >> $env:GITHUB_OUTPUT
+
+            - name: 📤 Upload VSIX
               uses: actions/upload-artifact@v7
               with:
-                  name: Artifacts
-                  path: |
-                      **/*.vsix
-                      **/*.tgz
-                      !**/node_modules
+                  name: ${{ steps.verify-vsix.outputs.artifact_name }}
+                  path: ${{ steps.verify-vsix.outputs.vsix_file }}
+                  if-no-files-found: error
+                  compression-level: 0
 
             - name: 🧪 Unit Tests
               id: unit-tests
@@ -191,6 +210,12 @@ jobs:
 
             - name: 📊 Generate Job Summary
               if: always()
+              env:
+                  PACKAGE_VERSION: ${{ steps.verify-vsix.outputs.package_version }}
+                  PACKAGE_PREVIEW: ${{ steps.verify-vsix.outputs.package_preview }}
+                  VSIX_FILE: ${{ steps.verify-vsix.outputs.vsix_file }}
+                  VSIX_SIZE: ${{ steps.verify-vsix.outputs.vsix_size }}
+                  ARTIFACT_NAME: ${{ steps.verify-vsix.outputs.artifact_name }}
               shell: pwsh
               run: |
                   # Only generate summary if VSIX verification completed
@@ -216,6 +241,7 @@ jobs:
                   - **Preview:** $env:PACKAGE_PREVIEW
                   - **VSIX File:** $env:VSIX_FILE
                   - **VSIX Size:** $env:VSIX_SIZE MB
+                  - **Artifact Name:** $env:ARTIFACT_NAME
 
                   ## 🧪 Test Results
                   - **Unit Tests:** $unitTestIcon $unitTestResult


### PR DESCRIPTION
Make CI more resilient to merge conflicts and avoid duplicate Build runs on PRs.

## Reviewer notes — what changes for you

- **New trigger:** pushes to `dev/**` branches now build automatically (alongside `main` and `rel/*`). No PR required to get a green build on a feature branch.
- **`pull_request` Build shows as "Skipped" — that's expected.** To prevent duplicate builds for the same SHA, the `pull_request` run is skipped for same-repo PRs; the `push` run covers that commit and satisfies the required `Build` check. Fork PRs still build via `pull_request`.
- **Need to validate the PR's test-merge with `main`** (the SHA `pull_request` would have built)? Two options:
  - **Easiest:** merge or rebase the latest `main` into the PR branch and push. The resulting `push` build exercises your code against current `main`.
  - **Exact test-merge commit** (when `main` is far ahead and you don't want to rebase): push `refs/pull/<num>/merge` as a temporary `dev/**` branch:
    ```sh
    git fetch origin pull/<num>/merge
    git push origin FETCH_HEAD:dev/test-merge-<num>
    # …after CI finishes:
    git push origin --delete dev/test-merge-<num>
    ```
  
  Note: `Run workflow` from the Actions tab and re-running the skipped run **don't** help here — neither produces a build of the test-merge commit.
- **Concurrency:** older runs on the same branch are cancelled when a newer commit lands. Those cancelled runs are on stale SHAs and do not block the PR.

## Problem

1. **`pull_request` runs silently skip on merge conflicts.** The `pull_request` event runs against the test-merge ref (`refs/pull/N/merge`). When a PR has conflicts with `main`, GitHub cannot create that ref and no run is queued. This was observed on #2991, where pushes produced no Build runs until conflicts were resolved.
2. **Same-repo PRs trigger duplicate Build runs.** Every push to a branch with an open PR fires both `push` and `pull_request` events, queueing two parallel Build jobs that do identical work.

## Changes

### 1. Add `dev/**` to the `push` trigger

Pushes to `dev/**` now build the head ref directly, so Build always runs regardless of merge state with `main`.

### 2. Skip the `pull_request` Build for same-repo PRs

```yaml
if: >-
    github.event_name != 'pull_request' ||
    github.event.pull_request.head.repo.full_name != github.repository
```

Logic:

| Trigger | From fork? | Result |
|---|---|---|
| `push` / `workflow_dispatch` | n/a | Build runs |
| `pull_request`, same repo | no | Build **skipped** (push already covers it) |
| `pull_request`, fork | yes | Build runs (push doesn't fire for forks) |

A skipped job is treated by branch protection as a passing required check, so the PR sees one green `Build` from the `push` run and one skipped `Build` from the `pull_request` run — neither blocks merge.

Cancellation via `cancel-in-progress` was tried first but rejected: a cancelled run reports as a failed required check on the head SHA and blocks the PR.

### 3. Add `concurrency` to dedupe stale runs

```yaml
concurrency:
    group: build-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
    cancel-in-progress: true
```

This now only matters when several commits land on the same branch in quick succession (e.g. during a rebase). The cancelled older run is on a stale SHA that is no longer the PR head, so it does not block the PR. Push and pull_request events for the same SHA are already deduped by the `if:` above and never collide here.

The required status check name (`Build`) is unchanged.

### 4. Improve the Build job summary

While iterating on the workflow, the job summary was also tightened up:

- **Switched from `$GITHUB_ENV` to step outputs** for VSIX metadata (`vsix_file`, `vsix_size`, `package_version`, `package_preview`, `artifact_name`). This silences the "Context access might be invalid: ARTIFACT_NAME" lint warnings — step outputs are statically analyzable, env vars written at runtime are not.
- **Added a "🔗 Source" section** to the summary with:
  - A linked short commit SHA (e.g. [`abc1234`](…)).
  - A linked PR reference of the form `#NNNN <title>` when applicable.
- **Resolves the PR on `push` runs too.** Since same-repo PRs are now built via the `push` event (see change 2), `github.event.pull_request` is empty. The summary step falls back to `gh api repos/{owner}/{repo}/commits/{sha}/pulls` to find the open PR for the head SHA. Required `pull-requests: read` permission was added at the workflow level and `GH_TOKEN` is passed into the step.
- **Appended `.zip` to the displayed artifact name** to match what the user actually downloads from the run page.
