### PR TITLE
[rel/0.34] Backport #3093: avoid emulator key literal in bundle

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,8 +88,15 @@ export const defaultTrigger = `function trigger() {
 
 }`;
 
+// The well-known emulator key is intentionally stored as base64-of-base64 and
+// decoded at runtime to avoid embedding the literal in bundled artifacts.
+const encodedWellKnownEmulatorPassword =
+    'QzJ5NnlEamY1L1Irb2IwTjhBN0NndjMwVlJESklXRUhMTSs0UURVNURFMm5ROW5EdVZUcW9iRDRiOG1HR3lQTWJJWm5xeU1zRWNhR1F5NjdYSXcvSnc9PQ==';
+
 export const wellKnownEmulatorPassword =
-    'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==';
+    typeof atob === 'function'
+        ? atob(encodedWellKnownEmulatorPassword)
+        : Buffer.from(encodedWellKnownEmulatorPassword, 'base64').toString('utf8');
 
 // Determine if emulator is supported on this platform, historically this was needed to disable emulator support on Silicon Macs
 // which is now supported via Docker. We still keep the check in case there are any other platform specific issues in the future.


### PR DESCRIPTION
## Backport summary
- Backports #3093 to rel/0.34 to avoid embedding the well-known emulator key literal in bundled output (Marketplace credscan stability fix).

## Notes
- Cherry-pick required manual path adaptation because rel/0.34 keeps the key in src/constants.ts (main uses src/cosmosdb/cosmosdb-shared-constants.ts).
- Behavior is equivalent: key is stored encoded and decoded at runtime.
- Intentionally excludes the additional regression test to keep the stable backport minimal.

## Validation
- npm run l10n
- npm run prettier-fix
- npm run lint
