### PR TITLE
fix: guard Fabric provider registration and drop abandoned activation call

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -217,8 +217,6 @@ export async function activateInternal(
                 performance.now() - azureResourcesStartTime;
         }
 
-        vscode.commands.executeCommand('cosmosDB.ai.deployInstructionFiles');
-
         const endTime = performance.now();
         activateContext.telemetry.measurements.endTime = endTime;
         activateContext.telemetry.measurements.totalActivationTime = endTime - startTime;
@@ -283,24 +281,28 @@ function registerFabricProviders(
     context: vscode.ExtensionContext,
     fabricApi: fabric.IFabricExtensionManager,
 ): Promise<void> {
-    ext.fabricNativeTreeNodeProvider = new FabricTreeNodeProvider(context, 'CosmosDBDatabase');
-    ext.fabricMirroredTreeNodeProvider = new FabricTreeNodeProvider(context, 'MirroredDatabase');
+    try {
+        ext.fabricNativeTreeNodeProvider = new FabricTreeNodeProvider(context, 'CosmosDBDatabase');
+        ext.fabricMirroredTreeNodeProvider = new FabricTreeNodeProvider(context, 'MirroredDatabase');
 
-    // Register Fabric providers and commands
-    // Mirrored DB is currently hidden until we have a better story around it
-    const extension: fabric.IFabricExtension & { artifactTypes: FabricArtifactType[] } = {
-        identity: context.extension.id,
-        apiVersion: String(fabric.apiVersion),
-        artifactTypes: ['CosmosDBDatabase' /*, 'MirroredDatabase'*/],
-        treeNodeProviders: [ext.fabricNativeTreeNodeProvider /*, ext.fabricMirroredTreeNodeProvider*/],
-        localProjectTreeNodeProviders: [],
-        artifactHandlers: [
-            ...FabricService.getArtifactHandlers('CosmosDBDatabase'),
-            ...FabricService.getArtifactHandlers('MirroredDatabase'),
-        ],
-    };
+        // Register Fabric providers and commands
+        // Mirrored DB is currently hidden until we have a better story around it
+        const extension: fabric.IFabricExtension & { artifactTypes: FabricArtifactType[] } = {
+            identity: context.extension.id,
+            apiVersion: String(fabric.apiVersion),
+            artifactTypes: ['CosmosDBDatabase' /*, 'MirroredDatabase'*/],
+            treeNodeProviders: [ext.fabricNativeTreeNodeProvider /*, ext.fabricMirroredTreeNodeProvider*/],
+            localProjectTreeNodeProviders: [],
+            artifactHandlers: [
+                ...FabricService.getArtifactHandlers('CosmosDBDatabase'),
+                ...FabricService.getArtifactHandlers('MirroredDatabase'),
+            ],
+        };
 
-    ext.fabricServices = fabricApi.addExtension(extension);
+        ext.fabricServices = fabricApi.addExtension(extension);
+    } catch (e) {
+        console.error('Error registering Fabric providers:', e);
+    }
 
     return Promise.resolve();
 }


### PR DESCRIPTION
## Summary

Two small activation fixes in `src/extension.ts`:

1. **Guard Fabric provider registration.** `registerFabricProviders` is now wrapped in a `try/catch`. Previously, if registering with the Fabric host failed — for example when Fabric does not yet know about this extension — the exception propagated and aborted the entire extension activation. The error is now logged and activation continues.

2. **Remove an abandoned activation call.** Dropped the leftover `vscode.commands.executeCommand('cosmosDB.ai.deployInstructionFiles')` line. That command is not registered anywhere in the codebase or `package.json` — it was stranded by the Fabric merge (#2921). The LLM instruction files are already handled by `cleanupLLMInstructionsFiles()` earlier in activation.

## Testing

- `npm run prettier-fix` — clean
- `npm run lint` (oxlint + eslint) — 0 errors
- `npm run build` (tsc ×3) — passes

No user-facing strings changed, so no localization update was required.
