### PR TITLE
Fix pipeline warnings and enhance GitHub API handling

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -1,3 +1,8 @@
+# Build number / pipeline run name. Set here (instead of via
+# ##vso[build.updatebuildnumber]) because OneBranch's restricted command policy
+# blocks that logging command in inline script tasks.
+name: $(Date:yyyyMMdd).$(Rev:r)
+
 # Trigger the build whenever `main` or `rel/*` is updated
 trigger:
     - main
@@ -90,10 +95,13 @@ extends:
                             ob_sdl_codeql_compiled_enabled: true
                     steps:
                         - task: PowerShell@2
-                          displayName: '🔢 Set Build Number'
+                          displayName: '🔢 Read package.json metadata'
                           name: setBuildNumberStep
                           inputs:
                               script: |
+                                  # Note: the pipeline run name (build number) is set via the top-level
+                                  # `name:` field in this YAML. ##vso[build.updatebuildnumber] is blocked
+                                  # by OneBranch's restricted command policy, so we don't override it here.
                                   try {
                                       $packageJson = Get-Content "$(Build.SourcesDirectory)/package.json" -Raw | ConvertFrom-Json
                                       $version = $packageJson.version
@@ -111,18 +119,15 @@ extends:
                                       }
 
                                       if ($version) {
-                                          $buildNumber = "vscode-cosmosdb-$version-$(Build.BuildNumber)"
-                                          Write-Host "##vso[build.updatebuildnumber]$buildNumber"
                                           Write-Host "##vso[task.setvariable variable=version;isOutput=true]$version"
                                           Write-Host "##vso[task.setvariable variable=preview;isOutput=true]$preview"
-                                          Write-Host "Build number set to: $buildNumber"
+                                          Write-Host "package.json version: $version (preview=$preview)"
+                                          Write-Host "Pipeline run name: $(Build.BuildNumber)"
                                       } else {
-                                          Write-Host "##vso[task.logissue type=warning]Version not found in package.json, keeping original build number"
-                                          Write-Host "Keeping original build number: $(Build.BuildNumber)"
+                                          Write-Host "##vso[task.logissue type=warning]Version not found in package.json"
                                       }
                                   } catch {
                                       Write-Host "##vso[task.logissue type=warning]Could not read package.json: $_"
-                                      Write-Host "Keeping original build number: $(Build.BuildNumber)"
                                   }
                               pwsh: true
                               targetType: 'inline'
@@ -137,11 +142,26 @@ extends:
                               outputfile: $(Build.SourcesDirectory)/NOTICE.html
                               outputformat: html
 
-                        - task: NodeTool@0
+                        - task: PowerShell@2
+                          displayName: '🔢 Read Node.js version from .nvmrc'
+                          inputs:
+                              script: |
+                                  $nvmrcPath = "$(Build.SourcesDirectory)/.nvmrc"
+                                  if (-not (Test-Path $nvmrcPath)) {
+                                      Write-Host "##vso[task.logissue type=error].nvmrc not found at $nvmrcPath"
+                                      Write-Host "##vso[task.complete result=Failed;]"
+                                      exit 1
+                                  }
+                                  $nodeVersion = (Get-Content $nvmrcPath -Raw).Trim().TrimStart('v')
+                                  Write-Output "##vso[task.setvariable variable=nodeVersion]$nodeVersion"
+                                  Write-Output "Node.js version from .nvmrc: $nodeVersion"
+                              pwsh: true
+                              targetType: 'inline'
+
+                        - task: UseNode@1
                           displayName: '📦 Using Node.js'
                           inputs:
-                              versionSource: fromFile
-                              versionFilePath: '$(Build.SourcesDirectory)/.nvmrc'
+                              version: '$(nodeVersion)'
 
                         - task: npmAuthenticate@0
                           displayName: '🔐 Authenticate to npm registry'

--- a/scripts/fetch-skill.mjs
+++ b/scripts/fetch-skill.mjs
@@ -19,6 +19,61 @@ const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 1000;
 
 /**
+ * Error subclass used to signal that a request was throttled by GitHub.
+ * The caller can decide whether to treat this as a soft failure (warning)
+ * instead of failing the build.
+ */
+class RateLimitError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'RateLimitError';
+    }
+}
+
+/**
+ * Detects whether a fetch Response indicates a GitHub rate-limit/abuse limit.
+ * GitHub returns 429 for secondary rate limits and 403 with
+ * `x-ratelimit-remaining: 0` for the primary REST API rate limit.
+ * @param {Response} response
+ * @returns {boolean}
+ */
+function isRateLimited(response) {
+    if (response.status === 429) {
+        return true;
+    }
+
+    if (response.status === 403) {
+        const remaining = response.headers.get('x-ratelimit-remaining');
+        if (remaining !== null && Number(remaining) === 0) {
+            return true;
+        }
+
+        if (response.headers.get('retry-after') !== null) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Computes the delay to wait before retrying a throttled request.
+ * @param {Response} response
+ * @param {number} attempt - Zero-based attempt index
+ * @returns {number} Delay in milliseconds
+ */
+function computeRetryDelay(response, attempt) {
+    const retryAfter = response.headers.get('retry-after');
+    if (retryAfter) {
+        const seconds = parseInt(retryAfter, 10);
+        if (!Number.isNaN(seconds)) {
+            return seconds * 1000;
+        }
+    }
+    return INITIAL_RETRY_DELAY_MS * 2 ** attempt;
+}
+
+/**
  * Reads and parses the package.json file
  * @returns {object} Parsed package.json content
  */
@@ -43,21 +98,35 @@ function readPackageJson() {
  */
 async function listGitHubTree(repo, commit, dirPath, exclude = []) {
     const url = `https://api.github.com/repos/${repo}/git/trees/${commit}?recursive=1`;
-    const response = await fetch(url, {
-        headers: { Accept: 'application/vnd.github.v3+json' },
-    });
 
-    if (!response.ok) {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        const response = await fetch(url, {
+            headers: { Accept: 'application/vnd.github.v3+json' },
+        });
+
+        if (response.ok) {
+            const data = await response.json();
+            const prefix = dirPath.endsWith('/') ? dirPath : `${dirPath}/`;
+
+            return data.tree
+                .filter((entry) => entry.type === 'blob' && entry.path.startsWith(prefix))
+                .map((entry) => entry.path)
+                .filter((p) => !exclude.some((pattern) => p.endsWith(`/${pattern}`)));
+        }
+
+        if (isRateLimited(response)) {
+            if (attempt < MAX_RETRIES) {
+                const delay = computeRetryDelay(response, attempt);
+                await new Promise((resolve) => setTimeout(resolve, delay));
+                continue;
+            }
+            throw new RateLimitError(
+                `HTTP ${response.status} ${response.statusText} — rate-limited while listing tree at ${url}`,
+            );
+        }
+
         throw new Error(`HTTP ${response.status} ${response.statusText} — failed to list tree at ${url}`);
     }
-
-    const data = await response.json();
-    const prefix = dirPath.endsWith('/') ? dirPath : `${dirPath}/`;
-
-    return data.tree
-        .filter((entry) => entry.type === 'blob' && entry.path.startsWith(prefix))
-        .map((entry) => entry.path)
-        .filter((p) => !exclude.some((pattern) => p.endsWith(`/${pattern}`)));
 }
 
 /**
@@ -77,11 +146,15 @@ async function fetchFileFromGitHub(repo, commit, filePath) {
             return await response.text();
         }
 
-        if (response.status === 429 && attempt < MAX_RETRIES) {
-            const retryAfter = response.headers.get('retry-after');
-            const delay = retryAfter ? parseInt(retryAfter, 10) * 1000 : INITIAL_RETRY_DELAY_MS * 2 ** attempt;
-            await new Promise((resolve) => setTimeout(resolve, delay));
-            continue;
+        if (isRateLimited(response)) {
+            if (attempt < MAX_RETRIES) {
+                const delay = computeRetryDelay(response, attempt);
+                await new Promise((resolve) => setTimeout(resolve, delay));
+                continue;
+            }
+            throw new RateLimitError(
+                `HTTP ${response.status} ${response.statusText} — rate-limited while fetching ${url}`,
+            );
         }
 
         throw new Error(`HTTP ${response.status} ${response.statusText} — failed to fetch ${url}`);
@@ -121,6 +194,19 @@ function cleanDirectory(dirPath) {
 }
 
 /**
+ * Emits a GitHub Actions warning annotation when running in CI, or a plain
+ * warning otherwise.
+ * @param {string} message
+ */
+function emitWarning(message) {
+    if (process.env.GITHUB_ACTIONS === 'true') {
+        console.log(`::warning::${message}`);
+    } else {
+        console.warn(`⚠ ${message}`);
+    }
+}
+
+/**
  * Main execution function
  */
 async function main() {
@@ -137,6 +223,7 @@ async function main() {
     }
 
     let hasErrors = false;
+    let rateLimited = false;
 
     for (const [skillName, config] of Object.entries(externalSkills)) {
         const { repo, path: skillPath, commit, exclude } = config;
@@ -152,31 +239,41 @@ async function main() {
             const files = await listGitHubTree(repo, commit, skillPath, exclude);
             console.log(`  Found ${files.length} files`);
 
-            // Clean the local directory to remove stale files
+            // Fetch all files into memory first, so that a partial failure
+            // (e.g. rate-limit halfway through) does not leave the local
+            // skills/ directory in a corrupted state.
             const destDir = path.join(rootDir, skillPath);
-            cleanDirectory(destDir);
-
-            // Fetch all files with concurrency limit
+            const downloaded = new Array(files.length);
             let fetched = 0;
-            const tasks = files.map((filePath) => async () => {
+            const tasks = files.map((filePath, i) => async () => {
                 const content = await fetchFileFromGitHub(repo, commit, filePath);
-                const destPath = path.join(rootDir, filePath);
-                const dir = path.dirname(destPath);
-
-                if (!fs.existsSync(dir)) {
-                    fs.mkdirSync(dir, { recursive: true });
-                }
-
-                fs.writeFileSync(destPath, content);
+                downloaded[i] = { filePath, content };
                 fetched++;
                 process.stdout.write(`\r  Fetching files... ${fetched}/${files.length}`);
             });
 
             await withConcurrency(tasks, MAX_CONCURRENT_FETCHES);
+
+            // All files fetched successfully — now replace the local copy.
+            cleanDirectory(destDir);
+            for (const { filePath, content } of downloaded) {
+                const destPath = path.join(rootDir, filePath);
+                const dir = path.dirname(destPath);
+                if (!fs.existsSync(dir)) {
+                    fs.mkdirSync(dir, { recursive: true });
+                }
+                fs.writeFileSync(destPath, content);
+            }
+
             console.log(`\n✓ ${skillName} updated successfully (${files.length} files)`);
         } catch (error) {
-            console.error(`\n✗ Failed to fetch ${skillName}: ${error.message}`);
-            hasErrors = true;
+            if (error instanceof RateLimitError) {
+                console.error(`\n⚠ Skipping ${skillName} due to GitHub rate limit: ${error.message}`);
+                rateLimited = true;
+            } else {
+                console.error(`\n✗ Failed to fetch ${skillName}: ${error.message}`);
+                hasErrors = true;
+            }
         }
     }
 
@@ -185,6 +282,16 @@ async function main() {
     if (hasErrors) {
         console.error('✗ Some skills failed to fetch. See errors above.');
         process.exit(1);
+    }
+
+    if (rateLimited) {
+        emitWarning(
+            'One or more external skills could not be fetched because GitHub rate-limited the request. ' +
+                'The locally committed skills/ directory was left untouched. ' +
+                'Re-run this job later (optionally authenticated) to refresh the skills.',
+        );
+        console.log('═══════════════════════════════════════════════════\n');
+        return;
     }
 
     console.log('✓ All skills fetched successfully.');


### PR DESCRIPTION
## Summary

Two CI improvements bundled together:

### 1. Fix Azure DevOps pipeline warnings (`.azure-pipelines/build.yml`)

- **`UseNode@0` deprecation.** Replaced the deprecated `NodeTool@0` task with `UseNode@1`. Because `UseNode@1` does not support `versionSource: fromFile`, a small preceding PowerShell step now reads `.nvmrc` and exposes the version as a pipeline variable, which is then passed to `UseNode@1`.
- **`##vso[build.updatebuildnumber]` blocked by OneBranch.** OneBranch's restricted-commands policy blocks setting the build number at runtime via `##vso[build.updatebuildnumber]`, which was producing pipeline warnings on every run. Moved build-number formatting to the top-level `name:` field (`$(Date:yyyyMMdd).$(Rev:r)`) and dropped the runtime override. The PowerShell step is now scoped to reading `package.json` metadata only, and was renamed accordingly.

### 2. Make `fetch-skill` resilient to GitHub rate limiting (`scripts/fetch-skill.mjs`)

The PR build for #3016 failed in the *Verify External Skills* step because GitHub rate-limited the unauthenticated REST calls used to list the skill tree. A transient rate limit should not fail the build.

- Added a `RateLimitError` class and an `isRateLimited(response)` helper that detects both HTTP 429 (secondary limit) and HTTP 403 with `x-ratelimit-remaining: 0` / `Retry-After` (primary REST limit — which is what actually hit the failing run).
- Extended `listGitHubTree` with the same retry/backoff loop that `fetchFileFromGitHub` already had — the previous code retried per-file downloads but had zero retries on the tree-listing call, which is where the failure occurred.
- Both functions now honor `Retry-After` headers, retry up to `MAX_RETRIES`, and only then throw `RateLimitError` so it is distinguishable from a real failure.
- Files are downloaded into memory first; the local `skills/` directory is only wiped and rewritten after a skill fetches completely. A rate-limit halfway through no longer leaves the working tree in a corrupted state.
- In `main()`, `RateLimitError` no longer sets `hasErrors`; instead it sets a `rateLimited` flag. At the end, if only rate-limit errors occurred, the script emits a `::warning::` GitHub Actions annotation (or a plain `⚠` warning locally) and exits `0`. Genuine non-rate-limit failures still exit `1`.

No changes are required in `.github/workflows/main.yml`: `npm run fetch-skill` now exits `0` on rate-limit, the subsequent `diff` against `skills-backup/` is clean (because the directory was not wiped), and the warning surfaces as a GitHub annotation instead of failing the build.

## Validation

- `npm run prettier-fix` — clean
- `npm run lint` — no new findings in changed files
- `node -c scripts/fetch-skill.mjs` — syntax OK
