### PR TITLE
fix(migration): remove fileBaseName from ddlExtractor.extract telemetry

### DIFF
--- a/src/panels/migration/helpers/migrationTelemetry.ts
+++ b/src/panels/migration/helpers/migrationTelemetry.ts
@@ -171,17 +171,14 @@ export function enrichErrorContext(context: IActionContext, error: unknown): voi
  * event) and accumulates phase-level rollups on the optional phase context for
  * dashboards/alerts that prefer one record per phase.
  *
- * No file contents or full paths are emitted — only the basename and structural
- * counts.
+ * No file contents, paths, or names are emitted — only structural counts.
  */
 export function reportDdlExtractorStats(
     callContext: IActionContext,
     stats: ExtractionStats,
-    fileBaseName: string,
     encoding: FileEncoding,
     phaseContext?: IActionContext,
 ): void {
-    callContext.telemetry.properties.fileBaseName = fileBaseName;
     callContext.telemetry.properties.encoding = encoding;
 
     const m = callContext.telemetry.measurements;

--- a/src/panels/migration/tools/migrationTools.ts
+++ b/src/panels/migration/tools/migrationTools.ts
@@ -369,7 +369,7 @@ export function createToolExecutor(
                         await callWithTelemetryAndErrorHandling('cosmosDB.migration.ddlExtractor.extract', (ctx) => {
                             ctx.errorHandling.suppressDisplay = true;
                             ctx.errorHandling.rethrow = false;
-                            reportDdlExtractorStats(ctx, stats, baseName, decoded.encoding, phaseContext);
+                            reportDdlExtractorStats(ctx, stats, decoded.encoding, phaseContext);
                         });
                         return extracted || rawText;
                     }


### PR DESCRIPTION
This pull request updates the telemetry reporting for the DDL extractor to further restrict the information collected, enhancing user privacy and data minimization. The most important changes are:

**Telemetry Data Minimization:**

* The `reportDdlExtractorStats` function in `migrationTelemetry.ts` no longer accepts or records the file base name, ensuring that no file contents, paths, or names are emitted—only structural counts are reported.
* All calls to `reportDdlExtractorStats`, such as in `migrationTools.ts`, have been updated to remove the file base name parameter, aligning with the stricter telemetry requirements.