### PR TITLE
fix: remove unnecessary locales from learn.microsoft.com urls

### DIFF
--- a/src/commands/newEmulatorConnection/PromptEmulatorTypeStep.ts
+++ b/src/commands/newEmulatorConnection/PromptEmulatorTypeStep.ts
@@ -45,8 +45,7 @@ export class PromptEmulatorTypeStep extends AzureWizardPromptStep<NewEmulatorCon
                 id: 'learnMore',
                 label: l10n.t('Learn more…'),
                 detail: l10n.t('Learn more about the Azure Cosmos DB (NoSQL) Emulator.'),
-                learnMoreUrl:
-                    'https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator?pivots=api-nosql',
+                learnMoreUrl: 'https://learn.microsoft.com/azure/cosmos-db/how-to-develop-emulator?pivots=api-nosql',
                 alwaysShow: true,
                 group: 'Learn More',
             },

--- a/src/tree/cosmosdb/CosmosDBAccountAttachedResourceItem.ts
+++ b/src/tree/cosmosdb/CosmosDBAccountAttachedResourceItem.ts
@@ -150,7 +150,7 @@ export abstract class CosmosDBAccountAttachedResourceItem
                         if (item === readMoreItem) {
                             void vscode.env.openExternal(
                                 vscode.Uri.parse(
-                                    'https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator?tabs=docker-linux%2Ccsharp&pivots=api-nosql#import-the-emulators-tlsssl-certificate',
+                                    'https://learn.microsoft.com/azure/cosmos-db/how-to-develop-emulator?tabs=docker-linux%2Ccsharp&pivots=api-nosql#import-the-emulators-tlsssl-certificate',
                                 ),
                             );
                         }

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/LearnButton.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/LearnButton.tsx
@@ -24,11 +24,10 @@ export const LearnButton = (props: ToolbarOverflowItemProps<HTMLButtonElement>) 
     const dispatcher = useQueryEditorDispatcher();
     const { ref, type } = props;
     const samples = ['SELECT * FROM c', 'SELECT * FROM c ORDER BY c.id', 'SELECT * FROM c OFFSET 0 LIMIT 10'];
-    const cosmosDBAgentKitUrl = 'https://learn.microsoft.com/en-us/azure/cosmos-db/gen-ai/agent-kit';
-    const cosmosDBMcpToolkitUrl =
-        'https://learn.microsoft.com/en-us/azure/cosmos-db/gen-ai/model-context-protocol-toolkit';
-    const cosmosDBShellUrl = 'https://learn.microsoft.com/en-us/azure/cosmos-db/shell/overview';
-    const cosmosDBVsCodeExtensionUrl = 'https://review.microsoft.com/en-us/azure/cosmos-db/vscode-extension/overview';
+    const cosmosDBAgentKitUrl = 'https://learn.microsoft.com/azure/cosmos-db/gen-ai/agent-kit';
+    const cosmosDBMcpToolkitUrl = 'https://learn.microsoft.com/azure/cosmos-db/gen-ai/model-context-protocol-toolkit';
+    const cosmosDBShellUrl = 'https://learn.microsoft.com/azure/cosmos-db/shell/overview';
+    const cosmosDBVsCodeExtensionUrl = 'https://learn.microsoft.com/azure/cosmos-db/vscode-extension/overview';
     const cosmosDBGalleryUrl = 'https://azurecosmosdb.github.io/gallery/';
 
     const insertSampleText = useCallback((sample: string) => void dispatcher.insertText(sample), [dispatcher]);


### PR DESCRIPTION
Remove locale ('en-us') from these URL's, they are automatically added when user visits the page.
Fix one broken link from review.microsoft.com to learn.microsoft.com.