### PR TITLE
fix(e2e): force a production dist when the dev watch task corrupted it

### DIFF
--- a/test/e2e/setup/globalSetup.ts
+++ b/test/e2e/setup/globalSetup.ts
@@ -121,7 +121,7 @@ function maxMtimeMs(dir: string): number {
  * In addition to freshness, we verify the bundle is a **production** build.
  * The `vite-watch:ext` dev task rebuilds `dist/main.mjs` in *development* mode
  * on every source save, which makes the bundle newer than `src/` (so it looks
- * "fresh") yet the webviews don't render under the e2e harness. {@link runVitePod}
+ * "fresh") yet the webviews don't render under the e2e harness. {@link runViteProd}
  * stamps the exact `main.mjs` mtime it produced into a marker file; if that
  * marker is missing or no longer matches `main.mjs`, the bundle was rebuilt by
  * something other than our production build and must be rebuilt.
@@ -156,7 +156,7 @@ function isDistStale(extensionDevelopmentPath: string): { stale: boolean; reason
     return { stale: false, reason: '' };
 }
 
-function runVitePod(extensionDevelopmentPath: string): void {
+function runViteProd(extensionDevelopmentPath: string): void {
     console.log('[e2e setup] Running `npm run vite-prod` (this can take ~30–60 s)…');
     const result = spawnSync('npm', ['run', 'vite-prod'], {
         cwd: repoRoot,
@@ -194,7 +194,7 @@ export default async function globalSetup(): Promise<void> {
         const { stale, reason } = isDistStale(extensionDevelopmentPath);
         if (stale) {
             console.log(`[e2e setup] dist/ is stale (${reason}) — rebuilding…`);
-            runVitePod(extensionDevelopmentPath);
+            runViteProd(extensionDevelopmentPath);
         } else {
             console.log('[e2e setup] dist/ is up to date');
         }

--- a/test/e2e/setup/globalSetup.ts
+++ b/test/e2e/setup/globalSetup.ts
@@ -10,11 +10,13 @@
  * effects:
  *
  *   1. Ensures the extension build (`dist/`) is **fresh** relative to the
- *      sources it was produced from. Mtimes of `package.json` + `src/`
- *      are compared against `dist/main.mjs` and `dist/package.json`; if any
- *      source is newer, `npm run vite-prod` is invoked automatically.
- *      Override with `COSMOSDB_E2E_SKIP_BUILD=1` (useful when you're
- *      iterating on tests only).
+ *      sources it was produced from, and is a **production** build. Mtimes of
+ *      `package.json` + `src/` are compared against `dist/main.mjs` and
+ *      `dist/package.json`; a sidecar marker also detects when `dist/` was
+ *      overwritten by the `vite-watch:ext` dev task (a development build that
+ *      doesn't render the webviews). If either check fails, `npm run vite-prod`
+ *      is invoked automatically. Override with `COSMOSDB_E2E_SKIP_BUILD=1`
+ *      (useful when you're iterating on tests only).
  *   2. Downloads/locates a stable VS Code via `@vscode/test-electron`
  *      (cached under `.vscode-test/`).
  *   3. Installs the extension's runtime dependencies (currently just
@@ -61,6 +63,15 @@ import {
 const REQUIRED_EXTENSIONS = ['ms-azuretools.vscode-azureresourcegroups'];
 const VSCODE_VERSION = 'stable';
 
+/**
+ * Sidecar file written into `dist/` after a successful production build. It
+ * records the built `main.mjs` mtime so the next run can tell whether the
+ * bundle is still the production build we produced or was overwritten by the
+ * `vite-watch:ext` dev task (which builds in development mode and breaks
+ * webview rendering under the harness).
+ */
+const PROD_BUILD_MARKER = '.e2e-prod-build';
+
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..', '..', '..');
 
@@ -106,12 +117,32 @@ function maxMtimeMs(dir: string): number {
  * into dist, so a mismatched manifest is the very symptom that prompted us
  * to add this check (VS Code complains about menu items referencing
  * commands that aren't in the stale dist/package.json).
+ *
+ * In addition to freshness, we verify the bundle is a **production** build.
+ * The `vite-watch:ext` dev task rebuilds `dist/main.mjs` in *development* mode
+ * on every source save, which makes the bundle newer than `src/` (so it looks
+ * "fresh") yet the webviews don't render under the e2e harness. {@link runVitePod}
+ * stamps the exact `main.mjs` mtime it produced into a marker file; if that
+ * marker is missing or no longer matches `main.mjs`, the bundle was rebuilt by
+ * something other than our production build and must be rebuilt.
  */
 function isDistStale(extensionDevelopmentPath: string): { stale: boolean; reason: string } {
     const mainMjs = path.join(extensionDevelopmentPath, 'main.mjs');
     const distPkg = path.join(extensionDevelopmentPath, 'package.json');
     if (!existsSync(mainMjs) || !existsSync(distPkg)) {
         return { stale: true, reason: 'dist/ missing' };
+    }
+    // Production-build verification (see doc comment above).
+    const marker = path.join(extensionDevelopmentPath, PROD_BUILD_MARKER);
+    if (!existsSync(marker)) {
+        return { stale: true, reason: 'no production-build marker (dist may be a dev/watch build)' };
+    }
+    const recordedMtime = Number(readFileSync(marker, 'utf-8').trim());
+    if (!Number.isFinite(recordedMtime) || recordedMtime !== statSync(mainMjs).mtimeMs) {
+        return {
+            stale: true,
+            reason: 'dist/main.mjs changed since the last production build (vite-watch dev build?)',
+        };
     }
     const distMin = Math.min(statSync(mainMjs).mtimeMs, statSync(distPkg).mtimeMs);
     const rootPkgMs = statSync(path.resolve(repoRoot, 'package.json')).mtimeMs;
@@ -125,7 +156,7 @@ function isDistStale(extensionDevelopmentPath: string): { stale: boolean; reason
     return { stale: false, reason: '' };
 }
 
-function runVitePod(): void {
+function runVitePod(extensionDevelopmentPath: string): void {
     console.log('[e2e setup] Running `npm run vite-prod` (this can take ~30–60 s)…');
     const result = spawnSync('npm', ['run', 'vite-prod'], {
         cwd: repoRoot,
@@ -136,6 +167,10 @@ function runVitePod(): void {
     if (result.status !== 0) {
         throw new Error(`\`npm run vite-prod\` exited with code ${result.status}`);
     }
+    // Stamp the freshly built `main.mjs` mtime so a later dev-mode rebuild
+    // (vite-watch:ext) is detected as "not a production build" on the next run.
+    const mainMjs = path.join(extensionDevelopmentPath, 'main.mjs');
+    writeFileSync(path.join(extensionDevelopmentPath, PROD_BUILD_MARKER), String(statSync(mainMjs).mtimeMs), 'utf-8');
 }
 
 export default async function globalSetup(): Promise<void> {
@@ -148,11 +183,18 @@ export default async function globalSetup(): Promise<void> {
             );
         }
         console.log('[e2e setup] COSMOSDB_E2E_SKIP_BUILD=1 — using whatever is in dist/ as-is');
+        const { stale, reason } = isDistStale(extensionDevelopmentPath);
+        if (stale) {
+            console.warn(
+                `[e2e setup] WARNING: dist/ may not be a production build (${reason}). ` +
+                    `Webviews can fail to render. Run \`npm run vite-prod\` or drop COSMOSDB_E2E_SKIP_BUILD=1.`,
+            );
+        }
     } else {
         const { stale, reason } = isDistStale(extensionDevelopmentPath);
         if (stale) {
             console.log(`[e2e setup] dist/ is stale (${reason}) — rebuilding…`);
-            runVitePod();
+            runVitePod(extensionDevelopmentPath);
         } else {
             console.log('[e2e setup] dist/ is up to date');
         }


### PR DESCRIPTION
## Summary

`npm run e2e` (and `e2e:ui` / `e2e:debug`) run `globalSetup`, which auto-builds `dist/` via `vite-prod` when it's stale. Staleness was decided purely by **mtime** (sources newer than `dist/main.mjs`). That misses a common dev workflow: the running `vite-watch:ext` task rebuilds `dist/main.mjs` in **development** mode on every source save, which makes the bundle *newer* than `src/` (so it looks "fresh") while the webviews no longer render under the harness — every webview spec then fails with an empty `#root` / "element not found".

## Fix

Record the production build's `main.mjs` mtime in a `dist/.e2e-prod-build` marker right after `vite-prod`. `isDistStale` now also reports stale when:
- the marker is missing (dist may be a dev/watch build), or
- `dist/main.mjs` no longer matches the marker (something — e.g. the dev watch — rebuilt it).

So `npm run e2e` always (re)builds a **production** bundle, rebuilding only when actually needed. Under `COSMOSDB_E2E_SKIP_BUILD=1` it logs a warning instead of forcing a build.

## Verification

- Run with no marker → "no production-build marker … — rebuilding", builds prod, writes marker, tests pass.
- Re-run → marker matches → "dist/ is up to date", no rebuild (fast).
- `touch dist/main.mjs` (simulating the dev watch) → "dist/main.mjs changed since the last production build … — rebuilding", tests pass.