### PR TITLE
fix: suppress CodeQL warning for MD5 hash check in cleanupLLMInstructionsFiles

### DIFF
--- a/src/cosmosdb/commands/cleanupLLMInstructionsFiles.ts
+++ b/src/cosmosdb/commands/cleanupLLMInstructionsFiles.ts
@@ -38,7 +38,7 @@ export async function cleanupLLMInstructionsFiles(): Promise<void> {
 
         if (fileExists) {
             const content = fs.readFileSync(filePath);
-            const actualMd5 = crypto.createHash('md5').update(content).digest('hex').toUpperCase();
+            const actualMd5 = crypto.createHash('md5').update(content).digest('hex').toUpperCase(); // CodeQL [SM04514] md5 checks user edits
             const md5Matched = actualMd5 === EXPECTED_MD5;
             context.telemetry.properties.md5Matched = String(md5Matched);
             ext.outputChannel.info(


### PR DESCRIPTION
Suppress this [CodeQL warning](https://codeql.microsoft.com/issues/8e9746d8-44c9-4489-af08-7482fd931d16).
We're using md5 hash to detect file modification from users, not for security.