### PR TITLE
fix: NL2Query in Query Editor properly handles container switch

### DIFF
--- a/src/chat/CosmosDbOperationsService.ts
+++ b/src/chat/CosmosDbOperationsService.ts
@@ -518,19 +518,17 @@ export class CosmosDbOperationsService {
             switch (operationName) {
                 case 'editQuery': {
                     const currentQuery = (parameters.currentQuery as string | undefined)?.trim();
-                    const { activeEditor, connection, currentResult, hasResults } = this.getActiveQueryEditorContext();
+                    const { connection, currentResult, hasResults } = this.getActiveQueryEditorContext();
 
                     if (!currentQuery) {
                         return l10n.t(
                             'No query found to edit. Please write or execute a query in the query editor first.',
                         );
                     }
-                    const historyContext = this.getQueryHistoryContext(activeEditor);
 
                     return this.handleEditQuery(
                         parameters.userPrompt as string,
                         connection,
-                        historyContext,
                         {
                             documentCount: hasResults ? currentResult?.documents?.length : undefined,
                             requestCharge: hasResults ? currentResult?.requestCharge : undefined,
@@ -587,14 +585,12 @@ export class CosmosDbOperationsService {
                         );
                     }
 
-                    let genEditor: QueryEditorTab;
                     let genConnection: NoSqlQueryConnection;
                     let genResult: ReturnType<QueryEditorTab['getCurrentQueryResults']>;
                     let genCurrentQuery: string | undefined;
                     let genHasResults: boolean;
                     try {
                         ({
-                            activeEditor: genEditor,
                             connection: genConnection,
                             currentResult: genResult,
                             query: genCurrentQuery,
@@ -605,12 +601,10 @@ export class CosmosDbOperationsService {
                             'No active query editor found. Please open a query editor first using the Azure extension or right-click on a container.',
                         );
                     }
-                    const genHistoryContext = this.getQueryHistoryContext(genEditor);
 
                     return this.handleEditQuery(
                         parameters.userPrompt as string,
                         genConnection,
-                        genHistoryContext,
                         {
                             documentCount: genHasResults ? genResult?.documents?.length : undefined,
                             requestCharge: genHasResults ? genResult?.requestCharge : undefined,
@@ -639,7 +633,6 @@ export class CosmosDbOperationsService {
     private async handleEditQuery(
         userPrompt: string,
         connection: NoSqlQueryConnection,
-        historyContext: QueryHistoryContext | undefined,
         resultContext: {
             documentCount?: number;
             requestCharge?: number;
@@ -663,13 +656,13 @@ export class CosmosDbOperationsService {
             userPrompt,
             sendCurrentQueryToLLM && currentQuery ? currentQuery : '',
             {
-                historyContext,
                 withExplanation: true,
                 onProgress,
                 onConfirm,
                 additionalContext,
                 source,
                 operation,
+                connection,
             },
         );
         const suggestion = llmSuggestion.query;
@@ -832,6 +825,8 @@ export class CosmosDbOperationsService {
             source?: string;
             /** The NL2Query operation type: 'generateQuery', 'editQuery', or 'explainQuery' */
             operation?: string;
+            /** Explicit connection to use for schema lookup and sampling. Falls back to getActiveConnection(). */
+            connection?: NoSqlQueryConnection;
         },
     ): Promise<string>;
     public async generateQueryWithLLM(
@@ -847,6 +842,7 @@ export class CosmosDbOperationsService {
             additionalContext?: string;
             source?: string;
             operation?: string;
+            connection?: NoSqlQueryConnection;
         },
     ): Promise<{ query: string; explanation: string }>;
     public async generateQueryWithLLM(
@@ -862,17 +858,10 @@ export class CosmosDbOperationsService {
             additionalContext?: string;
             source?: string;
             operation?: string;
+            connection?: NoSqlQueryConnection;
         },
     ): Promise<string | { query: string; explanation: string }> {
-        const {
-            modelId,
-            historyContext,
-            withExplanation,
-            cancellationToken,
-            onProgress,
-            onConfirm,
-            additionalContext,
-        } = options ?? {};
+        const { modelId, withExplanation, cancellationToken, onProgress, onConfirm, additionalContext } = options ?? {};
         const source = options?.source;
         const operation = options?.operation;
 
@@ -891,7 +880,14 @@ export class CosmosDbOperationsService {
         // or a previous sampling run), include it in the initial context so the LLM
         // can use it without needing to call the sampling tool.
         let cachedSchema: string | undefined;
-        const connection = this.getActiveConnection();
+        const connection = options?.connection ?? this.getActiveConnection();
+
+        // Derive history context from the connection if not explicitly provided
+        const historyContext =
+            options?.historyContext ??
+            (connection
+                ? this.getQueryHistoryForContainer(connection.accountId, connection.databaseId, connection.containerId)
+                : undefined);
         if (connection) {
             try {
                 const schemaId = SchemaFileStorage.getSchemaIdForConnection(connection);
@@ -1049,7 +1045,7 @@ export class CosmosDbOperationsService {
                 // Invoke our own tool directly so we can show custom confirmation
                 // (onConfirm), track telemetry, report progress, and cache the schema.
                 if (toolCall.name === SAMPLE_DATA_TOOL_NAME) {
-                    const connection = this.getActiveConnection();
+                    const connection = options?.connection ?? this.getActiveConnection();
                     if (connection) {
                         if (onConfirm) {
                             const confirmed = await onConfirm(l10n.t(SAMPLE_DATA_CONFIRMATION_MESSAGE));

--- a/src/panels/trpc/routers/queryEditorRouter.ts
+++ b/src/panels/trpc/routers/queryEditorRouter.ts
@@ -638,20 +638,13 @@ export const queryEditorRouterDef = queryEditorRouter({
                 }
 
                 const service = CosmosDbOperationsService.getInstance();
-                const historyContext = ctx.state.connection
-                    ? service.getQueryHistoryForContainer(
-                          ctx.state.connection.accountId,
-                          ctx.state.connection.databaseId,
-                          ctx.state.connection.containerId,
-                      )
-                    : undefined;
 
                 const generatedQuery = await service.generateQueryWithLLM(input.prompt, input.currentQuery, {
                     modelId: model.id,
-                    historyContext,
                     cancellationToken: token,
                     source: 'queryEditor',
                     operation: 'generateQuery',
+                    connection: ctx.state.connection,
                     onConfirm: async (message: string) => {
                         ctx.eventSink.emit({ type: 'confirmToolInvocation', message });
                         return new Promise<boolean>((resolve) => {


### PR DESCRIPTION
This change fixes the bug where user select a different container from the dropdown and query advisor generates a query based on the old container. The query history is now derived from the connection information.