### PR TITLE
fix(webview): restore production rendering after Vite migration

### DIFF
--- a/src/panels/BaseTab.ts
+++ b/src/panels/BaseTab.ts
@@ -82,10 +82,20 @@ export class BaseTab {
         if (isProduction || !devServer) {
             const assetsDir = path.join(ctx.extensionPath, dir, 'assets');
             try {
-                const cssFiles = fs.readdirSync(assetsDir).filter((f) => f.endsWith('.css'));
+                // Sort for a stable cascade — `readdirSync` order is not
+                // guaranteed across filesystems.
+                const cssFiles = fs
+                    .readdirSync(assetsDir)
+                    .filter((f) => f.endsWith('.css'))
+                    .sort((a, b) => a.localeCompare(b));
                 cssLinks = cssFiles.map((f) => `<link rel="stylesheet" href="${uri('assets', f)}" />`).join('\n    ');
-            } catch {
-                // No assets directory — older or non-Vite builds.
+            } catch (error) {
+                // No assets directory — older or non-Vite builds. Re-throw
+                // anything other than the missing-directory case so real
+                // filesystem failures aren't silently swallowed.
+                if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                    throw error;
+                }
             }
         }
 

--- a/src/panels/BaseTab.ts
+++ b/src/panels/BaseTab.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import crypto from 'crypto';
+import fs from 'fs';
 import path from 'path';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
@@ -74,6 +75,20 @@ export class BaseTab {
         const srcUri = isProduction || !devServer ? uri(filename) : `${DEV_SERVER_HOST}/${filename}`;
         const reactPreambleUri = !isProduction && devServer ? `${DEV_SERVER_HOST}/@react-refresh` : null;
 
+        // In production, Vite extracts CSS into separate files under `assets/`.
+        // The dev server injects CSS via JS at runtime, so this is only needed
+        // for built bundles.
+        let cssLinks = '';
+        if (isProduction || !devServer) {
+            const assetsDir = path.join(ctx.extensionPath, dir, 'assets');
+            try {
+                const cssFiles = fs.readdirSync(assetsDir).filter((f) => f.endsWith('.css'));
+                cssLinks = cssFiles.map((f) => `<link rel="stylesheet" href="${uri('assets', f)}" />`).join('\n    ');
+            } catch {
+                // No assets directory — older or non-Vite builds.
+            }
+        }
+
         const csp = (
             isProduction
                 ? [
@@ -104,6 +119,7 @@ export class BaseTab {
             reactPreambleUri,
             viewType: this.viewType,
             nonce,
+            cssLinks,
         });
     }
 
@@ -114,6 +130,7 @@ export class BaseTab {
         reactPreambleUri: string | null;
         title: string;
         nonce: string;
+        cssLinks: string;
     }) {
         const preamble = params.reactPreambleUri
             ? `
@@ -133,6 +150,7 @@ export class BaseTab {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${params.title}</title>
     <meta http-equiv="Content-Security-Policy" content="${params.csp}" />
+    ${params.cssLinks}
   </head>
 
   <body>

--- a/vite.config.views.mjs
+++ b/vite.config.views.mjs
@@ -56,6 +56,11 @@ export default ({ mode }) => {
             minify: !isDev,
             rollupOptions: {
                 input: path.resolve(__dirname, 'src/webviews/index.tsx'),
+                // Preserve the entry's named exports (e.g. `render`) so the
+                // webview HTML can `import { render } from "./views.js"`.
+                // Without this, app-mode builds treat the entry as side-effect
+                // only and strip its exports.
+                preserveEntrySignatures: 'strict',
                 output: {
                     format: 'es',
                     // Match filename expected by BaseTab.ts


### PR DESCRIPTION
- vite.config.views.mjs: set preserveEntrySignatures: 'strict' so the entry's named 'render' export survives the app-mode build; the webview HTML imports it and was failing with 'does not provide an export named render', leaving the panel blank.
- BaseTab.ts: inject <link rel="stylesheet"> tags for the CSS files Vite emits under dist/assets/ (Monaco, react-data-grid, Allotment, vscode token variables). Without these the grid, editor, and splitter render unstyled in packaged builds. Dev mode is unaffected since the Vite dev server injects CSS via JS.