### PR TITLE
test(e2e): capture VS Code window screenshots for webview tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,11 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      trace:
+        description: 'Record a per-test trace of the VS Code window (open the "trace" attachment in the report to replay it). Use when re-running to debug an unexpected failure.'
+        type: boolean
+        default: false
 
   push:
     branches:
@@ -111,6 +116,10 @@ jobs:
         # globalSetup would walk src/ for no gain.
         env:
           COSMOSDB_E2E_SKIP_BUILD: '1'
+          # When the workflow is dispatched manually with the `trace` input enabled, record a
+          # per-test window trace (and screenshots). Empty on push/PR runs, which falls back to
+          # the default capture mode (screenshot only on failure). See test/e2e/helpers/captureMode.ts.
+          COSMOSDB_E2E_SCREENSHOT: ${{ inputs.trace && 'trace' || '' }}
         run: xvfb-run -a npm run e2e
 
       - name: 📤 Upload Playwright HTML report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,9 +117,10 @@ jobs:
         env:
           COSMOSDB_E2E_SKIP_BUILD: '1'
           # When the workflow is dispatched manually with the `trace` input enabled, record a
-          # per-test window trace (and screenshots). Empty on push/PR runs, which falls back to
-          # the default capture mode (screenshot only on failure). See test/e2e/helpers/captureMode.ts.
-          COSMOSDB_E2E_SCREENSHOT: ${{ inputs.trace && 'trace' || '' }}
+          # per-test window trace (and screenshots). The `inputs` context is only populated for
+          # workflow_dispatch, so gate on the event name; push/PR runs resolve to '' and fall back
+          # to the default capture mode (screenshot only on failure). See test/e2e/helpers/captureMode.ts.
+          COSMOSDB_E2E_SCREENSHOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.trace) && 'trace' || '' }}
         run: xvfb-run -a npm run e2e
 
       - name: 📤 Upload Playwright HTML report

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -98,7 +98,7 @@
       }
     },
     {
-      "name": "E2E: Playwright UI (always screenshots)",
+      "name": "E2E: Playwright UI (window trace)",
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/@playwright/test/cli.js",
@@ -106,8 +106,12 @@
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "env": {
-        // Capture a screenshot after every test (pass or fail), not just on failure.
-        "COSMOSDB_E2E_SCREENSHOT": "on",
+        // Record + attach a self-managed trace of the VS Code window per test,
+        // and also capture the per-test screenshot (`trace` implies screenshots
+        // on). Open the "trace" attachment in the report/UI to launch the trace
+        // viewer with the full filmstrip / timeline that the runner can't
+        // capture for a manually-launched Electron window.
+        "COSMOSDB_E2E_SCREENSHOT": "trace",
         // The webview e2e suite doesn't need the Cosmos DB emulator (no Docker required).
         "COSMOSDB_E2E_SKIP_EMULATOR": "1"
       }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -84,6 +84,35 @@
       }
     },
     {
+      "name": "E2E: Webview tests",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/@playwright/test/cli.js",
+      "args": ["test"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": {
+        // The webview e2e suite doesn't need the Cosmos DB emulator (no Docker required).
+        "COSMOSDB_E2E_SKIP_EMULATOR": "1"
+        // Screenshots use the Playwright default (only on failure).
+      }
+    },
+    {
+      "name": "E2E: Playwright UI (always screenshots)",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/@playwright/test/cli.js",
+      "args": ["test", "--ui"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": {
+        // Capture a screenshot after every test (pass or fail), not just on failure.
+        "COSMOSDB_E2E_SCREENSHOT": "on",
+        // The webview e2e suite doesn't need the Cosmos DB emulator (no Docker required).
+        "COSMOSDB_E2E_SKIP_EMULATOR": "1"
+      }
+    },
+    {
       "type": "node",
       "request": "attach",
       "name": "Attach to Extension Host",

--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -43,6 +43,7 @@ import { execFileSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
 import { ensureE2eIsolationContext } from '../helpers/e2eIsolation';
 import { waitForWorkbenchReady } from '../helpers/workbenchReady';
 import { waitForExtensionsActivated } from '../setup/activation';
@@ -145,7 +146,16 @@ interface VsCodeFixtures {
     vscodeWindow: Page;
 }
 
-export const test = base.extend<object, VsCodeFixtures>({
+interface VsCodeTestFixtures {
+    /**
+     * Auto fixture (no value) that records a self-managed Playwright trace of
+     * the VS Code window for the duration of each test when
+     * `COSMOSDB_E2E_SCREENSHOT` selects a `trace` mode. See the fixture body.
+     */
+    windowTrace: void;
+}
+
+export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
     vscodeApp: [
         async ({}, use) => {
             const cfg = readE2eConfig();
@@ -310,6 +320,69 @@ export const test = base.extend<object, VsCodeFixtures>({
             await use(page);
         },
         { scope: 'worker' },
+    ],
+
+    windowTrace: [
+        async ({ vscodeApp, vscodeWindow }, use, testInfo) => {
+            const { trace } = resolveCapturePlan();
+            // `vscodeWindow` is depended on so the workbench is ready before
+            // tracing starts (and so this auto fixture is ordered after window
+            // setup); skip if it never came up.
+            if (trace === 'off' || vscodeWindow.isClosed()) {
+                await use();
+                return;
+            }
+
+            const context = vscodeApp.context();
+
+            // Own the trace where possible so `screenshots: true` is forced —
+            // that's what produces the filmstrip the runner can't capture for a
+            // manually `_electron.launch`-ed window. `snapshots` is deliberately
+            // OFF: the trace viewer's DOM-snapshot reconstruction can't reproduce
+            // VS Code's canvas-painted shell or its cross-origin webview iframes,
+            // so it renders a misleading, stripped-down approximation. Without
+            // snapshots the viewer falls back to the real screencast frames, and
+            // the trace stays smaller. If the runner already has tracing active
+            // on this context (e.g. on a retry), record this test's slice as a
+            // chunk of that existing session instead.
+            let owns = false;
+            try {
+                await context.tracing.start({ screenshots: true, snapshots: false, sources: true });
+                owns = true;
+            } catch {
+                try {
+                    await context.tracing.startChunk({ title: testInfo.title });
+                } catch {
+                    // Tracing unavailable — run the test without a window trace.
+                    await use();
+                    return;
+                }
+            }
+
+            await use();
+
+            const keep = shouldCapture(trace, testInfo.status !== testInfo.expectedStatus);
+            const file = testInfo.outputPath('vscode-window-trace.zip');
+            try {
+                if (owns) {
+                    await context.tracing.stop(keep ? { path: file } : undefined);
+                } else {
+                    await context.tracing.stopChunk(keep ? { path: file } : undefined);
+                }
+                if (keep) {
+                    // The attachment MUST be named `trace` (with the
+                    // `application/zip` content type): that's the only name the
+                    // Playwright HTML report / UI special-cases into an embedded
+                    // "open trace" link that launches the trace viewer in-page.
+                    // Any other name renders as a plain download, and the OS then
+                    // fails to open the raw zip ("unsupported format").
+                    await testInfo.attach('trace', { path: file, contentType: 'application/zip' });
+                }
+            } catch {
+                // Best-effort — never fail a test on trace capture/teardown.
+            }
+        },
+        { auto: true },
     ],
 });
 

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -23,7 +23,7 @@
  * the webview to be fully populated (React mounted, expected UI present).
  */
 
-import { type Frame, type Page } from '@playwright/test';
+import { test, type Frame, type Page } from '@playwright/test';
 
 const COMMAND_PALETTE_SHORTCUT = process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P';
 const QUICK_INPUT_SELECTOR = '.quick-input-widget input';
@@ -109,6 +109,55 @@ export async function getWebviewByPredicate(
 }
 
 /**
+ * Captures a screenshot of the whole VS Code window and attaches it to the
+ * current test, so it appears in the HTML report and is written under the
+ * results dir.
+ *
+ * Capture is controlled by `COSMOSDB_E2E_SCREENSHOT`, mirroring Playwright's
+ * `screenshot` option:
+ *   - `on` / `1`             — capture for every test (pass or fail)
+ *   - `off` / `0`            — never capture
+ *   - `only-on-failure`      — capture only when the test failed
+ *   - unset / any other      — same as `only-on-failure` (the default)
+ *
+ * Why explicit capture? Playwright's declarative `use.screenshot` only covers
+ * the browser `page` it manages. Our tests drive a custom Electron window via
+ * `_electron.launch`, which that machinery doesn't touch (no PNG is ever
+ * produced — even on failure), so we capture it ourselves.
+ */
+export async function captureWindowScreenshot(page: Page, name = 'vscode-window'): Promise<void> {
+    if (page.isClosed()) return;
+
+    let info: ReturnType<typeof test.info>;
+    try {
+        info = test.info();
+    } catch {
+        // Not running inside a test (e.g. called from a non-test context).
+        return;
+    }
+
+    const raw = (process.env.COSMOSDB_E2E_SCREENSHOT ?? '').trim().toLowerCase();
+    const mode = raw === 'on' || raw === '1' ? 'on' : raw === 'off' || raw === '0' ? 'off' : 'only-on-failure';
+    const shouldCapture = mode === 'on' || (mode === 'only-on-failure' && info.status !== info.expectedStatus);
+    if (!shouldCapture) return;
+
+    try {
+        // Wrap the capture in a named `test.step` so the underlying
+        // `Page.screenshot` call surfaces as a labeled action in the trace's
+        // Actions list (the main trace/watch screen, not just the Attachments
+        // tab). Selecting that action renders the PNG in the center snapshot
+        // pane. The `path` attachment additionally exposes it in Attachments.
+        await test.step(`📸 ${name}`, async () => {
+            const file = info.outputPath(`${name}.png`);
+            await page.screenshot({ path: file });
+            await info.attach(`${name} (${info.title})`, { path: file, contentType: 'image/png' });
+        });
+    } catch {
+        // Best-effort — never fail a test on screenshot capture.
+    }
+}
+
+/**
  * Close every editor tab via the `workbench.action.revertAndCloseActiveEditor`
  * command. Required between tests when the VS Code instance is shared across
  * a worker (see the worker-scoped `vscodeApp` fixture) — otherwise webview
@@ -116,6 +165,9 @@ export async function getWebviewByPredicate(
  */
 export async function closeAllEditorTabs(page: Page): Promise<void> {
     if (page.isClosed()) return;
+
+    // Capture the final webview state before the tabs are closed (when enabled).
+    await captureWindowScreenshot(page);
 
     try {
         // Dismiss any popover / menu that might intercept the palette shortcut.

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -24,6 +24,7 @@
  */
 
 import { test, type Frame, type Page } from '@playwright/test';
+import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
 
 const COMMAND_PALETTE_SHORTCUT = process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P';
 const QUICK_INPUT_SELECTOR = '.quick-input-widget input';
@@ -113,12 +114,10 @@ export async function getWebviewByPredicate(
  * current test, so it appears in the HTML report and is written under the
  * results dir.
  *
- * Capture is controlled by `COSMOSDB_E2E_SCREENSHOT`, mirroring Playwright's
- * `screenshot` option:
- *   - `on` / `1`             — capture for every test (pass or fail)
- *   - `off` / `0`            — never capture
- *   - `only-on-failure`      — capture only when the test failed
- *   - unset / any other      — same as `only-on-failure` (the default)
+ * Capture is controlled by `COSMOSDB_E2E_SCREENSHOT` (see
+ * `helpers/captureMode.ts` for the full mode table). In short: `on`/`1`
+ * captures every test, `off`/`0` never, and the default captures only on
+ * failure.
  *
  * Why explicit capture? Playwright's declarative `use.screenshot` only covers
  * the browser `page` it manages. Our tests drive a custom Electron window via
@@ -136,10 +135,9 @@ export async function captureWindowScreenshot(page: Page, name = 'vscode-window'
         return;
     }
 
-    const raw = (process.env.COSMOSDB_E2E_SCREENSHOT ?? '').trim().toLowerCase();
-    const mode = raw === 'on' || raw === '1' ? 'on' : raw === 'off' || raw === '0' ? 'off' : 'only-on-failure';
-    const shouldCapture = mode === 'on' || (mode === 'only-on-failure' && info.status !== info.expectedStatus);
-    if (!shouldCapture) return;
+    const { screenshot } = resolveCapturePlan();
+    const failed = info.status !== info.expectedStatus;
+    if (!shouldCapture(screenshot, failed)) return;
 
     try {
         // Wrap the capture in a named `test.step` so the underlying

--- a/test/e2e/helpers/captureMode.ts
+++ b/test/e2e/helpers/captureMode.ts
@@ -22,9 +22,11 @@
  *     trace-on-failure   → screenshot: only-on-failure, trace: only-on-failure
  *
  * The `trace` modes additionally record a self-managed Playwright trace of the
- * VS Code window — screenshots + DOM snapshots — and attach it per test. Opened
- * in the trace viewer it yields the full filmstrip / timeline ("main watch
- * screen") that the runner can't produce for a manually-launched Electron app.
+ * VS Code window — screencast screenshots only, no DOM snapshots (the snapshot
+ * reconstruction can't reproduce VS Code's canvas shell / cross-origin webviews)
+ * — and attach it per test. Opened in the trace viewer it yields the full
+ * filmstrip / timeline ("main watch screen") that the runner can't produce for
+ * a manually-launched Electron app.
  */
 
 export type CaptureWhen = 'on' | 'off' | 'only-on-failure';

--- a/test/e2e/helpers/captureMode.ts
+++ b/test/e2e/helpers/captureMode.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Single source of truth for the `COSMOSDB_E2E_SCREENSHOT` capture knob,
+ * shared by the screenshot helper (`webviewHelpers.captureWindowScreenshot`)
+ * and the self-managed window-trace fixture (`vscode.ts`).
+ *
+ * Our tests drive a real VS Code window launched via `_electron.launch`, which
+ * Playwright's declarative `use.screenshot` / `use.trace` machinery does not
+ * touch (those only cover the runner-managed browser context). So we capture
+ * both artifacts ourselves and gate them on a single env var:
+ *
+ *   COSMOSDB_E2E_SCREENSHOT
+ *     unset / other      → screenshot: only-on-failure, trace: off   (default)
+ *     off | 0            → screenshot: off,             trace: off
+ *     on  | 1            → screenshot: on,              trace: off
+ *     only-on-failure    → screenshot: only-on-failure, trace: off
+ *     trace              → screenshot: on,              trace: on
+ *     trace-on-failure   → screenshot: only-on-failure, trace: only-on-failure
+ *
+ * The `trace` modes additionally record a self-managed Playwright trace of the
+ * VS Code window — screenshots + DOM snapshots — and attach it per test. Opened
+ * in the trace viewer it yields the full filmstrip / timeline ("main watch
+ * screen") that the runner can't produce for a manually-launched Electron app.
+ */
+
+export type CaptureWhen = 'on' | 'off' | 'only-on-failure';
+
+export interface CapturePlan {
+    screenshot: CaptureWhen;
+    trace: CaptureWhen;
+}
+
+export function resolveCapturePlan(env: NodeJS.ProcessEnv = process.env): CapturePlan {
+    const raw = (env.COSMOSDB_E2E_SCREENSHOT ?? '').trim().toLowerCase();
+    switch (raw) {
+        case 'off':
+        case '0':
+            return { screenshot: 'off', trace: 'off' };
+        case 'on':
+        case '1':
+            return { screenshot: 'on', trace: 'off' };
+        case 'trace':
+            return { screenshot: 'on', trace: 'on' };
+        case 'trace-on-failure':
+            return { screenshot: 'only-on-failure', trace: 'only-on-failure' };
+        case 'only-on-failure':
+        default:
+            return { screenshot: 'only-on-failure', trace: 'off' };
+    }
+}
+
+/**
+ * Whether an artifact governed by `when` should be persisted given the test
+ * outcome. `failed` is `testInfo.status !== testInfo.expectedStatus`.
+ */
+export function shouldCapture(when: CaptureWhen, failed: boolean): boolean {
+    return when === 'on' || (when === 'only-on-failure' && failed);
+}


### PR DESCRIPTION
## What

Adds window-visual capture for the webview e2e suite — per-test **screenshots** and an optional **window trace** — plus matching VS Code launch configs and a CI toggle.

Playwright's declarative `use.screenshot` / `use.trace` only cover the browser `page` it manages — **not** the custom Electron window our e2e tests drive via `_electron.launch`. As a result no PNG (and no usable trace filmstrip) was ever produced, even on failure. We capture both ourselves.

## Capture modes — `COSMOSDB_E2E_SCREENSHOT`

| Value | Screenshot (PNG) | Window trace |
|---|---|---|
| unset / `only-on-failure` (default) | on failure | — |
| `off` / `0` | — | — |
| `on` / `1` | every test | — |
| `trace` | every test | every test |
| `trace-on-failure` | on failure | on failure |

Parsing lives in `test/e2e/helpers/captureMode.ts`, shared by the screenshot helper and the trace fixture.

## Changes

- **`test/e2e/fixtures/webviewHelpers.ts`** — `captureWindowScreenshot()`, invoked from `closeAllEditorTabs()`. Captures the whole VS Code window at native resolution and attaches it, wrapped in a named `test.step` so it also shows as an action in the trace's Actions list, not just the Attachments tab.
- **`test/e2e/fixtures/vscode.ts`** — new `windowTrace` auto fixture. In a `trace` mode it records a self-managed Playwright trace of the Electron context (`screenshots: true`, `snapshots: false`) and attaches it named **`trace`**, which the report/UI special-cases into an embedded "open trace" link (the filmstrip the runner can't produce for a manually-launched Electron window). `snapshots` is off on purpose: the DOM-snapshot reconstruction can't reproduce VS Code's canvas shell / cross-origin webviews, so without it the viewer falls back to the real screencast frames. Falls back to a trace *chunk* if the runner already owns tracing (e.g. on a retry).
- **`test/e2e/helpers/captureMode.ts`** *(new)* — shared env-var parsing.
- **`.vscode/launch.json`** — two configs:
  - **E2E: Webview tests** — runs the suite (screenshots default to only-on-failure).
  - **E2E: Playwright UI (window trace)** — `--ui` with `COSMOSDB_E2E_SCREENSHOT=trace` (records the window trace + screenshots).
- **`.github/workflows/e2e.yml`** — new `trace` `workflow_dispatch` input. When checked, the run uses `COSMOSDB_E2E_SCREENSHOT=trace`; push/PR runs are unchanged.

Both launch configs skip the Cosmos DB emulator (`COSMOSDB_E2E_SKIP_EMULATOR=1`; no Docker needed).

## How to use

**Locally**
- Screenshot the window for every test: `COSMOSDB_E2E_SCREENSHOT=on npm run e2e`, or use the **E2E: Webview tests** launch config (failure-only).
- Full window trace (filmstrip + timeline): run the **E2E: Playwright UI (window trace)** launch config, or `COSMOSDB_E2E_SCREENSHOT=trace npm run e2e`. Open the **`trace`** attachment in the report to replay it, or run `npx playwright show-trace <path>/vscode-window-trace.zip`.

**On CI (debugging an unexpected failure)**
1. **Actions** → **E2E Tests (Webview + Cosmos DB Emulator)** → **Run workflow**.
2. Tick **trace**, then run.
3. Download the **e2e-html-report** (or **e2e-results**) artifact and open the per-test **`trace`** attachment in the trace viewer.

> Note: trace filmstrip frames are capped at 800px by Playwright. For full-resolution detail, use the `vscode-window` PNG attachment, captured at the window's native resolution.

## Testing

- `tsc -p tsconfig.e2e.json --noEmit` ✅
- `eslint` ✅
- Ran the webview + migration specs with `COSMOSDB_E2E_SCREENSHOT=trace`: each test produced a `trace` attachment (verified: screencast filmstrip frames + actions, opens in the trace viewer) plus the native-resolution `vscode-window` PNG.
