### PR TITLE
fix(pipeline): ensure manual trigger for release pipeline

### DIFF
--- a/.azure-pipelines/release-extension.yml
+++ b/.azure-pipelines/release-extension.yml
@@ -1,3 +1,5 @@
+trigger: none # Only run this pipeline when manually triggered
+
 parameters:
     # The intended extension version to publish.
     # This is used to verify the version in package.json matches the version to publish to avoid accidental publishing.


### PR DESCRIPTION
This pull request makes a minor update to the Azure Pipelines configuration, disabling automatic triggers so that the release pipeline only runs when manually triggered.

* [`.azure-pipelines/release-extension.yml`](diffhunk://#diff-2a4b742212cf81acf76299a63aa2e4a9d1f3a3cd3cb59422fd7c57bdfaa2aa07R1-R2): Set `trigger: none` to require manual pipeline runs.