### PR TITLE
feat: Enable schema generation based on queries in CosmosDB query editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -906,7 +906,7 @@
           },
           "cosmosDB.queryEditor.generateSchemaBasedOnQueries": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "%cosmosdb.configuration.queryEditor.generateSchemaBasedOnQueries%"
           },
           "cosmosDB.experimental.migration.showTokenEstimate": {


### PR DESCRIPTION
This pull request makes a small but important configuration change to the `package.json` file. The default value for the `cosmosDB.queryEditor.generateSchemaBasedOnQueries` setting is now set to `true` instead of `false`. This means schema generation based on queries will be enabled by default for users.