### PR TITLE
fix(migration): resolve tslib via ESM to fix Phase 4 provisioning crash

### DIFF
--- a/vite.config.ext.mjs
+++ b/vite.config.ext.mjs
@@ -70,6 +70,22 @@ export default ({ mode }) => {
             mainFields: ['module', 'main'],
             extensions: ['.ts', '.js'],
             alias: {
+                // Force tslib to its ESM build. Legacy Azure SDKs
+                // (`@azure/arm-cosmosdb`, `@azure/arm-postgresql`,
+                // `@azure/arm-postgresql-flexible`, …) compile to CJS with
+                // `importHelpers: true` and pull in tslib. tslib's CJS entry
+                // (`tslib.js`) attaches helpers directly onto `module.exports`
+                // AND sets `module.exports.__esModule = true`. Rolldown's
+                // `__toESM` interop helper sees `__esModule === true` and
+                // therefore does NOT install a `.default` property on the
+                // wrapped namespace — but the emitted destructure still reads
+                // `.default`, producing the runtime crash:
+                //   "Cannot destructure property '__extends' of
+                //    '__toESM(...).default' as it is undefined."
+                // Aliasing tslib to its ESM build sidesteps the broken
+                // CJS-interop path entirely; the helpers come through as
+                // plain named ESM exports.
+                tslib: path.resolve(__dirname, 'node_modules/tslib/tslib.es6.mjs'),
                 '@cosmosdb/nosql-language-service/vscode': path.resolve(
                     __dirname,
                     'packages/nosql-language-service/src/providers/vscode/index.ts',


### PR DESCRIPTION
## Summary

Selecting a subscription in migration **Phase 4 (provisioning)** crashed with:

> Cannot destructure property `__extends` of `__toESM(...).default` as it is undefined.

## Root cause

Legacy Azure ARM SDKs (`@azure/arm-cosmosdb`, `@azure/arm-postgresql`, `@azure/arm-postgresql-flexible`) are compiled to CJS with `importHelpers: true` and depend on `tslib`. tslib's CJS entry attaches its helpers directly onto `module.exports` **and** sets `module.exports.__esModule = true`.

Rolldown's `__toESM` interop helper treats anything with `__esModule === true` as already-ESM and therefore skips installing a `.default` property on the wrapped namespace — but the emitted destructure still reads `.default`, producing `undefined.__extends` at runtime.

The crash only surfaced in Phase 4 because that's the first place we lazily `await import('@azure/arm-cosmosdb')` (via `createCosmosDBManagementClient`).

## Fix

Alias `tslib` to its proper ESM entry (`tslib.es6.mjs`) so the helpers come through as plain named ESM exports, bypassing the broken CJS-interop path entirely.

## Verification

- Reproduced before the fix by `node --input-type=module -e "import('./dist/modules-*.mjs')"` — threw the exact error.
- After the fix, dynamically importing every chunk in `dist/` from Node loads cleanly (only `main.mjs` errors on the unavailable `vscode` module, which is expected outside the EDH).
- Audited the rest of `dist/` for the same shape — no remaining `var { ... } = ....default` destructures, and all dual-entry look-alike packages (`@azure/core-*`, `@microsoft/applicationinsights-*`) already resolve through their ESM entries.

Fixes #3055