### PR TITLE
feat: add feedback acknowledgment message and reset feedback state after query generation

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -858,6 +858,7 @@
   "Take Survey": "Take Survey",
   "Target Environment": "Target Environment",
   "Test Connection": "Test Connection",
+  "Thanks for your feedback!": "Thanks for your feedback!",
   "The \"_etag\" field is required to update an item": "The \"_etag\" field is required to update an item",
   "The \"{databaseId}\" database has been deleted.": "The \"{databaseId}\" database has been deleted.",
   "The \"{name}\" database has been created.": "The \"{name}\" database has been created.",

--- a/src/panels/trpc/routers/queryEditorRouter.ts
+++ b/src/panels/trpc/routers/queryEditorRouter.ts
@@ -1021,6 +1021,7 @@ export const queryEditorRouterDef = queryEditorRouter({
                 ctx.actionContext.telemetry.properties.category = input.component;
                 ctx.actionContext.telemetry.properties.isAIGenerated = String(ctx.state.isLastQueryAIGenerated);
             }
+            void vscode.window.showInformationMessage(l10n.t('Thanks for your feedback!'));
         }),
 
     confirmToolInvocationResponse: queryEditorProcedure

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
@@ -323,6 +323,7 @@ export const GenerateQueryInput = () => {
         }
 
         setIsLoading(true);
+        setFeedbackGiven(null);
         try {
             // Get the current query content from the state
             const currentQuery = state.queryValue;


### PR DESCRIPTION
Fixes AzureCosmosDB/cosmosdb-vscode-ai-assistant-preview/issues/#3.

* Show information message "Thanks for your feedback!" when feedback button (thumb up or down) is pressed. Message eventually disappears by itself.
* After feedback is sent, button is disabled. Re-enable button after each query generation to enable new feedback. 


