### PR TITLE
[rel/0.34] Backport #3086: add explicit `id` to wizard steps to prevent mangled telemetry

### DIFF
--- a/src/commands/createContainer/CosmosDBContainerNameStep.ts
+++ b/src/commands/createContainer/CosmosDBContainerNameStep.ts
@@ -11,6 +11,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateContainerWizardContext } from './CreateContainerWizardContext';
 
 export class CosmosDBContainerNameStep extends AzureWizardPromptStep<CreateContainerWizardContext> {
+    public id = 'cosmosDB.createContainer.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateContainerWizardContext): Promise<void> {

--- a/src/commands/createContainer/CosmosDBExecuteStep.ts
+++ b/src/commands/createContainer/CosmosDBExecuteStep.ts
@@ -12,6 +12,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateContainerWizardContext } from './CreateContainerWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateContainerWizardContext> {
+    public id = 'cosmosDB.createContainer.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateContainerWizardContext): Promise<void> {

--- a/src/commands/createContainer/CosmosDBThroughputStep.ts
+++ b/src/commands/createContainer/CosmosDBThroughputStep.ts
@@ -12,6 +12,7 @@ const maxThroughput: number = 100000;
 const throughputStepSize = 100;
 
 export class CosmosDBThroughputStep extends AzureWizardPromptStep<CreateContainerWizardContext> {
+    public id = 'cosmosDB.createContainer.throughputStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateContainerWizardContext): Promise<void> {

--- a/src/commands/createDatabase/CosmosDBDatabaseNameStep.ts
+++ b/src/commands/createDatabase/CosmosDBDatabaseNameStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateDatabaseWizardContext } from './CreateDatabaseWizardContext';
 
 export class CosmosDBDatabaseNameStep extends AzureWizardPromptStep<CreateDatabaseWizardContext> {
+    public id = 'cosmosDB.createDatabase.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateDatabaseWizardContext): Promise<void> {

--- a/src/commands/createDatabase/CosmosDBExecuteStep.ts
+++ b/src/commands/createDatabase/CosmosDBExecuteStep.ts
@@ -11,6 +11,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateDatabaseWizardContext } from './CreateDatabaseWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateDatabaseWizardContext> {
+    public id = 'cosmosDB.createDatabase.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateDatabaseWizardContext): Promise<void> {

--- a/src/commands/createStoredProcedure/CosmosDBExecuteStep.ts
+++ b/src/commands/createStoredProcedure/CosmosDBExecuteStep.ts
@@ -11,6 +11,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateStoredProcedureWizardContext } from './CreateStoredProcedureWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateStoredProcedureWizardContext> {
+    public id = 'cosmosDB.createStoredProcedure.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateStoredProcedureWizardContext): Promise<void> {

--- a/src/commands/createStoredProcedure/CosmosDBStoredProcedureNameStep.ts
+++ b/src/commands/createStoredProcedure/CosmosDBStoredProcedureNameStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateStoredProcedureWizardContext } from './CreateStoredProcedureWizardContext';
 
 export class CosmosDBStoredProcedureNameStep extends AzureWizardPromptStep<CreateStoredProcedureWizardContext> {
+    public id = 'cosmosDB.createStoredProcedure.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateStoredProcedureWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBExecuteStep.ts
+++ b/src/commands/createTrigger/CosmosDBExecuteStep.ts
@@ -11,6 +11,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.executeStep';
     public priority: number = 100;
 
     public async execute(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBTriggerNameStep.ts
+++ b/src/commands/createTrigger/CosmosDBTriggerNameStep.ts
@@ -10,6 +10,7 @@ import { ext } from '../../extensionVariables';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBTriggerNameStep extends AzureWizardPromptStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.nameStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBTriggerOperationStep.ts
+++ b/src/commands/createTrigger/CosmosDBTriggerOperationStep.ts
@@ -8,6 +8,7 @@ import { getTriggerOperation } from '../../cosmosdb/fs/TriggerFileDescriptor';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBTriggerOperationStep extends AzureWizardPromptStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.operationStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/createTrigger/CosmosDBTriggerTypeStep.ts
+++ b/src/commands/createTrigger/CosmosDBTriggerTypeStep.ts
@@ -9,6 +9,7 @@ import { getTriggerType } from '../../cosmosdb/fs/TriggerFileDescriptor';
 import { type CreateTriggerWizardContext } from './CreateTriggerWizardContext';
 
 export class CosmosDBTriggerTypeStep extends AzureWizardPromptStep<CreateTriggerWizardContext> {
+    public id = 'cosmosDB.createTrigger.typeStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: CreateTriggerWizardContext): Promise<void> {

--- a/src/commands/deleteDatabaseAccount/DatabaseAccountDeleteStep.ts
+++ b/src/commands/deleteDatabaseAccount/DatabaseAccountDeleteStep.ts
@@ -9,6 +9,7 @@ import { type DeleteWizardContext } from './DeleteWizardContext';
 import { deleteCosmosDBAccount } from './deleteCosmosDBAccount';
 
 export class DatabaseAccountDeleteStep extends AzureWizardExecuteStep<DeleteWizardContext> {
+    public id = 'cosmosDB.deleteDatabaseAccount.deleteStep';
     public priority: number = 100;
 
     public async execute(context: DeleteWizardContext): Promise<void> {

--- a/src/commands/newConnection/CosmosDBConnectionStringStep.ts
+++ b/src/commands/newConnection/CosmosDBConnectionStringStep.ts
@@ -9,6 +9,8 @@ import { parseCosmosDBConnectionString } from '../../cosmosdb/cosmosDBConnection
 import { type NewConnectionWizardContext } from './NewConnectionWizardContext';
 
 export class CosmosDBConnectionStringStep extends AzureWizardPromptStep<NewConnectionWizardContext> {
+    public id = 'cosmosDB.newConnection.connectionStringStep';
+
     public async prompt(context: NewConnectionWizardContext): Promise<void> {
         context.connectionString = (
             await context.ui.showInputBox({

--- a/src/commands/newConnection/CosmosDBExecuteStep.ts
+++ b/src/commands/newConnection/CosmosDBExecuteStep.ts
@@ -13,6 +13,7 @@ import { WorkspaceResourceType } from '../../tree/workspace-api/SharedWorkspaceR
 import { type NewConnectionWizardContext } from './NewConnectionWizardContext';
 
 export class CosmosDBExecuteStep extends AzureWizardExecuteStep<NewConnectionWizardContext> {
+    public id = 'cosmosDB.newConnection.executeStep';
     public priority: number = 100;
 
     public async execute(context: NewConnectionWizardContext): Promise<void> {

--- a/src/commands/newConnection/CosmosDBTenantStep.ts
+++ b/src/commands/newConnection/CosmosDBTenantStep.ts
@@ -15,6 +15,8 @@ import { type NewConnectionWizardContext } from './NewConnectionWizardContext';
  * used for Entra ID authentication against the Cosmos DB account.
  */
 export class CosmosDBTenantStep extends AzureWizardPromptStep<NewConnectionWizardContext> {
+    public id = 'cosmosDB.newConnection.tenantStep';
+
     public async prompt(context: NewConnectionWizardContext): Promise<void> {
         const subscriptionProvider = new VSCodeAzureSubscriptionProvider();
 

--- a/src/commands/newEmulatorConnection/ExecuteStep.ts
+++ b/src/commands/newEmulatorConnection/ExecuteStep.ts
@@ -15,6 +15,7 @@ import {
 } from './NewEmulatorConnectionWizardContext';
 
 export class ExecuteStep extends AzureWizardExecuteStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.newEmulatorConnection.executeStep';
     public priority: number = 100;
 
     public async execute(context: NewEmulatorConnectionWizardContext): Promise<void> {

--- a/src/commands/newEmulatorConnection/PromptEmulatorPortStep.ts
+++ b/src/commands/newEmulatorConnection/PromptEmulatorPortStep.ts
@@ -12,6 +12,7 @@ import {
 } from './NewEmulatorConnectionWizardContext';
 
 export class PromptEmulatorPortStep extends AzureWizardPromptStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.emulator.portStep';
     public hideStepCount: boolean = false;
 
     public async prompt(context: NewEmulatorConnectionWizardContext): Promise<void> {

--- a/src/commands/newEmulatorConnection/PromptEmulatorTypeStep.ts
+++ b/src/commands/newEmulatorConnection/PromptEmulatorTypeStep.ts
@@ -14,6 +14,8 @@ import {
 } from './NewEmulatorConnectionWizardContext';
 
 export class PromptEmulatorTypeStep extends AzureWizardPromptStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.emulator.typeStep';
+
     constructor() {
         super();
     }

--- a/src/commands/newEmulatorConnection/nosql/PromptNosqlEmulatorConnectionStringStep.ts
+++ b/src/commands/newEmulatorConnection/nosql/PromptNosqlEmulatorConnectionStringStep.ts
@@ -13,6 +13,8 @@ import {
 
 // TODO: create one that can be shared for adding an account and adding an emulator
 export class PromptNosqlEmulatorConnectionStringStep extends AzureWizardPromptStep<NewEmulatorConnectionWizardContext> {
+    public id = 'cosmosDB.nosqlEmulator.connectionStringStep';
+
     public async prompt(context: NewEmulatorConnectionWizardContext): Promise<void> {
         context.connectionString = (
             await context.ui.showInputBox({


### PR DESCRIPTION
Backport of #3086 to `rel/0.34`.

## Problem

After PR #2972 fixed mangled telemetry **event names** (e.g. `wy.getresourceitem`), a related issue remained: the `lastStep` telemetry **property** still contained minified class names (e.g. `prompt-wy`, `execute-ev`).

### Root Cause

`@microsoft/vscode-azext-utils`' `AzureWizard` records the last executed step in telemetry using:

```js
// AzureWizard.js
context.telemetry.properties.lastStep = `${type}-${step.id || step.constructor.name}`;
```

The `AzureWizardExecuteStep` type declaration documents this explicitly:

> `id?: string` — Optional id used to determine if this step is unique, for things like caching values and telemetry. **If not specified, the class name will be used instead.**

In production builds, the minifier mangles class names (e.g. `CosmosDBDatabaseNameStep` → `wy`), but **not string literals**. So any wizard step without an explicit `id` produces unreadable telemetry in production. (`rel/0.34` ships a webpack/Terser build rather than the Vite/Rolldown build that surfaced this on `main`, but the underlying class-name mangling is the same risk.)

## Fix

Adds explicit `public id` fields with stable, hardcoded string literals to all 19 wizard step classes that were missing them. `CosmosDBPartitionKeyStep` already had `id` set dynamically in its constructor and is unchanged.

## Backport notes

- Clean cherry-pick of `b90e2ce5` (squash of #3086) onto `rel/0.34`. No conflicts; all 19 target files exist on `rel/0.34` unchanged.
- No user-facing strings added or removed — l10n bundle unchanged.

## Validation

Ran locally on the backport branch against `rel/0.34`:

- [x] `npm install`
- [x] `npm run build`
- [x] `npm run l10n` (no diff)
- [x] `npm run prettier-fix` (no changes)
- [x] `npm run lint`
