### PR TITLE
ci(codeql): exclude emulator TLS test files from cert-validation alert

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -64,7 +64,11 @@ extends:
             suppression:
                 suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
             codeql:
-                excludePathPatterns: '**/.vscode-test, dist' # Exclude .vscode-test and dist directories from CodeQL alerting
+                # Exclude .vscode-test and dist directories from CodeQL alerting. The two test-only files also use a
+                # scoped `https.Agent({ rejectUnauthorized: false })` to reach the Cosmos DB emulator's self-signed cert
+                # (js/disabling-certificate-validation); the emulator exposes no reliable cert to trust, and these files
+                # never run in production, so they are excluded rather than weakening the check for shipped code.
+                excludePathPatterns: '**/.vscode-test, dist, test/e2e/setup/emulator.ts, scripts/import-seed.mjs'
                 compiled:
                     ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
                         enabled: true


### PR DESCRIPTION
## Summary

CodeQL (`js/disabling-certificate-validation`) flags the `rejectUnauthorized: false` scoped `https.Agent` used to reach the Cosmos DB emulator's self-signed certificate in two **test-only** files:

- `test/e2e/setup/emulator.ts` (e2e emulator readiness probe)
- `scripts/import-seed.mjs` (local seed/dev script)

## Why exclude rather than fix

There is no SDK option to *trust* the emulator's self-signed certificate, and the linux/vnext-preview emulator exposes no reliable certificate to import (its `/_explorer/emulator.pem` endpoint returns HTTP 400 — already documented in `emulator.ts`). The agent is already correctly **scoped** (not a global `NODE_TLS_REJECT_UNAUTHORIZED=0`), so the relaxation doesn't leak to other HTTPS calls.

Since these files never run in production, they are added to `sdl.codeql.excludePathPatterns` in `.azure-pipelines/build.yml` rather than weakening the check for shipped code. The production path (`src/cosmosdb/getCosmosClient.ts`) is intentionally **not** excluded — it gates `rejectUnauthorized` on `isEmulator`.

## Changes

- `.azure-pipelines/build.yml`: add the two test files to `excludePathPatterns` with an explanatory comment.