### PR TITLE
Backport #3016: fix(rbac): Refactor Cosmos DB Control Plane Implementation

### DIFF
--- a/src/commands/createContainer/CosmosDBExecuteStep.ts
+++ b/src/commands/createContainer/CosmosDBExecuteStep.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PartitionKeyDefinitionVersion, PartitionKeyKind, type RequestOptions } from '@azure/cosmos';
 import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
-import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
+import { getControlPlane } from '../../cosmosdb/controlPlane';
 import { ext } from '../../extensionVariables';
 import { type CreateContainerWizardContext } from './CreateContainerWizardContext';
 
@@ -14,37 +13,22 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateContainerW
     public priority: number = 100;
 
     public async execute(context: CreateContainerWizardContext): Promise<void> {
-        const options: RequestOptions = {};
-        const { endpoint, credentials, isEmulator } = context.accountInfo;
         const { containerName, partitionKey, throughput, databaseId, nodeId } = context;
-
-        if (throughput !== 0) {
-            options.offerThroughput = throughput;
-        }
 
         return ext.state.showCreatingChild(
             nodeId,
             l10n.t('Creating "{nodeName}"…', { nodeName: containerName! }),
             async () => {
                 await new Promise((resolve) => setTimeout(resolve, 250));
-
-                const partitionKeyDefinition = {
-                    paths: partitionKey?.paths ?? [],
-                    kind:
-                        (partitionKey?.kind ?? (partitionKey?.paths?.length ?? 0) > 1)
-                            ? PartitionKeyKind.MultiHash // Multi-hash partition key if there are sub-partitions
-                            : PartitionKeyKind.Hash, // Hash partition key if there is only one partition
-                    version: PartitionKeyDefinitionVersion.V2,
-                };
-
-                const containerDefinition = {
-                    id: containerName,
-                    partitionKey: partitionKeyDefinition,
-                };
-
-                await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
-                    await cosmosClient.database(databaseId).containers.create(containerDefinition, options);
-                });
+                const controlPlane = getControlPlane(context.accountInfo);
+                await controlPlane.createContainer(
+                    databaseId,
+                    {
+                        id: containerName,
+                        partitionKey,
+                    },
+                    throughput,
+                );
             },
         );
     }

--- a/src/commands/createDatabase/CosmosDBExecuteStep.ts
+++ b/src/commands/createDatabase/CosmosDBExecuteStep.ts
@@ -5,7 +5,7 @@
 
 import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
-import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
+import { getControlPlane } from '../../cosmosdb/controlPlane';
 import { ext } from '../../extensionVariables';
 import { type CreateDatabaseWizardContext } from './CreateDatabaseWizardContext';
 
@@ -13,7 +13,6 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateDatabaseWi
     public priority: number = 100;
 
     public async execute(context: CreateDatabaseWizardContext): Promise<void> {
-        const { endpoint, credentials, isEmulator } = context.accountInfo;
         const { databaseName, nodeId } = context;
 
         return ext.state.showCreatingChild(
@@ -21,10 +20,8 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateDatabaseWi
             l10n.t('Creating "{nodeName}"…', { nodeName: databaseName! }),
             async () => {
                 await new Promise((resolve) => setTimeout(resolve, 250));
-
-                await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
-                    await cosmosClient.databases.create({ id: databaseName });
-                });
+                const controlPlane = getControlPlane(context.accountInfo);
+                await controlPlane.createDatabase(databaseName!);
             },
         );
     }

--- a/src/commands/createStoredProcedure/CosmosDBExecuteStep.ts
+++ b/src/commands/createStoredProcedure/CosmosDBExecuteStep.ts
@@ -8,13 +8,13 @@ import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
+import { nonNullProp } from '../../utils/nonNull';
 import { type CreateStoredProcedureWizardContext } from './CreateStoredProcedureWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateStoredProcedureWizardContext> {
     public priority: number = 100;
 
     public async execute(context: CreateStoredProcedureWizardContext): Promise<void> {
-        const { endpoint, credentials, isEmulator } = context.accountInfo;
         const { containerId, databaseId, storedProcedureBody, storedProcedureName, nodeId } = context;
 
         return ext.state.showCreatingChild(
@@ -28,13 +28,12 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateStoredProc
                     body: storedProcedureBody!,
                 };
 
-                await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
-                    const response = await cosmosClient
+                context.response = await withClaimsChallengeHandling(context.accountInfo, async (client) => {
+                    const response = await client
                         .database(databaseId)
                         .container(containerId)
                         .scripts.storedProcedures.create(body);
-
-                    context.response = response.resource;
+                    return nonNullProp(response, 'resource');
                 });
             },
         );

--- a/src/commands/createTrigger/CosmosDBExecuteStep.ts
+++ b/src/commands/createTrigger/CosmosDBExecuteStep.ts
@@ -8,13 +8,13 @@ import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
+import { nonNullProp } from '../../utils/nonNull';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateTriggerWizardContext> {
     public priority: number = 100;
 
     public async execute(context: CreateTriggerWizardContext): Promise<void> {
-        const { endpoint, credentials, isEmulator } = context.accountInfo;
         const { containerId, databaseId, triggerBody, triggerName, triggerOperation, triggerType, nodeId } = context;
 
         return ext.state.showCreatingChild(
@@ -30,14 +30,12 @@ export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateTriggerWiz
                     triggerOperation: triggerOperation!,
                 };
 
-                await withClaimsChallengeHandling(endpoint, credentials, isEmulator, async (cosmosClient) => {
-                    // Create the trigger using the Cosmos DB client
-                    const response = await cosmosClient
+                context.response = await withClaimsChallengeHandling(context.accountInfo, async (client) => {
+                    const response = await client
                         .database(databaseId)
                         .container(containerId)
                         .scripts.triggers.create(body);
-
-                    context.response = response.resource;
+                    return nonNullProp(response, 'resource');
                 });
             },
         );

--- a/src/commands/deleteContainer/deleteContainer.ts
+++ b/src/commands/deleteContainer/deleteContainer.ts
@@ -7,7 +7,7 @@ import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
 import * as l10n from '@vscode/l10n';
 import { API } from '../../AzureDBExperiences';
-import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
+import { getControlPlane } from '../../cosmosdb/controlPlane';
 import { ext } from '../../extensionVariables';
 import { type CosmosDBContainerResourceItem } from '../../tree/cosmosdb/CosmosDBContainerResourceItem';
 import { getConfirmationAsInSettings } from '../../utils/dialogs/getConfirmation';
@@ -53,11 +53,8 @@ export async function cosmosDBDeleteContainer(
     }
 
     try {
-        const success = await deleteContainer(node);
-
-        if (success) {
-            showConfirmationAsInSettings(successMessage);
-        }
+        await deleteContainer(node);
+        showConfirmationAsInSettings(successMessage);
     } finally {
         const lastSlashIndex = node.id.lastIndexOf('/');
         let parentId = node.id;
@@ -68,17 +65,9 @@ export async function cosmosDBDeleteContainer(
     }
 }
 
-async function deleteContainer(node: CosmosDBContainerResourceItem): Promise<boolean> {
-    let success = false;
+async function deleteContainer(node: CosmosDBContainerResourceItem): Promise<void> {
     await ext.state.showDeleting(node.id, async () => {
-        await withClaimsChallengeHandling(node.model.accountInfo, async (cosmosClient) => {
-            const response = await cosmosClient
-                .database(node.model.database.id)
-                .container(node.model.container.id)
-                .delete();
-            success = response.statusCode === 204;
-        });
+        const controlPlane = getControlPlane(node.model.accountInfo);
+        await controlPlane.deleteContainer(node.model.database.id, node.model.container.id);
     });
-
-    return success;
 }

--- a/src/commands/deleteDatabase/deleteDatabase.ts
+++ b/src/commands/deleteDatabase/deleteDatabase.ts
@@ -6,7 +6,7 @@
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
 import * as l10n from '@vscode/l10n';
-import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
+import { getControlPlane } from '../../cosmosdb/controlPlane';
 import { ext } from '../../extensionVariables';
 import { type CosmosDBDatabaseResourceItem } from '../../tree/cosmosdb/CosmosDBDatabaseResourceItem';
 import { getConfirmationAsInSettings } from '../../utils/dialogs/getConfirmation';
@@ -44,11 +44,8 @@ export async function cosmosDBDeleteDatabase(
     }
 
     try {
-        const success = await deleteDatabase(node);
-
-        if (success) {
-            showConfirmationAsInSettings(l10n.t('The "{databaseId}" database has been deleted.', { databaseId }));
-        }
+        await deleteDatabase(node);
+        showConfirmationAsInSettings(l10n.t('The "{databaseId}" database has been deleted.', { databaseId }));
     } finally {
         const lastSlashIndex = node.id.lastIndexOf('/');
         let parentId = node.id;
@@ -59,14 +56,9 @@ export async function cosmosDBDeleteDatabase(
     }
 }
 
-async function deleteDatabase(node: CosmosDBDatabaseResourceItem): Promise<boolean> {
-    let success = false;
+async function deleteDatabase(node: CosmosDBDatabaseResourceItem): Promise<void> {
     await ext.state.showDeleting(node.id, async () => {
-        await withClaimsChallengeHandling(node.model.accountInfo, async (cosmosClient) => {
-            const response = await cosmosClient.database(node.model.database.id).delete();
-            success = response.statusCode === 204;
-        });
+        const controlPlane = getControlPlane(node.model.accountInfo);
+        await controlPlane.deleteDatabase(node.model.database.id);
     });
-
-    return success;
 }

--- a/src/commands/deleteStoredProcedure/deleteStoredProcedure.ts
+++ b/src/commands/deleteStoredProcedure/deleteStoredProcedure.ts
@@ -49,8 +49,8 @@ export async function cosmosDBDeleteStoredProcedure(
     try {
         let success = false;
         await ext.state.showDeleting(node.id, async () => {
-            await withClaimsChallengeHandling(node.model.accountInfo, async (cosmosClient) => {
-                const response = await cosmosClient
+            await withClaimsChallengeHandling(node.model.accountInfo, async (client) => {
+                const response = await client
                     .database(databaseId)
                     .container(containerId)
                     .scripts.storedProcedure(procedureId)

--- a/src/commands/openNoSqlQueryEditor/openNoSqlQueryEditor.ts
+++ b/src/commands/openNoSqlQueryEditor/openNoSqlQueryEditor.ts
@@ -6,7 +6,7 @@
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
 import { API } from '../../AzureDBExperiences';
-import { type NoSqlQueryConnection } from '../../cosmosdb/NoSqlQueryConnection';
+import { createNoSqlQueryConnection, type NoSqlQueryConnection } from '../../cosmosdb/NoSqlQueryConnection';
 import { QueryEditorTab } from '../../panels/QueryEditorTab';
 import { type CosmosDBContainerResourceItem } from '../../tree/cosmosdb/CosmosDBContainerResourceItem';
 import { type CosmosDBItemsResourceItem } from '../../tree/cosmosdb/CosmosDBItemsResourceItem';
@@ -31,13 +31,11 @@ export async function openNoSqlQueryEditor(
         }
 
         context.telemetry.properties.experience = node.experience.api;
-        connection = getConnectionFromNode(node);
+        connection = createNoSqlQueryConnection(node);
     } else if (isTreeElementWithExperience(nodeOrConnection)) {
         // Case 2: Input is a container node (using proper type guard)
         context.telemetry.properties.experience = nodeOrConnection.experience.api;
-        connection = getConnectionFromNode(
-            nodeOrConnection as CosmosDBContainerResourceItem | CosmosDBItemsResourceItem,
-        );
+        connection = createNoSqlQueryConnection(nodeOrConnection);
     } else {
         // Case 3: Input is already a connection
         context.telemetry.properties.experience = API.Core;
@@ -45,17 +43,4 @@ export async function openNoSqlQueryEditor(
     }
 
     QueryEditorTab.render(connection);
-}
-
-// Helper function to extract connection from a container node
-function getConnectionFromNode(node: CosmosDBContainerResourceItem | CosmosDBItemsResourceItem): NoSqlQueryConnection {
-    const accountInfo = node.model.accountInfo;
-
-    return {
-        databaseId: node.model.database.id,
-        containerId: node.model.container.id,
-        endpoint: accountInfo.endpoint,
-        credentials: accountInfo.credentials,
-        isEmulator: accountInfo.isEmulator,
-    };
 }

--- a/src/commands/viewOffer/viewOffer.ts
+++ b/src/commands/viewOffer/viewOffer.ts
@@ -5,7 +5,7 @@
 
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
-import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
+import { getControlPlane } from '../../cosmosdb/controlPlane';
 import { type CosmosDBContainerResourceItem } from '../../tree/cosmosdb/CosmosDBContainerResourceItem';
 import { type CosmosDBDatabaseResourceItem } from '../../tree/cosmosdb/CosmosDBDatabaseResourceItem';
 import { pickAppResource } from '../../utils/pickItem/pickAppResource';
@@ -28,10 +28,13 @@ export async function cosmosDBViewDatabaseOffer(context: IActionContext, node?: 
     const accountInfo = node.model.accountInfo;
     const databaseId = node.model.database.id;
 
-    const offer = await withClaimsChallengeHandling(accountInfo, async (cosmosClient) =>
-        cosmosClient.database(databaseId).readOffer(),
+    const controlPlane = getControlPlane(accountInfo);
+    const offer = await controlPlane.readDatabaseThroughput(databaseId);
+    await vscodeUtil.showNewFile(
+        JSON.stringify(offer?.raw ?? offer ?? {}, undefined, 2),
+        `offer of ${databaseId}`,
+        '.json',
     );
-    await vscodeUtil.showNewFile(JSON.stringify(offer.resource, undefined, 2), `offer of ${databaseId}`, '.json');
 }
 
 export async function cosmosDBViewContainerOffer(context: IActionContext, node?: CosmosDBContainerResourceItem) {
@@ -52,22 +55,13 @@ export async function cosmosDBViewContainerOffer(context: IActionContext, node?:
     const databaseId = node.model.database.id;
     const containerId = node.model.container.id;
 
-    await withClaimsChallengeHandling(accountInfo, async (cosmosClient) => {
-        const offer = await cosmosClient.database(databaseId).container(containerId).readOffer();
-
-        if (!offer.resource) {
-            const dbOffer = await cosmosClient.database(databaseId).readOffer();
-            await vscodeUtil.showNewFile(
-                JSON.stringify(dbOffer.resource, undefined, 2),
-                `offer of ${databaseId}`,
-                '.json',
-            );
-        } else {
-            await vscodeUtil.showNewFile(
-                JSON.stringify(offer.resource, undefined, 2),
-                `offer of ${containerId}`,
-                '.json',
-            );
-        }
-    });
+    const controlPlane = getControlPlane(accountInfo);
+    const offer = await controlPlane.readContainerThroughput(databaseId, containerId);
+    // The control plane already falls back to the database offer for shared-throughput
+    // containers; the resulting payload is what the user sees.
+    await vscodeUtil.showNewFile(
+        JSON.stringify(offer?.raw ?? offer ?? {}, undefined, 2),
+        `offer of ${containerId}`,
+        '.json',
+    );
 }

--- a/src/cosmosdb/NoSqlQueryConnection.ts
+++ b/src/cosmosdb/NoSqlQueryConnection.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
-import { AzExtResourceType } from '@microsoft/vscode-azureresources-api';
+import { AzExtResourceType, type AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import { type CosmosDBContainerResourceItem } from '../tree/cosmosdb/CosmosDBContainerResourceItem';
 import { type CosmosDBItemResourceItem } from '../tree/cosmosdb/CosmosDBItemResourceItem';
 import { type CosmosDBItemsResourceItem } from '../tree/cosmosdb/CosmosDBItemsResourceItem';
@@ -13,6 +13,24 @@ import { type CosmosDBCredential } from './CosmosDBCredential';
 
 export type NoSqlQueryConnection = {
     accountId?: string; // Optional, used to identify the node in the tree
+    /**
+     * Cosmos DB account name. Populated from the source account when the
+     * connection is created from a tree node; required by ARM control-plane
+     * operations.
+     */
+    accountName?: string;
+    /**
+     * Azure subscription context. Populated only for Azure-signed-in accounts;
+     * undefined for the local emulator and workspace-attached connection-string
+     * accounts. Required (together with {@link resourceGroup} and
+     * {@link accountName}) for ARM control-plane operations.
+     */
+    subscription?: AzureSubscription;
+    /**
+     * Resource group name for the Cosmos DB account. Populated together with
+     * {@link subscription}.
+     */
+    resourceGroup?: string;
     databaseId: string;
     containerId: string;
     endpoint: string;
@@ -46,6 +64,9 @@ export function createNoSqlQueryConnection(
 
     return {
         accountId: accountInfo.id,
+        accountName: accountInfo.name,
+        subscription: accountInfo.subscription,
+        resourceGroup: accountInfo.resourceGroup,
         databaseId: databaseId,
         containerId: containerId,
         endpoint: accountInfo.endpoint,

--- a/src/cosmosdb/controlPlane/ArmCosmosDBControlPlane.ts
+++ b/src/cosmosdb/controlPlane/ArmCosmosDBControlPlane.ts
@@ -1,0 +1,263 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    type CosmosDBManagementClient,
+    type SqlContainerCreateUpdateParameters,
+    type SqlContainerGetResults,
+    type SqlDatabaseGetResults,
+    type ThroughputSettingsGetResults,
+} from '@azure/arm-cosmosdb';
+import { PartitionKeyDefinitionVersion, PartitionKeyKind, type ContainerDefinition } from '@azure/cosmos';
+import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
+import * as l10n from '@vscode/l10n';
+import { type ContainerResource, type DatabaseResource } from '../../tree/cosmosdb/models/CosmosDBTypes';
+import { createCosmosDBManagementClient } from '../../utils/azureClients';
+import { type CosmosDBControlPlane, type ThroughputResource } from './CosmosDBControlPlane';
+
+/**
+ * Control-plane implementation that uses the Azure Resource Manager
+ * (`@azure/arm-cosmosdb`) `sqlResources` operations. Required for accounts
+ * configured with native data-plane RBAC where data-plane control operations
+ * are rejected by the service. Available only for Azure-signed-in accounts
+ * (i.e. an `AccountInfo` with both `subscription` and `resourceGroup`).
+ */
+export class ArmCosmosDBControlPlane implements CosmosDBControlPlane {
+    private armClientPromise?: Promise<CosmosDBManagementClient>;
+
+    public constructor(
+        private readonly subscription: AzureSubscription,
+        private readonly resourceGroup: string,
+        private readonly accountName: string,
+    ) {}
+
+    public async listDatabases(): Promise<DatabaseResource[]> {
+        const client = await this.getArmClient();
+        const items: DatabaseResource[] = [];
+        for await (const db of client.sqlResources.listSqlDatabases(this.resourceGroup, this.accountName)) {
+            items.push(toDatabaseResource(db));
+        }
+        return items;
+    }
+
+    public async createDatabase(databaseId: string): Promise<DatabaseResource> {
+        const client = await this.getArmClient();
+        const response = await client.sqlResources.beginCreateUpdateSqlDatabaseAndWait(
+            this.resourceGroup,
+            this.accountName,
+            databaseId,
+            { resource: { id: databaseId }, options: {} },
+        );
+        return toDatabaseResource(response);
+    }
+
+    public async deleteDatabase(databaseId: string): Promise<void> {
+        const client = await this.getArmClient();
+        await client.sqlResources.beginDeleteSqlDatabaseAndWait(this.resourceGroup, this.accountName, databaseId);
+    }
+
+    public async listContainers(databaseId: string): Promise<ContainerResource[]> {
+        const client = await this.getArmClient();
+        const items: ContainerResource[] = [];
+        for await (const c of client.sqlResources.listSqlContainers(this.resourceGroup, this.accountName, databaseId)) {
+            items.push(toContainerResource(c));
+        }
+        return items;
+    }
+
+    public async createContainer(
+        databaseId: string,
+        definition: ContainerDefinition,
+        throughput?: number,
+    ): Promise<ContainerResource> {
+        const client = await this.getArmClient();
+        const containerId = definition.id!;
+        const partitionKeyPaths = definition.partitionKey?.paths ?? [];
+        const kind =
+            definition.partitionKey?.kind === PartitionKeyKind.MultiHash ||
+            (definition.partitionKey?.kind === undefined && partitionKeyPaths.length > 1)
+                ? PartitionKeyKind.MultiHash
+                : PartitionKeyKind.Hash;
+        const version = definition.partitionKey?.version ?? PartitionKeyDefinitionVersion.V2;
+
+        const parameters: SqlContainerCreateUpdateParameters = {
+            resource: {
+                id: containerId,
+                partitionKey: {
+                    paths: partitionKeyPaths,
+                    kind,
+                    version,
+                },
+                indexingPolicy:
+                    definition.indexingPolicy as SqlContainerCreateUpdateParameters['resource']['indexingPolicy'],
+                defaultTtl: definition.defaultTtl,
+                uniqueKeyPolicy:
+                    definition.uniqueKeyPolicy as SqlContainerCreateUpdateParameters['resource']['uniqueKeyPolicy'],
+                conflictResolutionPolicy:
+                    definition.conflictResolutionPolicy as SqlContainerCreateUpdateParameters['resource']['conflictResolutionPolicy'],
+            },
+            options: throughput && throughput !== 0 ? { throughput } : {},
+        };
+
+        const response = await client.sqlResources.beginCreateUpdateSqlContainerAndWait(
+            this.resourceGroup,
+            this.accountName,
+            databaseId,
+            containerId,
+            parameters,
+        );
+        return toContainerResource(response);
+    }
+
+    public async deleteContainer(databaseId: string, containerId: string): Promise<void> {
+        const client = await this.getArmClient();
+        await client.sqlResources.beginDeleteSqlContainerAndWait(
+            this.resourceGroup,
+            this.accountName,
+            databaseId,
+            containerId,
+        );
+    }
+
+    public async readDatabaseThroughput(databaseId: string): Promise<ThroughputResource | undefined> {
+        const client = await this.getArmClient();
+        try {
+            const response = await client.sqlResources.getSqlDatabaseThroughput(
+                this.resourceGroup,
+                this.accountName,
+                databaseId,
+            );
+            return toThroughputResource(response);
+        } catch (err) {
+            if (isNotFound(err)) {
+                return undefined;
+            }
+            throw err;
+        }
+    }
+
+    public async readContainerThroughput(
+        databaseId: string,
+        containerId: string,
+    ): Promise<ThroughputResource | undefined> {
+        const client = await this.getArmClient();
+        try {
+            const response = await client.sqlResources.getSqlContainerThroughput(
+                this.resourceGroup,
+                this.accountName,
+                databaseId,
+                containerId,
+            );
+            return toThroughputResource(response);
+        } catch (err) {
+            if (!isNotFound(err)) {
+                throw err;
+            }
+        }
+        // Container may inherit throughput from a shared-throughput database.
+        return this.readDatabaseThroughput(databaseId);
+    }
+
+    private getArmClient(): Promise<CosmosDBManagementClient> {
+        if (!this.armClientPromise) {
+            this.armClientPromise = (async () => {
+                const client = await callWithTelemetryAndErrorHandling(
+                    'createCosmosDBManagementClient',
+                    async (context: IActionContext) => {
+                        context.telemetry.suppressIfSuccessful = true;
+                        context.errorHandling.forceIncludeInReportIssueCommand = true;
+                        context.valuesToMask.push(this.subscription.subscriptionId);
+                        return createCosmosDBManagementClient(context, this.subscription);
+                    },
+                );
+                if (!client) {
+                    throw new Error(l10n.t('Failed to connect to Cosmos DB account'));
+                }
+                return client;
+            })();
+        }
+        return this.armClientPromise;
+    }
+}
+
+const EMPTY_RESOURCE_FIELDS = {
+    _rid: '',
+    _self: '',
+    _etag: '',
+    _ts: 0,
+    _attachments: '',
+};
+
+function toDatabaseResource(db: SqlDatabaseGetResults): DatabaseResource {
+    const resource = db.resource;
+    return {
+        id: resource?.id ?? db.name ?? '',
+        ...EMPTY_RESOURCE_FIELDS,
+        _rid: resource?.rid ?? '',
+        _ts: resource?.ts ?? 0,
+        _etag: resource?.etag ?? '',
+    };
+}
+
+function toContainerResource(c: SqlContainerGetResults): ContainerResource {
+    const resource = c.resource;
+    const partitionKey = resource?.partitionKey;
+    return {
+        id: resource?.id ?? c.name ?? '',
+        partitionKey: partitionKey
+            ? {
+                  paths: partitionKey.paths ?? [],
+                  kind: (partitionKey.kind as PartitionKeyKind | undefined) ?? PartitionKeyKind.Hash,
+                  version: (partitionKey.version as PartitionKeyDefinitionVersion | undefined) ?? undefined,
+                  systemKey: partitionKey.systemKey,
+              }
+            : undefined,
+        // The ARM and data-plane SDKs declare these policy types separately
+        // but the runtime shapes are identical. Cast through `unknown` to
+        // bridge them without copying every nested field.
+        indexingPolicy: resource?.indexingPolicy as unknown as ContainerResource['indexingPolicy'],
+        defaultTtl: resource?.defaultTtl,
+        uniqueKeyPolicy: resource?.uniqueKeyPolicy as unknown as ContainerResource['uniqueKeyPolicy'],
+        conflictResolutionPolicy:
+            resource?.conflictResolutionPolicy as unknown as ContainerResource['conflictResolutionPolicy'],
+        ...EMPTY_RESOURCE_FIELDS,
+        _rid: resource?.rid ?? '',
+        _ts: resource?.ts ?? 0,
+        _etag: resource?.etag ?? '',
+    };
+}
+
+function toThroughputResource(response: ThroughputSettingsGetResults): ThroughputResource | undefined {
+    const resource = response.resource;
+    if (!resource) {
+        return { raw: response };
+    }
+    return {
+        throughput: resource.throughput,
+        autoscaleMaxThroughput: resource.autoscaleSettings?.maxThroughput,
+        minimumThroughput: parseMinimumThroughput(resource.minimumThroughput),
+        raw: response,
+    };
+}
+
+function parseMinimumThroughput(value: unknown): number | undefined {
+    if (typeof value === 'number') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isNaN(parsed) ? undefined : parsed;
+    }
+    return undefined;
+}
+
+function isNotFound(err: unknown): boolean {
+    if (!err || typeof err !== 'object') {
+        return false;
+    }
+    const e = err as { statusCode?: number; code?: string | number };
+    return e.statusCode === 404 || e.code === 404 || e.code === 'NotFound' || e.code === 'ResourceNotFound';
+}

--- a/src/cosmosdb/controlPlane/CosmosDBControlPlane.ts
+++ b/src/cosmosdb/controlPlane/CosmosDBControlPlane.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type ContainerDefinition } from '@azure/cosmos';
+import { type ContainerResource, type DatabaseResource } from '../../tree/cosmosdb/models/CosmosDBTypes';
+
+/**
+ * A minimal serializable view of a database or container's throughput
+ * configuration. Both the ARM and the data-plane implementation populate the
+ * same DTO so that the consuming UI does not have to know which control-plane
+ * surface produced the value.
+ */
+export interface ThroughputResource {
+    /** Manual provisioned throughput (RU/s). Undefined for autoscale. */
+    throughput?: number;
+    /** Maximum RU/s for autoscale. Undefined for manual throughput. */
+    autoscaleMaxThroughput?: number;
+    /** Minimum throughput allowed for the resource (when reported by the service). */
+    minimumThroughput?: number;
+    /** Free-form raw payload for diagnostic display. */
+    raw?: unknown;
+}
+
+/**
+ * Abstraction over Azure Cosmos DB control-plane operations for the SQL
+ * (NoSQL) API: databases, containers, and throughput. Implementations either
+ * route through the ARM management plane (preferred for Azure-signed-in
+ * accounts) or through the data-plane `CosmosClient` (used for the local
+ * emulator and workspace-attached connection-string accounts where ARM is
+ * not available).
+ *
+ * Stored procedures, triggers, and user-defined functions are intentionally
+ * not included here: they are data-plane resources and callers should access
+ * them through the data-plane `CosmosClient` (see `withClaimsChallengeHandling`).
+ *
+ * Error contract: all methods throw on failure. The data-plane implementation
+ * surfaces `ErrorResponse` from `@azure/cosmos`; the ARM implementation
+ * surfaces `RestError` from `@azure/core-rest-pipeline`. A successful return
+ * (including `void`) means the operation completed; callers do not need to
+ * inspect status codes or response headers. Translating those errors into
+ * user-visible notifications is the responsibility of the surrounding
+ * `callWithTelemetryAndErrorHandling` wrapper used by command handlers.
+ */
+export interface CosmosDBControlPlane {
+    listDatabases(): Promise<DatabaseResource[]>;
+    createDatabase(databaseId: string): Promise<DatabaseResource>;
+    deleteDatabase(databaseId: string): Promise<void>;
+
+    listContainers(databaseId: string): Promise<ContainerResource[]>;
+    createContainer(
+        databaseId: string,
+        definition: ContainerDefinition,
+        throughput?: number,
+    ): Promise<ContainerResource>;
+    deleteContainer(databaseId: string, containerId: string): Promise<void>;
+
+    readDatabaseThroughput(databaseId: string): Promise<ThroughputResource | undefined>;
+    readContainerThroughput(databaseId: string, containerId: string): Promise<ThroughputResource | undefined>;
+}

--- a/src/cosmosdb/controlPlane/CosmosDBSdkControlPlane.ts
+++ b/src/cosmosdb/controlPlane/CosmosDBSdkControlPlane.ts
@@ -1,0 +1,148 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    PartitionKeyDefinitionVersion,
+    PartitionKeyKind,
+    type ContainerDefinition,
+    type ContainerRequest,
+    type CosmosClient,
+    type RequestOptions,
+} from '@azure/cosmos';
+import { type AccountInfo } from '../../tree/cosmosdb/AccountInfo';
+import { type ContainerResource, type DatabaseResource } from '../../tree/cosmosdb/models/CosmosDBTypes';
+import { nonNullProp } from '../../utils/nonNull';
+import { type NoSqlQueryConnection } from '../NoSqlQueryConnection';
+import { withClaimsChallengeHandling } from '../withClaimsChallengeHandling';
+import { type CosmosDBControlPlane, type ThroughputResource } from './CosmosDBControlPlane';
+
+/**
+ * Control-plane implementation that routes every operation through the
+ * Cosmos DB SDK (`CosmosClient`). Used for the local emulator and for
+ * workspace-attached connection-string accounts, where ARM is not reachable.
+ */
+export class CosmosDBSdkControlPlane implements CosmosDBControlPlane {
+    public constructor(private readonly accountInfo: AccountInfo | NoSqlQueryConnection) {}
+
+    private withClient<T>(callback: (client: CosmosClient) => Promise<T>): Promise<T> {
+        return withClaimsChallengeHandling(
+            this.accountInfo.endpoint,
+            this.accountInfo.credentials,
+            this.accountInfo.isEmulator,
+            callback,
+        );
+    }
+
+    public async listDatabases(): Promise<DatabaseResource[]> {
+        return this.withClient(async (client) => {
+            const result = await client.databases.readAll().fetchAll();
+            return result.resources;
+        });
+    }
+
+    public async createDatabase(databaseId: string): Promise<DatabaseResource> {
+        return this.withClient(async (client) => {
+            const response = await client.databases.create({ id: databaseId });
+            return nonNullProp(response, 'resource');
+        });
+    }
+
+    public async deleteDatabase(databaseId: string): Promise<void> {
+        await this.withClient(async (client) => {
+            await client.database(databaseId).delete();
+        });
+    }
+
+    public async listContainers(databaseId: string): Promise<ContainerResource[]> {
+        return this.withClient(async (client) => {
+            const result = await client.database(databaseId).containers.readAll().fetchAll();
+            return result.resources;
+        });
+    }
+
+    public async createContainer(
+        databaseId: string,
+        definition: ContainerDefinition,
+        throughput?: number,
+    ): Promise<ContainerResource> {
+        const options: RequestOptions = {};
+        if (throughput && throughput !== 0) {
+            options.offerThroughput = throughput;
+        }
+
+        const partitionKeyPaths = definition.partitionKey?.paths ?? [];
+        const partitionKeyDefinition = {
+            paths: partitionKeyPaths,
+            kind:
+                definition.partitionKey?.kind === PartitionKeyKind.MultiHash ||
+                (definition.partitionKey?.kind === undefined && partitionKeyPaths.length > 1)
+                    ? PartitionKeyKind.MultiHash
+                    : PartitionKeyKind.Hash,
+            version: definition.partitionKey?.version ?? PartitionKeyDefinitionVersion.V2,
+        };
+
+        const containerDefinition: ContainerRequest = {
+            ...definition,
+            id: definition.id!,
+            partitionKey: partitionKeyDefinition,
+        };
+
+        return this.withClient(async (client) => {
+            const response = await client.database(databaseId).containers.create(containerDefinition, options);
+            return nonNullProp(response, 'resource');
+        });
+    }
+
+    public async deleteContainer(databaseId: string, containerId: string): Promise<void> {
+        await this.withClient(async (client) => {
+            await client.database(databaseId).container(containerId).delete();
+        });
+    }
+
+    public async readDatabaseThroughput(databaseId: string): Promise<ThroughputResource | undefined> {
+        return this.withClient(async (client) => {
+            const offer = await client.database(databaseId).readOffer();
+            return mapOfferResource(offer.resource);
+        });
+    }
+
+    public async readContainerThroughput(
+        databaseId: string,
+        containerId: string,
+    ): Promise<ThroughputResource | undefined> {
+        return this.withClient(async (client) => {
+            const offer = await client.database(databaseId).container(containerId).readOffer();
+            if (offer.resource) {
+                return mapOfferResource(offer.resource);
+            }
+            // Container may inherit throughput from the database (shared throughput).
+            const dbOffer = await client.database(databaseId).readOffer();
+            return mapOfferResource(dbOffer.resource);
+        });
+    }
+}
+
+function mapOfferResource(offer: unknown): ThroughputResource | undefined {
+    if (!offer || typeof offer !== 'object') {
+        return undefined;
+    }
+    const o = offer as Record<string, unknown>;
+    const content = (o.content ?? {}) as Record<string, unknown>;
+    const offerThroughput = typeof content.offerThroughput === 'number' ? content.offerThroughput : undefined;
+    const autoscale = (content.offerAutopilotSettings ?? {}) as Record<string, unknown>;
+    const autoscaleMaxThroughput = typeof autoscale.maxThroughput === 'number' ? autoscale.maxThroughput : undefined;
+    const minimumThroughput =
+        typeof content.offerMinimumThroughputParameters === 'object' &&
+        content.offerMinimumThroughputParameters !== null &&
+        typeof (content.offerMinimumThroughputParameters as Record<string, unknown>).minimumThroughput === 'number'
+            ? ((content.offerMinimumThroughputParameters as Record<string, unknown>).minimumThroughput as number)
+            : undefined;
+    return {
+        throughput: offerThroughput,
+        autoscaleMaxThroughput,
+        minimumThroughput,
+        raw: offer,
+    };
+}

--- a/src/cosmosdb/controlPlane/getControlPlane.test.ts
+++ b/src/cosmosdb/controlPlane/getControlPlane.test.ts
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
+import { describe, expect, it, vi } from 'vitest';
+import { type AccountInfo } from '../../tree/cosmosdb/AccountInfo';
+import { type NoSqlQueryConnection } from '../NoSqlQueryConnection';
+
+class FakeArmControlPlane {
+    constructor(
+        public subscription: AzureSubscription,
+        public resourceGroup: string,
+        public accountName: string,
+    ) {}
+}
+
+class FakeSdkControlPlane {
+    constructor(public accountInfo: AccountInfo) {}
+}
+
+vi.mock('./ArmCosmosDBControlPlane', () => ({
+    ArmCosmosDBControlPlane: FakeArmControlPlane,
+}));
+
+vi.mock('./CosmosDBSdkControlPlane', () => ({
+    CosmosDBSdkControlPlane: FakeSdkControlPlane,
+}));
+
+const { getControlPlane, getControlPlaneForConnection } = await import('./index');
+
+function makeAccountInfo(overrides: Partial<AccountInfo> = {}): AccountInfo {
+    return {
+        credentials: [],
+        endpoint: 'https://example.documents.azure.com:443/',
+        id: 'test-id',
+        isEmulator: false,
+        isServerless: false,
+        name: 'test-account',
+        ...overrides,
+    };
+}
+
+const fakeSubscription = {
+    subscriptionId: '00000000-0000-0000-0000-000000000000',
+} as unknown as AzureSubscription;
+
+describe('getControlPlane', () => {
+    it('returns ARM control plane for Azure-signed-in account with subscription and resource group', () => {
+        const plane = getControlPlane(
+            makeAccountInfo({
+                subscription: fakeSubscription,
+                resourceGroup: 'rg-test',
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeArmControlPlane);
+        expect((plane as unknown as FakeArmControlPlane).subscription).toBe(fakeSubscription);
+        expect((plane as unknown as FakeArmControlPlane).resourceGroup).toBe('rg-test');
+        expect((plane as unknown as FakeArmControlPlane).accountName).toBe('test-account');
+    });
+
+    it('returns SDK control plane for the local emulator even with subscription and resource group', () => {
+        const plane = getControlPlane(
+            makeAccountInfo({
+                isEmulator: true,
+                subscription: fakeSubscription,
+                resourceGroup: 'rg-test',
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+
+    it('returns SDK control plane for workspace-attached account (no subscription)', () => {
+        const plane = getControlPlane(makeAccountInfo());
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+
+    it('returns SDK control plane when subscription is set but resource group is missing', () => {
+        const plane = getControlPlane(
+            makeAccountInfo({
+                subscription: fakeSubscription,
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+
+    it('returns SDK control plane when resource group is set but subscription is missing', () => {
+        const plane = getControlPlane(
+            makeAccountInfo({
+                resourceGroup: 'rg-test',
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+});
+
+function makeConnection(overrides: Partial<NoSqlQueryConnection> = {}): NoSqlQueryConnection {
+    return {
+        databaseId: 'db1',
+        containerId: 'c1',
+        endpoint: 'https://example.documents.azure.com:443/',
+        credentials: [],
+        isEmulator: false,
+        ...overrides,
+    };
+}
+
+describe('getControlPlaneForConnection', () => {
+    it('returns ARM control plane when connection carries subscription, resource group and account name', () => {
+        const plane = getControlPlaneForConnection(
+            makeConnection({
+                accountName: 'test-account',
+                subscription: fakeSubscription,
+                resourceGroup: 'rg-test',
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeArmControlPlane);
+        expect((plane as unknown as FakeArmControlPlane).subscription).toBe(fakeSubscription);
+        expect((plane as unknown as FakeArmControlPlane).resourceGroup).toBe('rg-test');
+        expect((plane as unknown as FakeArmControlPlane).accountName).toBe('test-account');
+    });
+
+    it('returns SDK control plane for the local emulator even with full Azure context', () => {
+        const plane = getControlPlaneForConnection(
+            makeConnection({
+                isEmulator: true,
+                accountName: 'test-account',
+                subscription: fakeSubscription,
+                resourceGroup: 'rg-test',
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+
+    it('returns SDK control plane for workspace-attached connection (no Azure context)', () => {
+        const plane = getControlPlaneForConnection(makeConnection());
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+
+    it('returns SDK control plane when account name is missing', () => {
+        const plane = getControlPlaneForConnection(
+            makeConnection({
+                subscription: fakeSubscription,
+                resourceGroup: 'rg-test',
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+
+    it('returns SDK control plane when subscription is missing', () => {
+        const plane = getControlPlaneForConnection(
+            makeConnection({
+                accountName: 'test-account',
+                resourceGroup: 'rg-test',
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+
+    it('returns SDK control plane when resource group is missing', () => {
+        const plane = getControlPlaneForConnection(
+            makeConnection({
+                accountName: 'test-account',
+                subscription: fakeSubscription,
+            }),
+        );
+        expect(plane).toBeInstanceOf(FakeSdkControlPlane);
+    });
+});

--- a/src/cosmosdb/controlPlane/index.ts
+++ b/src/cosmosdb/controlPlane/index.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type AccountInfo } from '../../tree/cosmosdb/AccountInfo';
+import { type NoSqlQueryConnection } from '../NoSqlQueryConnection';
+import { ArmCosmosDBControlPlane } from './ArmCosmosDBControlPlane';
+import { type CosmosDBControlPlane } from './CosmosDBControlPlane';
+import { CosmosDBSdkControlPlane } from './CosmosDBSdkControlPlane';
+
+export { type CosmosDBControlPlane, type ThroughputResource } from './CosmosDBControlPlane';
+
+/**
+ * Returns the appropriate control-plane implementation for an account.
+ *
+ * - Azure-signed-in accounts (with a known subscription and resource group)
+ *   use the ARM management plane. This is required for accounts configured
+ *   with native data-plane RBAC, where data-plane control operations are
+ *   rejected by the service (see issue #2990).
+ * - The local emulator and workspace-attached connection-string accounts use
+ *   the Cosmos DB SDK (`CosmosClient`) because ARM is not reachable for them.
+ *
+ * TODO: workspace-attached accounts that point at a real Azure Cosmos DB
+ * account configured with strict native data-plane RBAC will still fall into
+ * the SDK branch (no subscription/resource-group context is captured from a
+ * connection string), so database/container/throughput operations will be
+ * rejected by the service. Resolving this requires either prompting the user
+ * to associate the attached account with an Azure subscription or extending
+ * the connection-string import flow to capture that context.
+ */
+export function getControlPlane(accountInfo: AccountInfo): CosmosDBControlPlane {
+    if (!accountInfo.isEmulator && accountInfo.subscription && accountInfo.resourceGroup) {
+        return new ArmCosmosDBControlPlane(accountInfo.subscription, accountInfo.resourceGroup, accountInfo.name);
+    }
+    return new CosmosDBSdkControlPlane(accountInfo);
+}
+
+/**
+ * Returns the appropriate control-plane implementation for a query-editor
+ * connection. Mirrors {@link getControlPlane} but takes a
+ * {@link NoSqlQueryConnection}, which carries an optional Azure subscription
+ * and resource group when the connection originated from an Azure-signed-in
+ * account.
+ */
+export function getControlPlaneForConnection(connection: NoSqlQueryConnection): CosmosDBControlPlane {
+    if (!connection.isEmulator && connection.subscription && connection.resourceGroup && connection.accountName) {
+        return new ArmCosmosDBControlPlane(connection.subscription, connection.resourceGroup, connection.accountName);
+    }
+    return new CosmosDBSdkControlPlane(connection);
+}

--- a/src/cosmosdb/fs/StoredProcedureFileDescriptor.ts
+++ b/src/cosmosdb/fs/StoredProcedureFileDescriptor.ts
@@ -29,13 +29,13 @@ export class StoredProcedureFileDescriptor implements EditableFileSystemItem {
     }
 
     public async writeFileContent(_context: IActionContext, content: string): Promise<void> {
-        const replace = await withClaimsChallengeHandling(this.model.accountInfo, async (cosmosClient) =>
-            cosmosClient
+        this.model.procedure = await withClaimsChallengeHandling(this.model.accountInfo, async (client) => {
+            const response = await client
                 .database(this.model.database.id)
                 .container(this.model.container.id)
                 .scripts.storedProcedure(this.model.procedure.id)
-                .replace({ id: this.model.procedure.id, body: content }),
-        );
-        this.model.procedure = nonNullProp(replace, 'resource');
+                .replace({ id: this.model.procedure.id, body: content });
+            return nonNullProp(response, 'resource');
+        });
     }
 }

--- a/src/cosmosdb/fs/TriggerFileDescriptor.ts
+++ b/src/cosmosdb/fs/TriggerFileDescriptor.ts
@@ -48,16 +48,17 @@ export class TriggerFileDescriptor implements EditableFileSystemItem {
     }
 
     public async writeFileContent(context: IActionContext, content: string): Promise<void> {
-        const readResponse = await withClaimsChallengeHandling(this.model.accountInfo, (cosmosClient) =>
-            cosmosClient
+        const existing = await withClaimsChallengeHandling(this.model.accountInfo, async (client) => {
+            const response = await client
                 .database(this.model.database.id)
                 .container(this.model.container.id)
                 .scripts.trigger(this.model.trigger.id)
-                .read(),
-        );
+                .read();
+            return response.resource;
+        });
 
-        let triggerType = readResponse.resource?.triggerType;
-        let triggerOperation = readResponse.resource?.triggerOperation;
+        let triggerType = existing?.triggerType;
+        let triggerOperation = existing?.triggerOperation;
 
         if (!triggerType) {
             triggerType = await getTriggerType(context);
@@ -66,18 +67,18 @@ export class TriggerFileDescriptor implements EditableFileSystemItem {
             triggerOperation = await getTriggerOperation(context);
         }
 
-        const replace = await withClaimsChallengeHandling(this.model.accountInfo, (cosmosClient) =>
-            cosmosClient
+        this.model.trigger = await withClaimsChallengeHandling(this.model.accountInfo, async (client) => {
+            const response = await client
                 .database(this.model.database.id)
                 .container(this.model.container.id)
                 .scripts.trigger(this.model.trigger.id)
                 .replace({
                     id: this.model.trigger.id,
-                    triggerType: triggerType,
-                    triggerOperation: triggerOperation,
+                    triggerType,
+                    triggerOperation,
                     body: content,
-                }),
-        );
-        this.model.trigger = nonNullProp(replace, 'resource');
+                });
+            return nonNullProp(response, 'resource');
+        });
     }
 }

--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -10,7 +10,7 @@ import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import { getThemedIconPath } from '../constants';
 import { getCosmosDBKeyCredential } from '../cosmosdb/CosmosDBCredential';
-import { getCosmosClient } from '../cosmosdb/getCosmosClient';
+import { getControlPlaneForConnection } from '../cosmosdb/controlPlane';
 import { getNoSqlQueryConnection, type NoSqlQueryConnection } from '../cosmosdb/NoSqlQueryConnection';
 import { DocumentSession } from '../cosmosdb/session/DocumentSession';
 import { QuerySession } from '../cosmosdb/session/QuerySession';
@@ -212,13 +212,13 @@ export class QueryEditorTab extends BaseTab {
                 return;
             }
 
-            const cosmosClient = getCosmosClient(this.connection);
-            const databases = await cosmosClient.databases.readAll().fetchAll();
+            const controlPlane = getControlPlaneForConnection(this.connection);
+            const databases = await controlPlane.listDatabases();
             const containers = await Promise.allSettled(
-                databases.resources.map(async (database) => {
-                    const containers = await cosmosClient.database(database.id).containers.readAll().fetchAll();
+                databases.map(async (database) => {
+                    const dbContainers = await controlPlane.listContainers(database.id);
 
-                    return containers.resources.map((container) => [database.id, container.id] as string[]);
+                    return dbContainers.map((container) => [database.id, container.id] as string[]);
                 }),
             );
 

--- a/src/tree/cosmosdb/AccountInfo.ts
+++ b/src/tree/cosmosdb/AccountInfo.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import * as l10n from '@vscode/l10n';
 import { SERVERLESS_CAPABILITY_NAME, wellKnownEmulatorPassword } from '../../constants';
 import {
@@ -23,6 +24,18 @@ export interface AccountInfo {
     isEmulator: boolean;
     isServerless: boolean;
     name: string;
+    /**
+     * Azure subscription context, populated only for Azure-signed-in accounts
+     * (i.e. accounts discovered via the Azure Resources view). Required for
+     * ARM control-plane operations. Undefined for workspace-attached accounts
+     * and for the local emulator.
+     */
+    subscription?: AzureSubscription;
+    /**
+     * Resource group name for the Cosmos DB account. Populated together with
+     * {@link subscription}.
+     */
+    resourceGroup?: string;
 }
 
 function isCosmosDBAttachedAccountModel(account: unknown): account is CosmosDBAttachedAccountModel {
@@ -117,6 +130,8 @@ async function getAccountInfoForResource(account: CosmosDBAccountModel): Promise
         isEmulator: false,
         isServerless,
         name,
+        subscription: account.subscription,
+        resourceGroup,
     };
 }
 

--- a/src/tree/cosmosdb/CosmosDBAccountResourceItem.ts
+++ b/src/tree/cosmosdb/CosmosDBAccountResourceItem.ts
@@ -3,15 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type CosmosClient } from '@azure/cosmos';
 import type * as vscode from 'vscode';
 import { type Experience } from '../../AzureDBExperiences';
 import { getThemeAgnosticIconURI } from '../../constants';
 import { AuthenticationMethod } from '../../cosmosdb/AuthenticationMethod';
+import { getControlPlane } from '../../cosmosdb/controlPlane';
 import { getCosmosDBEntraIdCredential } from '../../cosmosdb/CosmosDBCredential';
 import { getSignedInPrincipalIdForAccountEndpoint } from '../../cosmosdb/utils/azureSessionHelper';
 import { ensureRbacPermissionV2, isRbacException, showRbacPermissionError } from '../../cosmosdb/utils/rbacUtils';
-import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../../extensionVariables';
 import { CosmosDBAccountResourceItemBase } from '../azure-resources-view/cosmosdb/CosmosDBAccountResourceItemBase';
 import { type TreeElement } from '../TreeElement';
@@ -31,9 +30,7 @@ export abstract class CosmosDBAccountResourceItem extends CosmosDBAccountResourc
 
     public async getChildren(): Promise<TreeElement[]> {
         const accountInfo = await getAccountInfo(this.account);
-        const databases = await withClaimsChallengeHandling(accountInfo, async (cosmosClient) =>
-            this.getDatabases(accountInfo, cosmosClient),
-        );
+        const databases = await this.getDatabases(accountInfo);
         const sortedDatabases = databases.sort((a, b) => a.id.localeCompare(b.id));
 
         return this.getChildrenImpl(accountInfo, sortedDatabases);
@@ -56,18 +53,11 @@ export abstract class CosmosDBAccountResourceItem extends CosmosDBAccountResourc
         }
     }
 
-    protected async getDatabases(
-        accountInfo: AccountInfo,
-        cosmosClient: CosmosClient,
-    ): Promise<DatabaseResource[]> | never {
-        const getResources = async () => {
-            const result = await cosmosClient.databases.readAll().fetchAll();
-            return result.resources;
-        };
+    protected async getDatabases(accountInfo: AccountInfo): Promise<DatabaseResource[]> | never {
+        const controlPlane = getControlPlane(accountInfo);
 
         try {
-            // Await is required here to ensure that the error is caught in the catch block
-            return await getResources();
+            return await controlPlane.listDatabases();
         } catch (e) {
             if (e instanceof Error && isRbacException(e) && !this.hasShownRbacNotification) {
                 this.hasShownRbacNotification = true;
@@ -81,7 +71,7 @@ export abstract class CosmosDBAccountResourceItem extends CosmosDBAccountResourc
                     e.message.includes(`[${principalId}]`) &&
                     (await ensureRbacPermissionV2(this.id, this.account.subscription, principalId))
                 ) {
-                    return getResources();
+                    return controlPlane.listDatabases();
                 } else {
                     void showRbacPermissionError(this.id, principalId);
                     ext.outputChannel.error(e);

--- a/src/tree/cosmosdb/CosmosDBDatabaseResourceItem.ts
+++ b/src/tree/cosmosdb/CosmosDBDatabaseResourceItem.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type CosmosClient } from '@azure/cosmos';
 import { createContextValue, createGenericElement } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { type Experience } from '../../AzureDBExperiences';
-import { withClaimsChallengeHandling } from '../../cosmosdb/withClaimsChallengeHandling';
+import { getControlPlane } from '../../cosmosdb/controlPlane';
 import { countExperienceUsageForSurvey } from '../../utils/survey';
 import { ExperienceKind, UsageImpact } from '../../utils/surveyTypes';
 import { type TreeElement } from '../TreeElement';
@@ -32,9 +31,8 @@ export abstract class CosmosDBDatabaseResourceItem
     }
 
     async getChildren(): Promise<TreeElement[]> {
-        const containers = await withClaimsChallengeHandling(this.model.accountInfo, async (cosmosClient) =>
-            this.getContainers(cosmosClient),
-        );
+        const controlPlane = getControlPlane(this.model.accountInfo);
+        const containers = await controlPlane.listContainers(this.model.database.id);
         const sortedContainers = containers.sort((a, b) => a.id.localeCompare(b.id));
 
         if (containers.length === 0) {
@@ -62,11 +60,6 @@ export abstract class CosmosDBDatabaseResourceItem
             label: this.model.database.id,
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
         };
-    }
-
-    protected async getContainers(cosmosClient: CosmosClient): Promise<ContainerResource[]> {
-        const result = await cosmosClient.database(this.model.database.id).containers.readAll().fetchAll();
-        return result.resources;
     }
 
     protected abstract getChildrenImpl(containers: ContainerResource[]): Promise<TreeElement[]>;

--- a/src/tree/cosmosdb/CosmosDBStoredProceduresResourceItem.ts
+++ b/src/tree/cosmosdb/CosmosDBStoredProceduresResourceItem.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type CosmosClient } from '@azure/cosmos';
 import { createContextValue } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
@@ -30,9 +29,14 @@ export abstract class CosmosDBStoredProceduresResourceItem
     }
 
     public async getChildren(): Promise<TreeElement[]> {
-        const storedProcedures = await withClaimsChallengeHandling(this.model.accountInfo, async (cosmosClient) =>
-            this.getStoredProcedures(cosmosClient),
-        );
+        const storedProcedures = await withClaimsChallengeHandling(this.model.accountInfo, async (client) => {
+            const result = await client
+                .database(this.model.database.id)
+                .container(this.model.container.id)
+                .scripts.storedProcedures.readAll()
+                .fetchAll();
+            return result.resources;
+        });
         const sortedProcedures = storedProcedures.sort((a, b) => a.id.localeCompare(b.id));
 
         return this.getChildrenImpl(sortedProcedures);
@@ -46,16 +50,6 @@ export abstract class CosmosDBStoredProceduresResourceItem
             label: l10n.t('Stored Procedures'),
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
         };
-    }
-
-    protected async getStoredProcedures(cosmosClient: CosmosClient): Promise<StoredProcedureResource[]> {
-        const result = await cosmosClient
-            .database(this.model.database.id)
-            .container(this.model.container.id)
-            .scripts.storedProcedures.readAll()
-            .fetchAll();
-
-        return result.resources;
     }
 
     protected abstract getChildrenImpl(storedProcedures: StoredProcedureResource[]): Promise<TreeElement[]>;

--- a/src/tree/cosmosdb/CosmosDBTriggersResourceItem.ts
+++ b/src/tree/cosmosdb/CosmosDBTriggersResourceItem.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type CosmosClient } from '@azure/cosmos';
 import { createContextValue } from '@microsoft/vscode-azext-utils';
 import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
@@ -30,9 +29,14 @@ export abstract class CosmosDBTriggersResourceItem
     }
 
     public async getChildren(): Promise<TreeElement[]> {
-        const triggers = await withClaimsChallengeHandling(this.model.accountInfo, async (cosmosClient) =>
-            this.getTriggers(cosmosClient),
-        );
+        const triggers = await withClaimsChallengeHandling(this.model.accountInfo, async (client) => {
+            const result = await client
+                .database(this.model.database.id)
+                .container(this.model.container.id)
+                .scripts.triggers.readAll()
+                .fetchAll();
+            return result.resources;
+        });
         const sortedTriggers = triggers.sort((a, b) => a.id.localeCompare(b.id));
 
         return this.getChildrenImpl(sortedTriggers);
@@ -46,15 +50,6 @@ export abstract class CosmosDBTriggersResourceItem
             label: l10n.t('Triggers'),
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
         };
-    }
-
-    protected async getTriggers(cosmosClient: CosmosClient): Promise<TriggerResource[]> {
-        const result = await cosmosClient
-            .database(this.model.database.id)
-            .container(this.model.container.id)
-            .scripts.triggers.readAll()
-            .fetchAll();
-        return result.resources;
     }
 
     protected abstract getChildrenImpl(triggers: TriggerResource[]): Promise<TreeElement[]>;


### PR DESCRIPTION
Backport of #3016.

## Summary

Refactors Azure Cosmos DB (NoSQL) control-plane operations behind a new `CosmosDBControlPlane` abstraction with two implementations: ARM (preferred for Azure-signed-in accounts) and the Cosmos DB SDK (`CosmosClient`, used for the local emulator and workspace-attached connection-string accounts). Selecting ARM for Azure-signed-in accounts fixes resource creation/deletion failing on accounts configured with strict native data-plane RBAC.

Fixes #2990.

## Conflicts resolved

- **`src/commands/openNoSqlQueryEditor/openNoSqlQueryEditor.ts`**: Both HEAD and the cherry-pick modified the same hunk (replacing `getConnectionFromNode` with `createNoSqlQueryConnection`). Kept the cherry-pick version.
- **`src/panels/trpc/routers/queryEditorRouter.ts`** (modify/delete): This file does not exist in `rel/0.34`'s architecture — the query editor logic is inline in `QueryEditorTab.ts`. The file was deleted from the backport, and the equivalent control-plane change (replacing `getCosmosClient` + direct SDK calls with `getControlPlaneForConnection().listDatabases()` + `listContainers()`) was applied to `src/panels/QueryEditorTab.ts` instead.