### PR TITLE
fix(e2e): make the webview e2e harness launch and tear down reliably

### DIFF
--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -38,7 +38,8 @@
  * file should declare its own cleanup.
  */
 
-import { _electron as electron, type ElectronApplication, type Page, test as base } from '@playwright/test';
+import { test as base, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -143,7 +144,16 @@ export const test = base.extend<object, VsCodeFixtures>({
 
             // Worker-scoped temp dirs under the run-scoped temp root.
             const workerDir = mkdtempSync(path.join(isolation.tempRootDir, 'worker-'));
-            const userDataDir = path.join(workerDir, 'user-data');
+            // VS Code creates a Unix domain socket at `<user-data-dir>/<ver>-main.sock`
+            // during startup. POSIX caps socket paths at ~103 chars; the run-scoped
+            // temp root (which can live under a long `TMPDIR`) easily pushes the socket
+            // path past that limit, crashing VS Code's main process with
+            // `listen EINVAL` before any window opens. Keep the user-data dir on a
+            // short base on POSIX so the socket path stays within the limit. Windows
+            // uses named pipes (no filesystem-path limit), so the original location
+            // is fine there.
+            const userDataDir =
+                process.platform === 'win32' ? path.join(workerDir, 'user-data') : mkdtempSync('/tmp/cdbe2e-');
             const workspaceDir = path.join(workerDir, 'workspace');
             mkdirSync(userDataDir, { recursive: true });
 
@@ -215,14 +225,41 @@ export const test = base.extend<object, VsCodeFixtures>({
 
             await use(app);
 
-            await app.close().catch(() => {
-                /* close races with Electron teardown are expected */
-            });
+            // VS Code spawns helper processes (extension host, renderers,
+            // utility) that keep the app alive, so `app.close()` reliably hangs
+            // past the worker-teardown timeout. Every one of those processes
+            // carries this worker's unique `--user-data-dir` in its argv, so a
+            // targeted `pkill -f` tears the whole instance down without touching
+            // other workers. Windows uses named pipes and closes cleanly, so
+            // fall back to `app.close()` there.
+            if (process.platform === 'win32') {
+                await app.close().catch(() => {
+                    /* close races with Electron teardown are expected */
+                });
+            } else {
+                try {
+                    execFileSync('pkill', ['-9', '-f', userDataDir]);
+                } catch {
+                    /* no matching processes / pkill unavailable — ignore */
+                }
+                await app.close().catch(() => {
+                    /* connection already dropped once the processes were killed */
+                });
+            }
             // Best-effort cleanup; on Windows file handles can linger briefly.
             try {
                 rmSync(workerDir, { recursive: true, force: true });
             } catch {
                 /* ignore */
+            }
+            // The POSIX user-data dir lives outside workerDir (short-path
+            // workaround above), so remove it separately.
+            if (userDataDir !== path.join(workerDir, 'user-data')) {
+                try {
+                    rmSync(userDataDir, { recursive: true, force: true });
+                } catch {
+                    /* ignore */
+                }
             }
         },
         { scope: 'worker' },

--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -131,6 +131,15 @@ async function disableNativeDialogs(app: ElectronApplication): Promise<void> {
         });
 }
 
+/** Best-effort recursive directory removal that never throws. */
+function removeDirQuietly(dir: string): void {
+    try {
+        rmSync(dir, { recursive: true, force: true });
+    } catch {
+        /* ignore */
+    }
+}
+
 interface VsCodeFixtures {
     vscodeApp: ElectronApplication;
     vscodeWindow: Page;
@@ -170,7 +179,7 @@ export const test = base.extend<object, VsCodeFixtures>({
 
             seedUserSettings(userDataDir);
 
-            const app = await electron.launch({
+            const launchPromise = electron.launch({
                 executablePath: cfg.vscodeExecutablePath,
                 args: [
                     // Disable Electron's internal sandbox so Playwright's CDP attach
@@ -221,6 +230,16 @@ export const test = base.extend<object, VsCodeFixtures>({
                 },
             });
 
+            // `electron.launch` failures (startup crash, missing executable, …)
+            // skip Playwright's fixture teardown, which would leak the POSIX
+            // `userDataDir` under `/tmp` (it lives outside the run-scoped temp
+            // root). Clean both dirs up on early failure before rethrowing.
+            const app = await launchPromise.catch((err: unknown) => {
+                removeDirQuietly(workerDir);
+                removeDirQuietly(userDataDir);
+                throw err;
+            });
+
             await disableNativeDialogs(app);
 
             await use(app);
@@ -240,26 +259,25 @@ export const test = base.extend<object, VsCodeFixtures>({
                 try {
                     execFileSync('pkill', ['-9', '-f', userDataDir]);
                 } catch {
-                    /* no matching processes / pkill unavailable — ignore */
+                    // `pkill` is missing or matched nothing. Fall back to killing
+                    // the launched process directly so teardown can't hang on
+                    // `app.close()` (VS Code keeps helper processes alive).
+                    try {
+                        app.process().kill('SIGKILL');
+                    } catch {
+                        /* already exited */
+                    }
                 }
                 await app.close().catch(() => {
                     /* connection already dropped once the processes were killed */
                 });
             }
             // Best-effort cleanup; on Windows file handles can linger briefly.
-            try {
-                rmSync(workerDir, { recursive: true, force: true });
-            } catch {
-                /* ignore */
-            }
+            removeDirQuietly(workerDir);
             // The POSIX user-data dir lives outside workerDir (short-path
             // workaround above), so remove it separately.
             if (userDataDir !== path.join(workerDir, 'user-data')) {
-                try {
-                    rmSync(userDataDir, { recursive: true, force: true });
-                } catch {
-                    /* ignore */
-                }
+                removeDirQuietly(userDataDir);
             }
         },
         { scope: 'worker' },


### PR DESCRIPTION
## Summary

Two environment-independent fixes in `test/e2e/fixtures/vscode.ts` that prevented the Playwright webview e2e suite from running on macOS (and any host with a long `TMPDIR`). These are pure harness fixes — they benefit **every** spec (the smoke spec failed identically before).

### 1. Launch failure — socket path too long
VS Code creates a Unix domain socket at `<user-data-dir>/<ver>-main.sock` on startup. POSIX caps socket paths at ~103 chars, so a user-data dir nested under a long run-scoped temp root makes the main process die with `listen EINVAL` **before any window opens**. Every spec then fails with the misleading generic error:

```
Error: VS Code closed before a window became available.
```

Fix: place the user-data dir on a short base on POSIX (`/tmp/cdbe2e-*`) so the socket path stays within the limit, and clean it up in teardown.

### 2. Teardown hang — non-zero exit despite passing
`app.close()` reliably hangs because VS Code keeps helper processes (extension host, renderers, utility) alive, which blows the worker-teardown timeout (90s) and makes the run exit non-zero **even though all tests pass**. Fix: kill the instance by its unique `--user-data-dir` via `pkill -f`, then close — cutting teardown from a 90s hang to instant.

Windows is unaffected (named pipes, no filesystem-path limit) and keeps the original behavior.

## Validation
- Before: the webview smoke spec fails instantly with "VS Code closed before a window became available".
- After: the suite launches, runs, and exits cleanly (`exit 0`).