### PR TITLE
fix(rbac): route Cosmos DB control-plane ops through ARM for native-RBAC accounts (backport of #3016 to rel/0.32)

### DIFF
--- a/src/commands/createContainer/CosmosDBExecuteStep.ts
+++ b/src/commands/createContainer/CosmosDBExecuteStep.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PartitionKeyDefinitionVersion, PartitionKeyKind, type RequestOptions } from '@azure/cosmos';
+import { PartitionKeyDefinitionVersion, type RequestOptions } from '@azure/cosmos';
 import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
-import { armCreateContainer, getArmAccountContext } from '../../cosmosdb/armControlPlane';
+import { armCreateContainer, getArmAccountContext, getPartitionKeyKind } from '../../cosmosdb/armControlPlane';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
 import { type CreateContainerWizardContext } from './CreateContainerWizardContext';
@@ -31,17 +31,9 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateContainerW
                 await new Promise((resolve) => setTimeout(resolve, 250));
 
                 const partitionKeyPaths = partitionKey?.paths ?? [];
-                // Compare to MultiHash explicitly; the previous expression
-                // `(partitionKey?.kind ?? paths.length > 1) ? MultiHash : Hash`
-                // short-circuits on the truthy "Hash" string and would
-                // incorrectly produce MultiHash whenever kind was Hash.
                 const partitionKeyDefinition = {
                     paths: partitionKeyPaths,
-                    kind:
-                        partitionKey?.kind === PartitionKeyKind.MultiHash ||
-                        (partitionKey?.kind === undefined && partitionKeyPaths.length > 1)
-                            ? PartitionKeyKind.MultiHash
-                            : PartitionKeyKind.Hash,
+                    kind: getPartitionKeyKind(partitionKey?.kind, partitionKeyPaths.length),
                     version: PartitionKeyDefinitionVersion.V2,
                 };
 

--- a/src/commands/createContainer/CosmosDBExecuteStep.ts
+++ b/src/commands/createContainer/CosmosDBExecuteStep.ts
@@ -6,6 +6,7 @@
 import { PartitionKeyDefinitionVersion, PartitionKeyKind, type RequestOptions } from '@azure/cosmos';
 import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
+import { armCreateContainer, getArmAccountContext } from '../../cosmosdb/armControlPlane';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
 import { type CreateContainerWizardContext } from './CreateContainerWizardContext';
@@ -17,6 +18,7 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateContainerW
         const options: RequestOptions = {};
         const { endpoint, credentials, isEmulator } = context.accountInfo;
         const { containerName, partitionKey, throughput, databaseId, nodeId } = context;
+        const armCtx = getArmAccountContext(context.accountInfo);
 
         if (throughput !== 0) {
             options.offerThroughput = throughput;
@@ -28,12 +30,18 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateContainerW
             async () => {
                 await new Promise((resolve) => setTimeout(resolve, 250));
 
+                const partitionKeyPaths = partitionKey?.paths ?? [];
+                // Compare to MultiHash explicitly; the previous expression
+                // `(partitionKey?.kind ?? paths.length > 1) ? MultiHash : Hash`
+                // short-circuits on the truthy "Hash" string and would
+                // incorrectly produce MultiHash whenever kind was Hash.
                 const partitionKeyDefinition = {
-                    paths: partitionKey?.paths ?? [],
+                    paths: partitionKeyPaths,
                     kind:
-                        (partitionKey?.kind ?? (partitionKey?.paths?.length ?? 0) > 1)
-                            ? PartitionKeyKind.MultiHash // Multi-hash partition key if there are sub-partitions
-                            : PartitionKeyKind.Hash, // Hash partition key if there is only one partition
+                        partitionKey?.kind === PartitionKeyKind.MultiHash ||
+                        (partitionKey?.kind === undefined && partitionKeyPaths.length > 1)
+                            ? PartitionKeyKind.MultiHash
+                            : PartitionKeyKind.Hash,
                     version: PartitionKeyDefinitionVersion.V2,
                 };
 
@@ -42,9 +50,13 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateContainerW
                     partitionKey: partitionKeyDefinition,
                 };
 
-                await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
-                    await cosmosClient.database(databaseId).containers.create(containerDefinition, options);
-                });
+                if (armCtx) {
+                    await armCreateContainer(armCtx, databaseId, containerDefinition, throughput);
+                } else {
+                    await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
+                        await cosmosClient.database(databaseId).containers.create(containerDefinition, options);
+                    });
+                }
             },
         );
     }

--- a/src/commands/createDatabase/CosmosDBExecuteStep.ts
+++ b/src/commands/createDatabase/CosmosDBExecuteStep.ts
@@ -5,6 +5,7 @@
 
 import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
+import { armCreateDatabase, getArmAccountContext } from '../../cosmosdb/armControlPlane';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
 import { type CreateDatabaseWizardContext } from './CreateDatabaseWizardContext';
@@ -15,6 +16,7 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateDatabaseWi
     public async execute(context: CreateDatabaseWizardContext): Promise<void> {
         const { endpoint, credentials, isEmulator } = context.accountInfo;
         const { databaseName, nodeId } = context;
+        const armCtx = getArmAccountContext(context.accountInfo);
 
         return ext.state.showCreatingChild(
             nodeId,
@@ -22,9 +24,13 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateDatabaseWi
             async () => {
                 await new Promise((resolve) => setTimeout(resolve, 250));
 
-                await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
-                    await cosmosClient.databases.create({ id: databaseName });
-                });
+                if (armCtx) {
+                    await armCreateDatabase(armCtx, databaseName!);
+                } else {
+                    await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
+                        await cosmosClient.databases.create({ id: databaseName });
+                    });
+                }
             },
         );
     }

--- a/src/commands/deleteContainer/deleteContainer.ts
+++ b/src/commands/deleteContainer/deleteContainer.ts
@@ -7,6 +7,7 @@ import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
 import * as l10n from '@vscode/l10n';
 import { API } from '../../AzureDBExperiences';
+import { armDeleteContainer, getArmAccountContext } from '../../cosmosdb/armControlPlane';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
 import { type CosmosDBContainerResourceItem } from '../../tree/cosmosdb/CosmosDBContainerResourceItem';
@@ -71,13 +72,19 @@ export async function cosmosDBDeleteContainer(
 async function deleteContainer(node: CosmosDBContainerResourceItem): Promise<boolean> {
     let success = false;
     await ext.state.showDeleting(node.id, async () => {
-        await withClaimsChallengeHandling(node.model.accountInfo, async (cosmosClient) => {
-            const response = await cosmosClient
-                .database(node.model.database.id)
-                .container(node.model.container.id)
-                .delete();
-            success = response.statusCode === 204;
-        });
+        const armCtx = getArmAccountContext(node.model.accountInfo);
+        if (armCtx) {
+            await armDeleteContainer(armCtx, node.model.database.id, node.model.container.id);
+            success = true;
+        } else {
+            await withClaimsChallengeHandling(node.model.accountInfo, async (cosmosClient) => {
+                const response = await cosmosClient
+                    .database(node.model.database.id)
+                    .container(node.model.container.id)
+                    .delete();
+                success = response.statusCode === 204;
+            });
+        }
     });
 
     return success;

--- a/src/commands/deleteDatabase/deleteDatabase.ts
+++ b/src/commands/deleteDatabase/deleteDatabase.ts
@@ -6,6 +6,7 @@
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
 import * as l10n from '@vscode/l10n';
+import { armDeleteDatabase, getArmAccountContext } from '../../cosmosdb/armControlPlane';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
 import { type CosmosDBDatabaseResourceItem } from '../../tree/cosmosdb/CosmosDBDatabaseResourceItem';
@@ -62,10 +63,16 @@ export async function cosmosDBDeleteDatabase(
 async function deleteDatabase(node: CosmosDBDatabaseResourceItem): Promise<boolean> {
     let success = false;
     await ext.state.showDeleting(node.id, async () => {
-        await withClaimsChallengeHandling(node.model.accountInfo, async (cosmosClient) => {
-            const response = await cosmosClient.database(node.model.database.id).delete();
-            success = response.statusCode === 204;
-        });
+        const armCtx = getArmAccountContext(node.model.accountInfo);
+        if (armCtx) {
+            await armDeleteDatabase(armCtx, node.model.database.id);
+            success = true;
+        } else {
+            await withClaimsChallengeHandling(node.model.accountInfo, async (cosmosClient) => {
+                const response = await cosmosClient.database(node.model.database.id).delete();
+                success = response.statusCode === 204;
+            });
+        }
     });
 
     return success;

--- a/src/commands/viewOffer/viewOffer.ts
+++ b/src/commands/viewOffer/viewOffer.ts
@@ -36,7 +36,13 @@ export async function cosmosDBViewDatabaseOffer(context: IActionContext, node?: 
 
     if (armCtx) {
         const offer = await armReadDatabaseThroughput(armCtx, databaseId);
-        await vscodeUtil.showNewFile(JSON.stringify(offer?.resource, undefined, 2), `offer of ${databaseId}`, '.json');
+        // Coalesce to null so JSON.stringify always returns a string; an offer
+        // can legitimately be absent (e.g., serverless accounts).
+        await vscodeUtil.showNewFile(
+            JSON.stringify(offer?.resource ?? null, undefined, 2),
+            `offer of ${databaseId}`,
+            '.json',
+        );
         return;
     }
 
@@ -72,7 +78,9 @@ export async function cosmosDBViewContainerOffer(context: IActionContext, node?:
         // as the file label only when we got a container-scoped result.
         const label =
             offer?.name && offer.name.includes('/containers/') ? `offer of ${containerId}` : `offer of ${databaseId}`;
-        await vscodeUtil.showNewFile(JSON.stringify(offer?.resource, undefined, 2), label, '.json');
+        // Coalesce to null so JSON.stringify always returns a string; an offer
+        // can legitimately be absent (e.g., serverless accounts).
+        await vscodeUtil.showNewFile(JSON.stringify(offer?.resource ?? null, undefined, 2), label, '.json');
         return;
     }
 

--- a/src/commands/viewOffer/viewOffer.ts
+++ b/src/commands/viewOffer/viewOffer.ts
@@ -5,6 +5,11 @@
 
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
+import {
+    armReadContainerThroughput,
+    armReadDatabaseThroughput,
+    getArmAccountContext,
+} from '../../cosmosdb/armControlPlane';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { type CosmosDBContainerResourceItem } from '../../tree/cosmosdb/CosmosDBContainerResourceItem';
 import { type CosmosDBDatabaseResourceItem } from '../../tree/cosmosdb/CosmosDBDatabaseResourceItem';
@@ -27,6 +32,13 @@ export async function cosmosDBViewDatabaseOffer(context: IActionContext, node?: 
 
     const accountInfo = node.model.accountInfo;
     const databaseId = node.model.database.id;
+    const armCtx = getArmAccountContext(accountInfo);
+
+    if (armCtx) {
+        const offer = await armReadDatabaseThroughput(armCtx, databaseId);
+        await vscodeUtil.showNewFile(JSON.stringify(offer?.resource, undefined, 2), `offer of ${databaseId}`, '.json');
+        return;
+    }
 
     const offer = await withClaimsChallengeHandling(accountInfo, async (cosmosClient) =>
         cosmosClient.database(databaseId).readOffer(),
@@ -51,6 +63,18 @@ export async function cosmosDBViewContainerOffer(context: IActionContext, node?:
     const accountInfo = node.model.accountInfo;
     const databaseId = node.model.database.id;
     const containerId = node.model.container.id;
+    const armCtx = getArmAccountContext(accountInfo);
+
+    if (armCtx) {
+        const offer = await armReadContainerThroughput(armCtx, databaseId, containerId);
+        // armReadContainerThroughput already falls back to the database offer
+        // when the container has no dedicated throughput, so use containerId
+        // as the file label only when we got a container-scoped result.
+        const label =
+            offer?.name && offer.name.includes('/containers/') ? `offer of ${containerId}` : `offer of ${databaseId}`;
+        await vscodeUtil.showNewFile(JSON.stringify(offer?.resource, undefined, 2), label, '.json');
+        return;
+    }
 
     await withClaimsChallengeHandling(accountInfo, async (cosmosClient) => {
         const offer = await cosmosClient.database(databaseId).container(containerId).readOffer();

--- a/src/cosmosdb/armControlPlane.ts
+++ b/src/cosmosdb/armControlPlane.ts
@@ -83,15 +83,7 @@ export async function armCreateContainer(
 ): Promise<void> {
     const containerId = definition.id!;
     const partitionKeyPaths = definition.partitionKey?.paths ?? [];
-    // The expression `(definition.partitionKey?.kind ?? paths.length > 1) ? MultiHash : Hash`
-    // would short-circuit on the truthy "Hash" string and incorrectly produce
-    // MultiHash whenever kind was explicitly Hash. Compare to MultiHash and
-    // only fall back to the path-count heuristic when kind is undefined.
-    const kind =
-        definition.partitionKey?.kind === PartitionKeyKind.MultiHash ||
-        (definition.partitionKey?.kind === undefined && partitionKeyPaths.length > 1)
-            ? PartitionKeyKind.MultiHash
-            : PartitionKeyKind.Hash;
+    const kind = getPartitionKeyKind(definition.partitionKey?.kind, partitionKeyPaths.length);
     const version = definition.partitionKey?.version ?? PartitionKeyDefinitionVersion.V2;
 
     const parameters: SqlContainerCreateUpdateParameters = {
@@ -180,4 +172,25 @@ function isNotFound(err: unknown): boolean {
     }
     const e = err as { statusCode?: number; code?: string | number };
     return e.statusCode === 404 || e.code === 404 || e.code === 'NotFound' || e.code === 'ResourceNotFound';
+}
+
+/**
+ * Selects the partition-key kind for a new container, fixing the operator-
+ * precedence bug in the previous expression
+ * `(kind ?? paths.length > 1) ? MultiHash : Hash`, which short-circuited on
+ * the truthy `'Hash'` string and incorrectly produced `MultiHash` whenever
+ * `kind` was explicitly `Hash`. Compare to `MultiHash` and only fall back to
+ * the path-count heuristic when `kind` is undefined.
+ *
+ * Shared between the ARM (`armCreateContainer`) and data-plane
+ * (`createContainer/CosmosDBExecuteStep`) paths so the two cannot drift.
+ */
+export function getPartitionKeyKind(kind: PartitionKeyKind | undefined, pathCount: number): PartitionKeyKind {
+    if (kind === PartitionKeyKind.MultiHash) {
+        return PartitionKeyKind.MultiHash;
+    }
+    if (kind === undefined && pathCount > 1) {
+        return PartitionKeyKind.MultiHash;
+    }
+    return PartitionKeyKind.Hash;
 }

--- a/src/cosmosdb/armControlPlane.ts
+++ b/src/cosmosdb/armControlPlane.ts
@@ -102,7 +102,7 @@ export async function armCreateContainer(
             conflictResolutionPolicy:
                 definition.conflictResolutionPolicy as SqlContainerCreateUpdateParameters['resource']['conflictResolutionPolicy'],
         },
-        options: throughput && throughput !== 0 ? { throughput } : {},
+        options: throughput !== undefined && throughput !== 0 ? { throughput } : {},
     };
 
     const client = await getArmClient(ctx);

--- a/src/cosmosdb/armControlPlane.ts
+++ b/src/cosmosdb/armControlPlane.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    type CosmosDBManagementClient,
+    type SqlContainerCreateUpdateParameters,
+    type ThroughputSettingsGetResults,
+} from '@azure/arm-cosmosdb';
+import { PartitionKeyDefinitionVersion, PartitionKeyKind, type ContainerDefinition } from '@azure/cosmos';
+import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
+import * as l10n from '@vscode/l10n';
+import { type AccountInfo } from '../tree/cosmosdb/AccountInfo';
+import { createCosmosDBManagementClient } from '../utils/azureClients';
+
+/**
+ * Minimal ARM-based control-plane shim for issue #2990 (rel/0.32 backport).
+ *
+ * Accounts configured with strict native data-plane RBAC reject control-plane
+ * operations issued via the data-plane `CosmosClient`. For Azure-signed-in
+ * accounts we have enough context to instead route those operations through
+ * ARM, which the role does not block. The full control-plane abstraction from
+ * `main` (#3016) is intentionally not backported — only the surface needed to
+ * unblock create/delete database & container and offer reads.
+ *
+ * Emulator and workspace-attached connection-string accounts continue to use
+ * the data-plane `CosmosClient` because ARM is not reachable for them.
+ */
+
+export interface ArmAccountContext {
+    subscription: AzureSubscription;
+    resourceGroup: string;
+    accountName: string;
+}
+
+export function getArmAccountContext(accountInfo: AccountInfo): ArmAccountContext | undefined {
+    if (accountInfo.isEmulator || !accountInfo.subscription || !accountInfo.resourceGroup) {
+        return undefined;
+    }
+    return {
+        subscription: accountInfo.subscription,
+        resourceGroup: accountInfo.resourceGroup,
+        accountName: accountInfo.name,
+    };
+}
+
+async function getArmClient(ctx: ArmAccountContext): Promise<CosmosDBManagementClient> {
+    const client = await callWithTelemetryAndErrorHandling(
+        'createCosmosDBManagementClient',
+        async (context: IActionContext) => {
+            context.telemetry.suppressIfSuccessful = true;
+            context.errorHandling.forceIncludeInReportIssueCommand = true;
+            context.valuesToMask.push(ctx.subscription.subscriptionId);
+            return createCosmosDBManagementClient(context, ctx.subscription);
+        },
+    );
+    if (!client) {
+        throw new Error(l10n.t('Failed to connect to Cosmos DB account'));
+    }
+    return client;
+}
+
+export async function armCreateDatabase(ctx: ArmAccountContext, databaseId: string): Promise<void> {
+    const client = await getArmClient(ctx);
+    await client.sqlResources.beginCreateUpdateSqlDatabaseAndWait(ctx.resourceGroup, ctx.accountName, databaseId, {
+        resource: { id: databaseId },
+        options: {},
+    });
+}
+
+export async function armDeleteDatabase(ctx: ArmAccountContext, databaseId: string): Promise<void> {
+    const client = await getArmClient(ctx);
+    await client.sqlResources.beginDeleteSqlDatabaseAndWait(ctx.resourceGroup, ctx.accountName, databaseId);
+}
+
+export async function armCreateContainer(
+    ctx: ArmAccountContext,
+    databaseId: string,
+    definition: ContainerDefinition,
+    throughput?: number,
+): Promise<void> {
+    const containerId = definition.id!;
+    const partitionKeyPaths = definition.partitionKey?.paths ?? [];
+    // The expression `(definition.partitionKey?.kind ?? paths.length > 1) ? MultiHash : Hash`
+    // would short-circuit on the truthy "Hash" string and incorrectly produce
+    // MultiHash whenever kind was explicitly Hash. Compare to MultiHash and
+    // only fall back to the path-count heuristic when kind is undefined.
+    const kind =
+        definition.partitionKey?.kind === PartitionKeyKind.MultiHash ||
+        (definition.partitionKey?.kind === undefined && partitionKeyPaths.length > 1)
+            ? PartitionKeyKind.MultiHash
+            : PartitionKeyKind.Hash;
+    const version = definition.partitionKey?.version ?? PartitionKeyDefinitionVersion.V2;
+
+    const parameters: SqlContainerCreateUpdateParameters = {
+        resource: {
+            id: containerId,
+            partitionKey: {
+                paths: partitionKeyPaths,
+                kind,
+                version,
+            },
+            indexingPolicy:
+                definition.indexingPolicy as SqlContainerCreateUpdateParameters['resource']['indexingPolicy'],
+            defaultTtl: definition.defaultTtl,
+            uniqueKeyPolicy:
+                definition.uniqueKeyPolicy as SqlContainerCreateUpdateParameters['resource']['uniqueKeyPolicy'],
+            conflictResolutionPolicy:
+                definition.conflictResolutionPolicy as SqlContainerCreateUpdateParameters['resource']['conflictResolutionPolicy'],
+        },
+        options: throughput && throughput !== 0 ? { throughput } : {},
+    };
+
+    const client = await getArmClient(ctx);
+    await client.sqlResources.beginCreateUpdateSqlContainerAndWait(
+        ctx.resourceGroup,
+        ctx.accountName,
+        databaseId,
+        containerId,
+        parameters,
+    );
+}
+
+export async function armDeleteContainer(
+    ctx: ArmAccountContext,
+    databaseId: string,
+    containerId: string,
+): Promise<void> {
+    const client = await getArmClient(ctx);
+    await client.sqlResources.beginDeleteSqlContainerAndWait(
+        ctx.resourceGroup,
+        ctx.accountName,
+        databaseId,
+        containerId,
+    );
+}
+
+export async function armReadDatabaseThroughput(
+    ctx: ArmAccountContext,
+    databaseId: string,
+): Promise<ThroughputSettingsGetResults | undefined> {
+    const client = await getArmClient(ctx);
+    try {
+        return await client.sqlResources.getSqlDatabaseThroughput(ctx.resourceGroup, ctx.accountName, databaseId);
+    } catch (err) {
+        if (isNotFound(err)) {
+            return undefined;
+        }
+        throw err;
+    }
+}
+
+export async function armReadContainerThroughput(
+    ctx: ArmAccountContext,
+    databaseId: string,
+    containerId: string,
+): Promise<ThroughputSettingsGetResults | undefined> {
+    const client = await getArmClient(ctx);
+    try {
+        return await client.sqlResources.getSqlContainerThroughput(
+            ctx.resourceGroup,
+            ctx.accountName,
+            databaseId,
+            containerId,
+        );
+    } catch (err) {
+        if (!isNotFound(err)) {
+            throw err;
+        }
+    }
+    // Container may inherit throughput from a shared-throughput database.
+    return armReadDatabaseThroughput(ctx, databaseId);
+}
+
+function isNotFound(err: unknown): boolean {
+    if (!err || typeof err !== 'object') {
+        return false;
+    }
+    const e = err as { statusCode?: number; code?: string | number };
+    return e.statusCode === 404 || e.code === 404 || e.code === 'NotFound' || e.code === 'ResourceNotFound';
+}

--- a/src/tree/cosmosdb/AccountInfo.ts
+++ b/src/tree/cosmosdb/AccountInfo.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import * as l10n from '@vscode/l10n';
 import { SERVERLESS_CAPABILITY_NAME, wellKnownEmulatorPassword } from '../../constants';
 import {
@@ -23,6 +24,18 @@ export interface AccountInfo {
     isEmulator: boolean;
     isServerless: boolean;
     name: string;
+    /**
+     * Azure subscription that hosts this account. Populated only for accounts
+     * surfaced via the Azure Resources view (i.e. `getAccountInfoForResource`),
+     * which means the user is signed in to Azure and we have ARM context.
+     * Together with {@link resourceGroup} this allows control-plane operations
+     * (create/delete database & container, read throughput) to be issued via
+     * ARM, which is required for accounts configured with strict native
+     * data-plane RBAC (see issue #2990).
+     */
+    subscription?: AzureSubscription;
+    /** Resource group of the account. See {@link subscription}. */
+    resourceGroup?: string;
 }
 
 function isCosmosDBAttachedAccountModel(account: unknown): account is CosmosDBAttachedAccountModel {
@@ -117,6 +130,8 @@ async function getAccountInfoForResource(account: CosmosDBAccountModel): Promise
         isEmulator: false,
         isServerless,
         name,
+        subscription: account.subscription,
+        resourceGroup,
     };
 }
 


### PR DESCRIPTION
Targeted backport of #3016 to `rel/0.32` for issue #2990.

## Why minimal

The full control-plane refactor on `main` (#3016) is a 14-commit, ~900-line change. For a locked-down release branch we only want the surface needed to unblock #2990. This PR is a single commit, ~275 added lines, 7 files touched, no renames, no new abstractions, no test infra changes.

## What's broken (#2990)

Cosmos DB accounts configured with strict native data-plane RBAC reject control-plane operations issued via the data-plane `CosmosClient` (create database, create container, delete operations, throughput reads). The `withClaimsChallengeHandling` retry loop cannot recover — the operations are not authorized regardless of token claims. Routing those operations through ARM resolves the failure for Azure-signed-in accounts.

## What this PR does

- **`AccountInfo`** — adds optional `subscription?: AzureSubscription` and `resourceGroup?: string`. Populated only by `getAccountInfoForResource` (Azure Resources view); attached / connection-string accounts leave them undefined.
- **New `src/cosmosdb/armControlPlane.ts`** (~180 lines) — small ARM-based shim:
  - `getArmAccountContext(accountInfo)` returns `{subscription, resourceGroup, accountName}` only when ARM is reachable (`!isEmulator && subscription && resourceGroup`); otherwise `undefined`.
  - `armCreateDatabase`, `armDeleteDatabase`, `armCreateContainer`, `armDeleteContainer`.
  - `armReadDatabaseThroughput`, `armReadContainerThroughput` (the latter falls back to the database offer when the container has no dedicated throughput, matching the existing data-plane behavior).
- **5 callsites refactored to branch on `getArmAccountContext`**, falling through to the existing `withClaimsChallengeHandling` path when ARM context is not available:
  - `createDatabase/CosmosDBExecuteStep.ts`
  - `createContainer/CosmosDBExecuteStep.ts`
  - `deleteDatabase/deleteDatabase.ts`
  - `deleteContainer/deleteContainer.ts`
  - `viewOffer/viewOffer.ts`
- **Bug fix in `createContainer`** — same partition-key kind selection bug as fixed on main: `(partitionKey?.kind ?? paths.length > 1) ? MultiHash : Hash` short-circuits on the truthy `'Hash'` string and incorrectly produces `MultiHash` whenever `kind` was explicitly `Hash`. Replaced with an explicit `=== PartitionKeyKind.MultiHash` comparison; the data-plane and ARM paths apply the same fix.

## Behavior

| Account kind | Before | After |
| --- | --- | --- |
| Azure-signed-in, standard | Data plane (CosmosClient) | ARM |
| Azure-signed-in, native data-plane RBAC | Data plane (failed) | ARM (works) |
| Local emulator | Data plane | Data plane |
| Workspace-attached (connection string) | Data plane | Data plane |

## Intentionally out of scope vs #3016

Dropped from the backport because they are not required to fix #2990 and add risk on the release branch:
- `CosmosDBControlPlane` interface, `ArmCosmosDBControlPlane` class, `CosmosDBSdkControlPlane` class, `getControlPlane` selector.
- Renames (`DataPlaneCosmosDBControlPlane` → `CosmosDBSdkControlPlane`).
- `NoSqlQueryConnection` extension and `getControlPlaneForConnection`.
- Query-editor connection-picker refactor (`QueryEditorTab.getConnections` continues to use the data plane).
- `consolidate NoSqlQueryConnection factory` cleanup.
- `validate delete response status codes` / error-contract documentation refactors.
- `remove sproc/trigger from CosmosDBControlPlane abstraction` (no abstraction to remove from).
- `getControlPlane.test.ts` (no abstraction to test).
- `fix: preserve minimumThroughput value of 0` (only relevant to the dropped abstraction).

## Known limitation

Workspace-attached connection-string accounts that point at a real Azure Cosmos DB account configured with strict native data-plane RBAC will continue to have control-plane operations fail, because the connection string does not carry Azure subscription or resource-group context. This matches the behavior on `main` (#3016) and is documented in #3016's discussion. Will be addressed separately.

## Validation

- `npx tsc -p tsconfig.json --noEmit` — no new errors. (Three pre-existing rel/0.32 deprecation/jest warnings — `TS2688 'jest'`, `TS5107 moduleResolution=node10`, `TS5101 baseUrl` — are unchanged.)
- `npx prettier --write` on touched files — clean.
- `npx eslint` on touched files — no findings.
- Manual smoke testing on Azure-signed-in (standard + native RBAC), emulator, and workspace-attached accounts is recommended before merge.

## Related

- Original PR against `main`: #3016
- Issue: #2990
- Supersedes: #3031 (closed; that one was a literal cherry-pick of all 14 commits)
