### PR TITLE
refactor(nosql-language-service): unify provider APIs and document options

### DIFF
--- a/packages/nosql-language-service/src/providers/codemirror/index.test.ts
+++ b/packages/nosql-language-service/src/providers/codemirror/index.test.ts
@@ -460,22 +460,6 @@ describe('createMultiQuerySeparatorExtension', () => {
         // No new ranges computed
         expect(deps.createdRanges).toHaveLength(initialRangeCount);
     });
-
-    it('supports custom separator class', () => {
-        const deps = createSeparatorDepsMock();
-        const ext = createMultiQuerySeparatorExtension(service, deps, {
-            separatorClass: 'my-custom-sep',
-        }) as {
-            _cls: new (view: unknown) => { decorations: unknown };
-        };
-
-        const view = createSeparatorViewMock('SELECT 1;\nSELECT 2;');
-        new ext._cls(view);
-
-        // 2 separators (trailing ; creates empty region)
-        expect(deps.createdRanges).toHaveLength(2);
-        expect(deps.createdRanges[0].class).toBe('my-custom-sep');
-    });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/nosql-language-service/src/providers/codemirror/separatorExtension.ts
+++ b/packages/nosql-language-service/src/providers/codemirror/separatorExtension.ts
@@ -24,15 +24,24 @@ function ensureSeparatorStyles(): void {
     document.head.appendChild(style);
 }
 
+/**
+ * Build a CodeMirror `ViewPlugin` extension that draws a separator line
+ * under each semicolon in a multi-query document.
+ *
+ * Styles are hardcoded and injected into the document head under the
+ * `cosmosdb-query-separator` class — symmetric with the Monaco and VS Code
+ * multi-query decorators, which also don't expose styling knobs.
+ *
+ * @param service - The language service used to find `;` positions.
+ * @param deps - CodeMirror modules the extension needs (see {@link MultiQuerySeparatorDeps}).
+ */
 export function createMultiQuerySeparatorExtension(
     service: SqlLanguageService,
     deps: MultiQuerySeparatorDeps,
-    options?: { separatorClass?: string },
 ): unknown {
     ensureSeparatorStyles();
 
-    const className = options?.separatorClass ?? SEPARATOR_CLASS;
-    const lineDeco = deps.Decoration.line({ class: className });
+    const lineDeco = deps.Decoration.line({ class: SEPARATOR_CLASS });
 
     function buildDecorations(doc: { toString(): string; lineAt(pos: number): { from: number } }): unknown {
         const text = doc.toString();

--- a/packages/nosql-language-service/src/providers/codemirror/types.ts
+++ b/packages/nosql-language-service/src/providers/codemirror/types.ts
@@ -7,15 +7,40 @@ import { type Diagnostic } from '@codemirror/lint';
 import { type EditorView, type TooltipView } from '@codemirror/view';
 import { DiagnosticSeverity as DsSeverity } from '../../services/types.js';
 
+/**
+ * Suggested options shape for a CodeMirror host that wraps the language
+ * service's individual extension factories behind a single config object.
+ *
+ * Unlike the Monaco/VS Code adapters, the CodeMirror surface is a set of
+ * standalone factories the host composes manually — nothing in this package
+ * consumes `CodeMirrorOptions` directly. It exists so different hosts can
+ * agree on the same option names when they expose a single config knob.
+ */
 export interface CodeMirrorOptions {
-    /** @default true */
+    /**
+     * Compose the autocomplete source (`createCompletionSource(service)`).
+     * Disable if your host already provides completions for this language.
+     * @default true
+     */
     completions?: boolean;
-    /** @default true */
+    /**
+     * Compose the lint source (`createLintSource(service)`).
+     * Disable for read-only viewers where you don't want squiggles.
+     * @default true
+     */
     diagnostics?: boolean;
-    /** @default true */
+    /**
+     * Compose the hover tooltip source (`createHoverTooltipSource(service)`).
+     * @default true
+     */
     hover?: boolean;
 }
 
+/**
+ * CodeMirror modules the multi-query separator extension needs to draw
+ * its line decorations. Injected by the host so this package can stay
+ * free of a hard `@codemirror/view` dependency at module load time.
+ */
 export interface MultiQuerySeparatorDeps {
     ViewPlugin: {
         fromClass<V extends object>(

--- a/packages/nosql-language-service/src/providers/monaco/multiQueryDecorator.ts
+++ b/packages/nosql-language-service/src/providers/monaco/multiQueryDecorator.ts
@@ -94,7 +94,6 @@ export class MonacoMultiQueryDecorator implements Disposable {
         options: {
             languageId?: string;
             decorationDelay?: number;
-            separatorSpacing?: number;
             highlightActiveBlock?: boolean;
         } = {},
     ) {

--- a/packages/nosql-language-service/src/providers/monaco/register.ts
+++ b/packages/nosql-language-service/src/providers/monaco/register.ts
@@ -75,13 +75,23 @@ export function registerCosmosDbSql(
         );
     }
 
-    disposables.push(monaco.languages.registerFoldingRangeProvider(langId, new MonacoFoldingRangeProvider(service)));
-    disposables.push(
-        new MonacoMultiQueryDecorator(monaco, service, {
-            languageId: langId,
-            decorationDelay: options.diagnosticDelay,
-        }),
-    );
+    const multiQuery = service.multiQuery;
+
+    if (options.folding ?? multiQuery) {
+        disposables.push(
+            monaco.languages.registerFoldingRangeProvider(langId, new MonacoFoldingRangeProvider(service)),
+        );
+    }
+
+    if (options.multiQueryDecorations ?? multiQuery) {
+        disposables.push(
+            new MonacoMultiQueryDecorator(monaco, service, {
+                languageId: langId,
+                decorationDelay: options.decorationDelay ?? options.diagnosticDelay,
+                highlightActiveBlock: options.highlightActiveBlock,
+            }),
+        );
+    }
 
     return {
         dispose() {

--- a/packages/nosql-language-service/src/providers/monaco/types.ts
+++ b/packages/nosql-language-service/src/providers/monaco/types.ts
@@ -13,30 +13,100 @@ import { DiagnosticSeverity as DsSeverity } from '../../services/types.js';
 export type MonacoNamespace = typeof monacoEditor;
 
 export interface MonacoRegistrationOptions {
-    /** @default "cosmosdb-sql" */
+    /**
+     * Monaco language id to register providers against. Must match the id
+     * declared in your `monaco.languages.register({ id })` (or will be
+     * auto-registered if no language with this id exists yet).
+     * @default "cosmosdb-sql"
+     */
     languageId?: string;
-    /** @default true */
+    /**
+     * Register the autocomplete provider (keywords, functions, schema fields,
+     * aliases). Disable if your host already provides completions.
+     * @default true
+     */
     completions?: boolean;
-    /** @default true */
+    /**
+     * Push parser errors and warnings as Monaco markers. Disable for read-only
+     * viewers where you don't want the gutter to show squiggles.
+     * @default true
+     */
     diagnostics?: boolean;
-    /** @default true */
+    /**
+     * Register hover documentation for keywords, functions, and schema fields.
+     * @default true
+     */
     hover?: boolean;
-    /** @default true */
+    /**
+     * Register function signature help (parameter hints) while typing inside
+     * a function call.
+     * @default true
+     */
     signatureHelp?: boolean;
-    /** @default true */
+    /**
+     * Register the document formatter (`Format Document` command and
+     * `editor.formatOnSave` integration).
+     * @default true
+     */
     formatting?: boolean;
-    /** @default true */
+    /**
+     * Install the Monarch tokenizer and language configuration (brackets,
+     * comments, auto-closing pairs). Disable if your host registers its own
+     * tokenizer or uses a different syntax highlighter.
+     * @default true
+     */
     monarchTokenizer?: boolean;
-    /** @default 300 */
+    /**
+     * Register the folding-range provider for multi-query documents.
+     * Each semicolon-separated query becomes a foldable region.
+     * @default service.multiQuery
+     */
+    folding?: boolean;
+    /**
+     * Render multi-query separator lines and the active-block bar in the gutter.
+     * @default service.multiQuery
+     */
+    multiQueryDecorations?: boolean;
+    /**
+     * Highlight the query block under the cursor.
+     * Only relevant when `multiQueryDecorations` is enabled.
+     * @default true
+     */
+    highlightActiveBlock?: boolean;
+    /**
+     * Debounce (in ms) between the last edit and pushing diagnostic markers.
+     * Higher values reduce parser load on continuous typing; lower values
+     * make errors appear faster.
+     * @default 300
+     */
     diagnosticDelay?: number;
+    /**
+     * Debounce (in ms) for redrawing multi-query decorations after edits.
+     * Falls back to `diagnosticDelay` so both pipelines stay in lockstep
+     * unless you explicitly want them different.
+     * @default diagnosticDelay ?? 300
+     */
+    decorationDelay?: number;
 }
 
 export interface MonacoDiagnosticsProviderOptions {
-    /** @default "cosmosdb-sql" */
+    /**
+     * Monaco language id this provider should observe. Models with a
+     * different language are ignored.
+     * @default "cosmosdb-sql"
+     */
     languageId?: string;
-    /** @default "cosmosdb-sql" */
+    /**
+     * Marker `owner` string passed to `editor.setModelMarkers`. Use a
+     * distinct owner per source so other markers on the same model aren't
+     * wiped when this provider updates.
+     * @default "cosmosdb-sql"
+     */
     owner?: string;
-    /** @default 300 */
+    /**
+     * Debounce (in ms) between the last edit and re-running diagnostics.
+     * @default 300
+     */
     diagnosticDelay?: number;
 }
 

--- a/packages/nosql-language-service/src/providers/vscode/register.ts
+++ b/packages/nosql-language-service/src/providers/vscode/register.ts
@@ -79,18 +79,23 @@ export function registerCosmosDbSql(
         );
     }
 
-    if (typeof vscode.languages.registerFoldingRangeProvider === 'function') {
+    const multiQuery = service.multiQuery;
+
+    if ((options.folding ?? multiQuery) && typeof vscode.languages.registerFoldingRangeProvider === 'function') {
         disposables.push(
             vscode.languages.registerFoldingRangeProvider(selector, new VSCodeFoldingRangeProvider(vscode, service)),
         );
     }
 
-    disposables.push(
-        new VSCodeMultiQueryDecorator(vscode, service, {
-            languageId: langId,
-            decorationDelay: options.decorationDelay ?? options.diagnosticDelay,
-        }),
-    );
+    if (options.multiQueryDecorations ?? multiQuery) {
+        disposables.push(
+            new VSCodeMultiQueryDecorator(vscode, service, {
+                languageId: langId,
+                decorationDelay: options.decorationDelay ?? options.diagnosticDelay,
+                highlightActiveBlock: options.highlightActiveBlock,
+            }),
+        );
+    }
 
     const composite: Disposable = {
         dispose() {

--- a/packages/nosql-language-service/src/providers/vscode/types.ts
+++ b/packages/nosql-language-service/src/providers/vscode/types.ts
@@ -13,30 +13,93 @@ import { DiagnosticSeverity as DsSeverity } from '../../services/types.js';
 export type VSCodeNamespace = typeof vscodeApi;
 
 export interface VSCodeRegistrationOptions {
-    /** @default "cosmosdb-sql" */
+    /**
+     * VS Code language id to register providers against. Must match the
+     * language contribution in your extension's `package.json`.
+     * @default "cosmosdb-sql"
+     */
     languageId?: string;
-    /** @default true */
+    /**
+     * Register the autocomplete provider (keywords, functions, schema fields,
+     * aliases). Disable if your extension already provides completions.
+     * @default true
+     */
     completions?: boolean;
-    /** @default true */
+    /**
+     * Publish parser errors and warnings to a diagnostic collection. Disable
+     * for read-only viewers where you don't want squiggles in the Problems
+     * panel.
+     * @default true
+     */
     diagnostics?: boolean;
-    /** @default true */
+    /**
+     * Register hover documentation for keywords, functions, and schema fields.
+     * @default true
+     */
     hover?: boolean;
-    /** @default true */
+    /**
+     * Register function signature help (parameter hints) while typing inside
+     * a function call.
+     * @default true
+     */
     signatureHelp?: boolean;
-    /** @default true */
+    /**
+     * Register the document formatter (`Format Document` command and
+     * `editor.formatOnSave` integration).
+     * @default true
+     */
     formatting?: boolean;
-    /** @default 300 */
+    /**
+     * Register the folding-range provider for multi-query documents.
+     * Each semicolon-separated query becomes a foldable region.
+     * @default service.multiQuery
+     */
+    folding?: boolean;
+    /**
+     * Render multi-query separator lines and the active-block bar in the gutter.
+     * @default service.multiQuery
+     */
+    multiQueryDecorations?: boolean;
+    /**
+     * Highlight the query block under the cursor.
+     * Only relevant when `multiQueryDecorations` is enabled.
+     * @default true
+     */
+    highlightActiveBlock?: boolean;
+    /**
+     * Debounce (in ms) between the last edit and pushing diagnostics.
+     * Higher values reduce parser load on continuous typing; lower values
+     * make errors appear faster.
+     * @default 300
+     */
     diagnosticDelay?: number;
-    /** @default 300 */
+    /**
+     * Debounce (in ms) for redrawing multi-query decorations after edits.
+     * Falls back to `diagnosticDelay` so both pipelines stay in lockstep
+     * unless you explicitly want them different.
+     * @default diagnosticDelay ?? 300
+     */
     decorationDelay?: number;
 }
 
 export interface VSCodeDiagnosticsProviderOptions {
-    /** @default "cosmosdb-sql" */
+    /**
+     * VS Code language id this provider should observe. Documents with a
+     * different language are ignored.
+     * @default "cosmosdb-sql"
+     */
     languageId?: string;
-    /** @default "cosmosdb-sql" */
+    /**
+     * Name of the `DiagnosticCollection` created for these diagnostics.
+     * Use a distinct name per source so other diagnostics on the same
+     * document aren't wiped when this provider updates.
+     * @default "cosmosdb-sql"
+     */
     collectionName?: string;
-    /** @default 300 */
+    /**
+     * Debounce (in ms) between the last edit and re-running diagnostics.
+     * @default 300
+     */
     diagnosticDelay?: number;
 }
 

--- a/packages/nosql-language-service/src/services/SqlLanguageService.ts
+++ b/packages/nosql-language-service/src/services/SqlLanguageService.ts
@@ -65,6 +65,11 @@ export class SqlLanguageService {
         this.host = host ?? {};
     }
 
+    /** Whether the host enabled multi-query document support. */
+    get multiQuery(): boolean {
+        return !!this.host.multiQuery;
+    }
+
     // ─── Multi-query document ──────────────────────────────
 
     /**


### PR DESCRIPTION
Two complementary cleanups on the language-service providers:
* CodeMirror: remove the unused `separatorClass` option from `createMultiQuerySeparatorExtension` so the three providers (CodeMirror / Monaco / VS Code) expose a symmetric, knob-free separator API. The class name is hardcoded, matching the Monaco/VS Code adapters which never exposed this knob either. The single test that exercised the option is removed; existing behaviour tests cover the default class.
* Monaco / VS Code / CodeMirror options: expand JSDoc on every `*RegistrationOptions` / `*Options` field so hosts can see at a glance what each knob does and when to disable it. Adds new options on the Monaco side: `folding`, `multiQueryDecorations`, `highlightActiveBlock`, `decorationDelay` (with sensible defaults that fall back to `service.multiQuery` / `diagnosticDelay`).
