### PR TITLE
ci: tolerate PR comment failures on fork PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -303,14 +303,21 @@ jobs:
 
                   echo "✅ Job summary written to: ${GITHUB_STEP_SUMMARY}"
 
-                  # Post (or update) a PR comment if we found a PR
+                  # Post (or update) a PR comment if we found a PR.
+                  # Fork PRs run with a read-only GITHUB_TOKEN regardless of the
+                  # workflow's declared permissions, so `gh pr comment` will fail
+                  # with "Resource not accessible by integration". Treat any
+                  # failure here as a warning so it does not fail the job.
                   if [ -n "${PR_NUMBER:-}" ]; then
-                      gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
-                          --body "$(cat "$GITHUB_STEP_SUMMARY")" \
-                          --edit-last 2>/dev/null \
+                      if gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+                              --body "$(cat "$GITHUB_STEP_SUMMARY")" \
+                              --edit-last 2>/dev/null \
                           || gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
-                              --body "$(cat "$GITHUB_STEP_SUMMARY")"
-                      echo "✅ PR #${PR_NUMBER} comment posted"
+                              --body "$(cat "$GITHUB_STEP_SUMMARY")" 2>/dev/null; then
+                          echo "✅ PR #${PR_NUMBER} comment posted"
+                      else
+                          echo "::warning::Unable to post PR comment on #${PR_NUMBER} (likely a fork PR with a read-only GITHUB_TOKEN). Skipping."
+                      fi
                   fi
 
                   # Fail the job if any tests failed


### PR DESCRIPTION
## Problem
The `📊 Generate Job Summary` step failed in [this run](https://github.com/microsoft/vscode-cosmosdb/actions/runs/26092880460/job/76722863136?pr=3042) with:
```
GraphQL: Resource not accessible by integration (addComment)
Error: Process completed with exit code 1.
```
even though the unit and integration tests had passed.
## Root cause
For `pull_request` events triggered from **forks**, GitHub forces `GITHUB_TOKEN` to be read-only regardless of any `permissions:` declared in the workflow. `gh pr comment` then fails with the GraphQL error above.
Because GitHub Actions runs `bash` steps with `set -e -o pipefail`, the failed fallback `gh pr comment` in the `|| ...` chain propagated its non-zero exit code and killed the whole step.
## Fix
Wrap both `gh pr comment` attempts (`--edit-last` and the fallback create) in an `if/then/else` block:
- Suppress their stderr with `2>/dev/null` so the GraphQL error doesn't spam the log.
- If both fail, emit a `::warning::` annotation instead of exiting non-zero.
- Same-repo PRs and `push` runs continue to get the nice PR comment as before.
The final `Fail the job if any tests failed` check at the end of the step is unchanged and remains the only way for this step to fail.
## Test plan
- Same-repo PR (this one): job summary step succeeds, PR comment is posted/updated.
- Fork PR: job summary step succeeds, `::warning::` annotation appears in the run, no PR comment.
- Failing tests: step still fails because of the final tests check, independently of comment posting.
