### PR TITLE
fix(queryEditor): hide Throughput Bucket menu when connected to Cosmos DB Emulator

### DIFF
--- a/src/panels/trpc/routers/queryEditorRouter.ts
+++ b/src/panels/trpc/routers/queryEditorRouter.ts
@@ -111,10 +111,14 @@ export const queryEditorRouterDef = queryEditorRouter({
 
         const containerSchema = ctx.state.connection ? await readSchemaForConnection(ctx.state.connection) : null;
 
+        // Throughput buckets are not supported by the Cosmos DB Emulator —
+        // hide the option entirely when the active connection points at an emulator.
+        const supportsThroughputBuckets = !!ctx.state.connection && !ctx.state.connection.isEmulator;
+
         return {
             connectionState,
             queryHistory,
-            throughputBuckets: ctx.state.connection ? [true, true, true, true, true] : undefined,
+            throughputBuckets: supportsThroughputBuckets ? [true, true, true, true, true] : undefined,
             initialQuery: ctx.state.query,
             isSurveyCandidate: !getIsSurveyDisabledGlobally(),
             isAIFeaturesEnabled: ext.isAIFeaturesEnabled ?? false,

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
@@ -324,9 +324,10 @@ export class QueryEditorContextProvider extends BaseContextProvider<QueryEditorA
                 this.dispatch({ type: 'updateHistory', queryHistory: result.queryHistory });
             }
 
-            if (result.throughputBuckets) {
-                this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets: result.throughputBuckets });
-            }
+            // Always dispatch — the server may explicitly return `undefined` to indicate
+            // throughput buckets are unsupported (e.g. when connected to the Cosmos DB
+            // Emulator). Without this, the default state ([true × 5]) would keep showing.
+            this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets: result.throughputBuckets });
 
             if (result.initialQuery) {
                 void this.insertText(result.initialQuery);


### PR DESCRIPTION
## Summary

The "Throughput Bucket" dropdown in the query editor toolbar was visible even when the active connection was to the Cosmos DB Emulator. Throughput buckets are not supported by the emulator, so the option had no effect — leading users to think the feature was broken rather than unsupported.

## Changes

- **`src/panels/trpc/routers/queryEditorRouter.ts`** — The `init` mutation now returns `throughputBuckets: undefined` when the active connection points at an emulator (`ctx.state.connection.isEmulator`).
- **`src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx`** — Always dispatch the `updateThroughputBuckets` action with the server result. Previously the dispatch was guarded by `if (result.throughputBuckets)`, so an `undefined` server response left the default state (`[true, true, true, true, true]`) in place and the menu kept rendering.

The UI already hides the submenu when `state.throughputBuckets` is `undefined` (see `RunQueryButton.tsx`), so no UI change was required.

## Testing

- Connect to the Cosmos DB Emulator → open a container's query editor → the "Throughput Bucket" entry no longer appears in the Run-query menu.
- Connect to a real Cosmos DB account → menu still shows "No bucket" + "Bucket 1–5" as before.

## Validation

- `npm run prettier-fix` — clean
- `npm run lint` — clean
- No user-facing strings changed; `npm run l10n` not required.

## Issue

Fixes [AzureCosmosDB/cosmosdb-vscode-ai-assistant-preview#17](https://github.com/AzureCosmosDB/cosmosdb-vscode-ai-assistant-preview/issues/17).
