### PR TITLE
fix: add explicit `id` to wizard steps to prevent mangled telemetry

### DIFF
--- a/src/commands/createContainer/CosmosDBContainerNameStep.ts
+++ b/src/commands/createContainer/CosmosDBContainerNameStep.ts
@@ -11,6 +11,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateContainerWizardContext } from './CreateContainerWizardContext';
 
 export class CosmosDBContainerNameStep extends AzureWizardPromptStep<CreateContainerWizardContext> {
+    public id = 'cosmosDB.createContainer.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateContainerWizardContext): Promise<void> {

--- a/src/commands/createContainer/CosmosDBExecuteStep.ts
+++ b/src/commands/createContainer/CosmosDBExecuteStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateContainerWizardContext } from './CreateContainerWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateContainerWizardContext> {
+    public id = 'cosmosDB.createContainer.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateContainerWizardContext): Promise<void> {

--- a/src/commands/createContainer/CosmosDBThroughputStep.ts
+++ b/src/commands/createContainer/CosmosDBThroughputStep.ts
@@ -12,6 +12,7 @@ const maxThroughput: number = 100000;
 const throughputStepSize = 100;
 
 export class CosmosDBThroughputStep extends AzureWizardPromptStep<CreateContainerWizardContext> {
+    public id = 'cosmosDB.createContainer.throughputStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateContainerWizardContext): Promise<void> {

--- a/src/commands/createDatabase/CosmosDBDatabaseNameStep.ts
+++ b/src/commands/createDatabase/CosmosDBDatabaseNameStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateDatabaseWizardContext } from './CreateDatabaseWizardContext';
 
 export class CosmosDBDatabaseNameStep extends AzureWizardPromptStep<CreateDatabaseWizardContext> {
+    public id = 'cosmosDB.createDatabase.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateDatabaseWizardContext): Promise<void> {

--- a/src/commands/createDatabase/CosmosDBExecuteStep.ts
+++ b/src/commands/createDatabase/CosmosDBExecuteStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateDatabaseWizardContext } from './CreateDatabaseWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateDatabaseWizardContext> {
+    public id = 'cosmosDB.createDatabase.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateDatabaseWizardContext): Promise<void> {

--- a/src/commands/createStoredProcedure/CosmosDBExecuteStep.ts
+++ b/src/commands/createStoredProcedure/CosmosDBExecuteStep.ts
@@ -12,6 +12,7 @@ import { nonNullProp } from '../../utils/nonNull';
 import { type CreateStoredProcedureWizardContext } from './CreateStoredProcedureWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateStoredProcedureWizardContext> {
+    public id = 'cosmosDB.createStoredProcedure.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateStoredProcedureWizardContext): Promise<void> {

--- a/src/commands/createStoredProcedure/CosmosDBStoredProcedureNameStep.ts
+++ b/src/commands/createStoredProcedure/CosmosDBStoredProcedureNameStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateStoredProcedureWizardContext } from './CreateStoredProcedureWizardContext';
 
 export class CosmosDBStoredProcedureNameStep extends AzureWizardPromptStep<CreateStoredProcedureWizardContext> {
+    public id = 'cosmosDB.createStoredProcedure.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateStoredProcedureWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBExecuteStep.ts
+++ b/src/commands/createTrigger/CosmosDBExecuteStep.ts
@@ -12,6 +12,7 @@ import { nonNullProp } from '../../utils/nonNull';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBTriggerNameStep.ts
+++ b/src/commands/createTrigger/CosmosDBTriggerNameStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBTriggerNameStep extends AzureWizardPromptStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBTriggerOperationStep.ts
+++ b/src/commands/createTrigger/CosmosDBTriggerOperationStep.ts
@@ -8,6 +8,7 @@ import { getTriggerOperation } from '../../cosmosdb/fs/TriggerFileDescriptor';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBTriggerOperationStep extends AzureWizardPromptStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.operationStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBTriggerTypeStep.ts
+++ b/src/commands/createTrigger/CosmosDBTriggerTypeStep.ts
@@ -8,6 +8,7 @@ import { getTriggerType } from '../../cosmosdb/fs/TriggerFileDescriptor';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBTriggerTypeStep extends AzureWizardPromptStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.typeStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/deleteDatabaseAccount/DatabaseAccountDeleteStep.ts
+++ b/src/commands/deleteDatabaseAccount/DatabaseAccountDeleteStep.ts
@@ -9,6 +9,7 @@ import { deleteCosmosDBAccount } from './deleteCosmosDBAccount';
 import { type DeleteWizardContext } from './DeleteWizardContext';
 
 export class DatabaseAccountDeleteStep extends AzureWizardExecuteStep<DeleteWizardContext> {
+    public id = 'cosmosDB.deleteDatabaseAccount.deleteStep';
     public priority: number = 100;
 
     public async execute(context: DeleteWizardContext): Promise<void> {

--- a/src/commands/newConnection/CosmosDBConnectionStringStep.ts
+++ b/src/commands/newConnection/CosmosDBConnectionStringStep.ts
@@ -9,6 +9,8 @@ import { parseCosmosDBConnectionString } from '../../cosmosdb/cosmosDBConnection
 import { type NewConnectionWizardContext } from './NewConnectionWizardContext';
 
 export class CosmosDBConnectionStringStep extends AzureWizardPromptStep<NewConnectionWizardContext> {
+    public id = 'cosmosDB.newConnection.connectionStringStep';
+
     public async prompt(context: NewConnectionWizardContext): Promise<void> {
         context.connectionString = (
             await context.ui.showInputBox({

--- a/src/commands/newConnection/CosmosDBExecuteStep.ts
+++ b/src/commands/newConnection/CosmosDBExecuteStep.ts
@@ -13,6 +13,7 @@ import { WorkspaceResourceType } from '../../tree/workspace-api/SharedWorkspaceR
 import { type NewConnectionWizardContext } from './NewConnectionWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<NewConnectionWizardContext> {
+    public id = 'cosmosDB.newConnection.executeStep';
     public priority: number = 100;
 
     public async execute(context: NewConnectionWizardContext): Promise<void> {

--- a/src/commands/newConnection/CosmosDBTenantStep.ts
+++ b/src/commands/newConnection/CosmosDBTenantStep.ts
@@ -15,6 +15,8 @@ import { type NewConnectionWizardContext } from './NewConnectionWizardContext';
  * used for Entra ID authentication against the Cosmos DB account.
  */
 export class CosmosDBTenantStep extends AzureWizardPromptStep<NewConnectionWizardContext> {
+    public id = 'cosmosDB.newConnection.tenantStep';
+
     public async prompt(context: NewConnectionWizardContext): Promise<void> {
         const subscriptionProvider = new VSCodeAzureSubscriptionProvider();
 

--- a/src/commands/newEmulatorConnection/ExecuteStep.ts
+++ b/src/commands/newEmulatorConnection/ExecuteStep.ts
@@ -15,6 +15,7 @@ import {
 } from './NewEmulatorConnectionWizardContext';
 
 export class ExecuteStep extends AzureWizardExecuteStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.newEmulatorConnection.executeStep';
     public priority: number = 100;
 
     public async execute(context: NewEmulatorConnectionWizardContext): Promise<void> {

--- a/src/commands/newEmulatorConnection/PromptEmulatorPortStep.ts
+++ b/src/commands/newEmulatorConnection/PromptEmulatorPortStep.ts
@@ -12,6 +12,7 @@ import {
 } from './NewEmulatorConnectionWizardContext';
 
 export class PromptEmulatorPortStep extends AzureWizardPromptStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.emulator.portStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: NewEmulatorConnectionWizardContext): Promise<void> {

--- a/src/commands/newEmulatorConnection/PromptEmulatorTypeStep.ts
+++ b/src/commands/newEmulatorConnection/PromptEmulatorTypeStep.ts
@@ -14,6 +14,8 @@ import {
 } from './NewEmulatorConnectionWizardContext';
 
 export class PromptEmulatorTypeStep extends AzureWizardPromptStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.emulator.typeStep';
+
     constructor() {
         super();
     }

--- a/src/commands/newEmulatorConnection/nosql/PromptNosqlEmulatorConnectionStringStep.ts
+++ b/src/commands/newEmulatorConnection/nosql/PromptNosqlEmulatorConnectionStringStep.ts
@@ -13,6 +13,8 @@ import {
 
 // TODO: create one that can be shared for adding an account and adding an emulator
 export class PromptNosqlEmulatorConnectionStringStep extends AzureWizardPromptStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.nosqlEmulator.connectionStringStep';
+
     public async prompt(context: NewEmulatorConnectionWizardContext): Promise<void> {
         context.connectionString = (
             await context.ui.showInputBox({


### PR DESCRIPTION
## Problem

After PR #2972 fixed mangled telemetry **event names** (e.g. `wy.getresourceitem`), a related issue remained: the `lastStep` telemetry **property** still contained minified class names (e.g. `prompt-wy`, `execute-ev`).

### Root Cause

`@microsoft/vscode-azext-utils`' `AzureWizard` records the last executed step in telemetry using:

```js
// AzureWizard.js
context.telemetry.properties.lastStep = `${type}-${step.id || step.constructor.name}`;
```

The `AzureWizardExecuteStep` type declaration even documents this explicitly:

> `id?: string` — Optional id used to determine if this step is unique, for things like caching values and telemetry. **If not specified, the class name will be used instead.**

In production builds, Vite's Rolldown/OXC minifier mangles class names (e.g. `CosmosDBDatabaseNameStep` → `wy`), but **not string literals**. So any wizard step without an explicit `id` will produce unreadable telemetry in production.

## Fix

Added explicit `public id` fields with stable, hardcoded string literals to all **19 wizard step classes** that were missing them:

| File | ID |
|------|----|
| `createDatabase/CosmosDBDatabaseNameStep` | `cosmosDB.createDatabase.nameStep` |
| `createDatabase/CosmosDBExecuteStep` | `cosmosDB.createDatabase.executeStep` |
| `newConnection/CosmosDBConnectionStringStep` | `cosmosDB.newConnection.connectionStringStep` |
| `newConnection/CosmosDBTenantStep` | `cosmosDB.newConnection.tenantStep` |
| `newConnection/CosmosDBExecuteStep` | `cosmosDB.newConnection.executeStep` |
| `newEmulatorConnection/PromptEmulatorTypeStep` | `cosmosDB.emulator.typeStep` |
| `newEmulatorConnection/PromptEmulatorPortStep` | `cosmosDB.emulator.portStep` |
| `newEmulatorConnection/ExecuteStep` | `cosmosDB.newEmulatorConnection.executeStep` |
| `newEmulatorConnection/nosql/PromptNosqlEmulatorConnectionStringStep` | `cosmosDB.nosqlEmulator.connectionStringStep` |
| `createStoredProcedure/CosmosDBStoredProcedureNameStep` | `cosmosDB.createStoredProcedure.nameStep` |
| `createStoredProcedure/CosmosDBExecuteStep` | `cosmosDB.createStoredProcedure.executeStep` |
| `deleteDatabaseAccount/DatabaseAccountDeleteStep` | `cosmosDB.deleteDatabaseAccount.deleteStep` |
| `createTrigger/CosmosDBTriggerNameStep` | `cosmosDB.createTrigger.nameStep` |
| `createTrigger/CosmosDBTriggerTypeStep` | `cosmosDB.createTrigger.typeStep` |
| `createTrigger/CosmosDBTriggerOperationStep` | `cosmosDB.createTrigger.operationStep` |
| `createTrigger/CosmosDBExecuteStep` | `cosmosDB.createTrigger.executeStep` |
| `createContainer/CosmosDBContainerNameStep` | `cosmosDB.createContainer.nameStep` |
| `createContainer/CosmosDBThroughputStep` | `cosmosDB.createContainer.throughputStep` |
| `createContainer/CosmosDBExecuteStep` | `cosmosDB.createContainer.executeStep` |

The one step that already had `id` set was `CosmosDBPartitionKeyStep` — it sets `this.id` dynamically in the constructor since the same class is instantiated up to 3 times per wizard run.

## Related

- PR #2972 — fixed mangled event *names* in `BaseCachedBranchDataProvider` (`providerName` was `this.constructor.name`)
- This PR fixes the same class of problem for wizard step telemetry *properties*