### PR TITLE
Temporarily disable Component Governance tasks causing network isolation noise

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -132,8 +132,11 @@ extends:
                               pwsh: true
                               targetType: 'inline'
 
-                        - task: ComponentGovernanceComponentDetection@0
-                          displayName: '🛡️ Component Governance - Component Detection'
+                        # Temporarily disabled: manual Component Governance detection is causing
+                        # Network Isolation blocked-connection noise in this
+                        # pipeline. This task can be re-enabled after policy/tooling alignment.
+                        # - task: ComponentGovernanceComponentDetection@0
+                        #   displayName: '🛡️ Component Governance - Component Detection'
 
                         - task: notice@0
                           displayName: '📄 Generate NOTICE file'

--- a/.azure-pipelines/common/lint.yml
+++ b/.azure-pipelines/common/lint.yml
@@ -5,6 +5,9 @@ steps:
     command: custom
     customCommand: run lint
 
-- task: ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-  condition: ne(variables['System.PullRequest.IsFork'], 'True')
+# Temporarily disabled: Component Governance detection is producing Network
+# Isolation blocked-connection noise in this pipeline. Re-enable once policy
+# and tooling behavior are aligned.
+# - task: ComponentGovernanceComponentDetection@0
+#   displayName: 'Component Detection'
+#   condition: ne(variables['System.PullRequest.IsFork'], 'True')


### PR DESCRIPTION
## Summary
- Comment out manually injected Component Governance detection step in build pipeline
- Comment out Component Governance detection step in common lint pipeline
- Add inline comments explaining temporary disablement due to network isolation blocked-connection noise

## Validation
- npm run prettier-fix
- npm run lint

## Context
Network Isolation reported blocked/non-compliant outbound activity associated with Component Governance and test-host traffic. This change temporarily disables the two explicit Component Governance task invocations pending policy/tooling alignment.