### PR TITLE
[rel/0.34] fix: handle absent index metrics gracefully when query returns zero results

### DIFF
--- a/src/cosmosdb/session/QuerySessionResult.ts
+++ b/src/cosmosdb/session/QuerySessionResult.ts
@@ -53,12 +53,23 @@ export class QuerySessionResult {
             throw new Error(l10n.t('Results for page {pageNumber} already exists', { pageNumber: `${pageNumber}` }));
         }
 
+        let indexMetrics = response.indexMetrics;
+        // empty string, null, undefined
+        if (!indexMetrics) {
+            indexMetrics = '{}';
+        }
+
+        // If metrics are empty and previous page has metrics, it means they didn't change and we can reuse them
+        if (indexMetrics === '{}' && this.queryResults.has(pageNumber - 1)) {
+            indexMetrics = this.queryResults.get(pageNumber - 1)?.indexMetrics ?? '{}';
+        }
+
         this.queryResults.set(pageNumber, {
             activityId: response.activityId,
             documents: response.resources,
             iteration: pageNumber,
             metadata: this.metadata,
-            indexMetrics: response.indexMetrics,
+            indexMetrics: indexMetrics,
             // Cosmos DB library has wrong type definition
             queryMetrics: (response.queryMetrics as unknown as QueryMetrics[])['0'],
             requestCharge: response.requestCharge,

--- a/src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx
@@ -15,7 +15,7 @@ import {
     TableRow,
 } from '@fluentui/react-components';
 import * as l10n from '@vscode/l10n';
-import { isJSON } from 'es-toolkit';
+import { isEmptyObject, isJSON } from 'es-toolkit';
 import type React from 'react';
 import { useQueryEditorDispatcher } from '../state/QueryEditorContext';
 
@@ -193,7 +193,8 @@ const parseIndexMetricsV2 = (indexMetricsStr: string): IndexMetrics => {
     const sections: IndexMetricsSection[] = [];
     const json = JSON.parse(indexMetricsStr) as IndexMetricsV2;
 
-    if (!isIndexMetricsV2(json)) {
+    // Index metrics might be just {} in case indexes weren't applied
+    if (!isIndexMetricsV2(json) && !isEmptyObject(json)) {
         throw new Error('Invalid index metrics JSON format');
     }
 


### PR DESCRIPTION
Backport of #3034 to `rel/0.34`.

## Original description

When a Cosmos DB query succeeds but matches no documents, the backend
omits or sends an empty `x-ms-cosmos-index-utilization` response header.
The Stats tab was attempting to parse this absent/empty value as JSON,
which threw an unhandled error and displayed:

> "Failed to parse index metrics: Invalid index metrics JSON format"

— a misleading message on an otherwise successful query.

**Fix:** guard the index metrics parsing so that an absent, empty, or
non-JSON value is treated as "no index metrics available" instead of
surfacing a raw parse error in the UI. The index metrics section is now
omitted / shows N/A when the header is missing or unparseable.

Fixes: zero-result queries incorrectly showing a parse error in the
Stats tab of the NoSQL query editor.

## Conflicts resolved

The original PR mixed the bugfix with incidental refactoring that does not fit `rel/0.34`'s structure. The backport applies **only the bugfix** and drops the incidental changes:

**Kept (the actual fix):**
- `src/cosmosdb/session/QuerySessionResult.ts` — guard empty `indexMetrics` and reuse previous page's metrics when unchanged.
- `src/webviews/cosmosdb/QueryEditor/ResultPanel/IndexMetricsView.tsx` — accept `{}` as valid (no metrics available) instead of throwing.

**Dropped (incidental, conflicted with `rel/0.34`):**
- `src/cosmosdb/session/QuerySession.ts`, `src/utils/convertors.ts`, `src/panels/BaseTab.ts` — `uuid()` → `crypto.randomUUID()` migration. `rel/0.34` still uses the `uuid` package; these constructors also have a different signature on this branch.
- `src/webviews/cosmosdb/QueryEditor/QueryPanel/RunQueryButton.tsx`, `src/webviews/cosmosdb/QueryEditor/ResultPanel/CopyToClipboardButton.tsx` — minor UI/await tweaks unrelated to the fix.
- `vite.config.views.mjs` — file does not exist on `rel/0.34` (the branch still uses webpack); deletion conflict resolved by `git rm`.

## Validation

Local validation ran on top of `origin/rel/0.34` and passed:
- `npm install`
- `npm run build`
- `npm run prettier-fix`
- `npm run lint`
