### PR TITLE
[rel/0.34] Backport #3036: recover query-editor dropdown UX telemetry-safe

### DIFF
--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -207,44 +207,54 @@ export class QueryEditorTab extends BaseTab {
                 await this.channel.postMessage({
                     type: 'event',
                     name: 'setConnectionList',
-                    params: [],
+                    params: [{}],
                 });
                 return;
             }
+            try {
+                const cosmosClient = getCosmosClient(this.connection);
+                const databases = await cosmosClient.databases.readAll().fetchAll();
+                const containers = await Promise.allSettled(
+                    databases.resources.map(async (database) => {
+                        const containers = await cosmosClient.database(database.id).containers.readAll().fetchAll();
 
-            const cosmosClient = getCosmosClient(this.connection);
-            const databases = await cosmosClient.databases.readAll().fetchAll();
-            const containers = await Promise.allSettled(
-                databases.resources.map(async (database) => {
-                    const containers = await cosmosClient.database(database.id).containers.readAll().fetchAll();
-
-                    return containers.resources.map((container) => [database.id, container.id] as string[]);
-                }),
-            );
-
-            const errors = containers.filter((result) => result.status === 'rejected');
-            const connections = containers
-                .filter((result) => result.status === 'fulfilled')
-                .reduce(
-                    (acc, databaseContainers) => {
-                        databaseContainers.value.forEach(([databaseId, containerId]) => {
-                            acc[databaseId] ??= [];
-                            acc[databaseId].push(containerId);
-                        });
-                        return acc;
-                    },
-                    {} as Record<string, string[]>,
+                        return containers.resources.map((container) => [database.id, container.id] as string[]);
+                    }),
                 );
 
-            if (errors.length > 0) {
-                context.telemetry.properties.error = errors.map((error) => toStringUniversal(error.reason)).join(', ');
-            }
+                const errors = containers.filter((result) => result.status === 'rejected');
+                const connections = containers
+                    .filter((result) => result.status === 'fulfilled')
+                    .reduce(
+                        (acc, databaseContainers) => {
+                            databaseContainers.value.forEach(([databaseId, containerId]) => {
+                                acc[databaseId] ??= [];
+                                acc[databaseId].push(containerId);
+                            });
+                            return acc;
+                        },
+                        {} as Record<string, string[]>,
+                    );
 
-            await this.channel.postMessage({
-                type: 'event',
-                name: 'setConnectionList',
-                params: [connections],
-            });
+                if (errors.length > 0) {
+                    context.telemetry.properties.error = errors
+                        .map((error) => toStringUniversal(error.reason))
+                        .join(', ');
+                }
+
+                await this.channel.postMessage({
+                    type: 'event',
+                    name: 'setConnectionList',
+                    params: [connections],
+                });
+            } catch (error: unknown) {
+                await this.channel.postMessage({
+                    type: 'event',
+                    name: 'setConnectionList',
+                    params: [{}],
+                });
+                throw error;
+            }
         });
     }
 

--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -211,6 +211,20 @@ export class QueryEditorTab extends BaseTab {
                 });
                 return;
             }
+            // Mask sensitive connection values so Cosmos SDK errors and aggregated
+            // rejection reasons cannot leak endpoint/account identifiers via telemetry
+            // when the exception is rethrown for callWithTelemetryAndErrorHandling to log.
+            const masterKey = this.connection.credentials
+                ? getCosmosDBKeyCredential(this.connection.credentials)?.key
+                : undefined;
+            if (masterKey) {
+                context.valuesToMask.push(masterKey);
+            }
+            context.valuesToMask.push(
+                this.connection.endpoint,
+                this.connection.databaseId,
+                this.connection.containerId,
+            );
             try {
                 const cosmosClient = getCosmosClient(this.connection);
                 const databases = await cosmosClient.databases.readAll().fetchAll();


### PR DESCRIPTION
Backport of #3036 to rel/0.34.

Scope:
- Recover query editor connection dropdown UX on errors
- Preserve telemetry behavior without swallowing exceptions

Notes:
- Squashed into a single commit
- No localizable strings were added or changed in this backport, so no translation sync from main was required

Validation:
- npm run prettier-fix
- npm run lint