### PR TITLE
[rel/0.34] Backport #3058: hide Throughput Bucket menu on Cosmos DB Emulator

### DIFF
--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -400,12 +400,18 @@ export class QueryEditorTab extends BaseTab {
                     throw new Error(l10n.t('No connection'));
                 }
 
+                // Throughput buckets are not supported by the Cosmos DB Emulator —
+                // hide the option entirely when the active connection points at an emulator.
+                // Posting `undefined` tells the webview to clear the default state so the
+                // submenu is not rendered.
+                const supportsThroughputBuckets = !this.connection.isEmulator;
+
                 // TODO: Implement logic to fetch throughput buckets
                 // For now, we will just set the buckets to true.
                 await this.channel.postMessage({
                     type: 'event',
                     name: 'updateThroughputBuckets',
-                    params: [[true, true, true, true, true]],
+                    params: [supportsThroughputBuckets ? [true, true, true, true, true] : undefined],
                 });
             },
         );

--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -402,8 +402,11 @@ export class QueryEditorTab extends BaseTab {
 
                 // Throughput buckets are not supported by the Cosmos DB Emulator —
                 // hide the option entirely when the active connection points at an emulator.
-                // Posting `undefined` tells the webview to clear the default state so the
-                // submenu is not rendered.
+                // Sending an empty `params` array tells the webview to clear the default
+                // state so the submenu is not rendered. We avoid putting `undefined` inside
+                // `params` because `vscode.Webview.postMessage` JSON-serializes the payload
+                // and array holes become `null`, which would not round-trip as `undefined`
+                // on the receiving side.
                 const supportsThroughputBuckets = !this.connection.isEmulator;
 
                 // TODO: Implement logic to fetch throughput buckets
@@ -411,7 +414,7 @@ export class QueryEditorTab extends BaseTab {
                 await this.channel.postMessage({
                     type: 'event',
                     name: 'updateThroughputBuckets',
-                    params: [supportsThroughputBuckets ? [true, true, true, true, true] : undefined],
+                    params: supportsThroughputBuckets ? [[true, true, true, true, true]] : [],
                 });
             },
         );

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
@@ -189,7 +189,10 @@ export class QueryEditorContextProvider extends BaseContextProvider {
             //this.showToast('Query error', error, 'error');
         });
 
-        this.channel.on('updateThroughputBuckets', (throughputBuckets: boolean[]) => {
+        this.channel.on('updateThroughputBuckets', (throughputBuckets: boolean[] | undefined) => {
+            // Always dispatch — the server may explicitly return `undefined` to indicate
+            // throughput buckets are unsupported (e.g. when connected to the Cosmos DB
+            // Emulator). Without this, the default state ([true × 5]) would keep showing.
             this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets });
         });
     }


### PR DESCRIPTION
Backport of #3058 to `rel/0.34`.

## Summary

Throughput buckets are not supported by the Cosmos DB Emulator, so showing the option in the query editor toolbar created confusion (it appeared to silently do nothing). After this fix, the extension posts `undefined` for emulator connections, and the webview always dispatches the update so an `undefined` payload correctly hides the submenu (previously the default `[true, true, true, true, true]` state kept the menu rendered).

Fixes AzureCosmosDB/cosmosdb-vscode-ai-assistant-preview#17.

## Notes for reviewers — not a clean cherry-pick

`rel/0.34` predates the tRPC migration that landed on `main` (#2982), so the files touched by the original PR don't exist on this branch. This is a **manual semantic port** of the same fix mapped onto the channel-message architecture:

| Original (main) | Backport (rel/0.34) |
| --- | --- |
| `src/panels/trpc/routers/queryEditorRouter.ts` — returns `throughputBuckets: undefined` for emulator | `src/panels/QueryEditorTab.ts` — `updateThroughputBuckets()` posts `undefined` when `connection.isEmulator` |
| `src/webviews/.../QueryEditorContextProvider.tsx` — always dispatches `updateThroughputBuckets`, even when `undefined` | Same file, same fix: relax channel handler typing to `boolean[] \| undefined` and dispatch unconditionally (already dispatching unconditionally on rel/0.34, just needed the type relaxation) |

Reducer/action types in `QueryEditorState.tsx` already accept `throughputBuckets?: boolean[]`, so no type plumbing was needed there.

## Validation

Ran locally on the backport branch against `rel/0.34`:

- [x] `npm install`
- [x] `npm run build`
- [x] `npm run l10n` (no diff — no user-facing strings added/removed)
- [x] `npm run prettier-fix` (no changes)
- [x] `npm run lint`
