### PR TITLE
test(e2e): Query Editor e2e + coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "docker-down": "docker compose down",
     "docker-restart": "npm run docker-down && npm run docker-up",
     "e2e": "playwright test",
+    "e2e:coverage": "cross-env COSMOSDB_E2E_COVERAGE=1 playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:debug": "playwright test --debug",
     "e2e:emulator:up": "docker compose -f docker-compose.e2e.yml -p cosmosdb-e2e up -d --remove-orphans",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -133,8 +133,9 @@ test/e2e/
                                       tree-open path, the document CRUD
                                       round-trip, run-selected-fragment, the
                                       empty-result / invalid-query error paths,
-                                      the Duplicate-tab control, and the
-                                      column-resize dialog
+                                      the Duplicate-tab control, the
+                                      column-resize dialog, and the Cancel
+                                      control
 ```
 
 ## Query Editor coverage (`@queryEditor`)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -131,8 +131,9 @@ test/e2e/
                                       paging + page-size, table selection +
                                       drill-in, query history, the production
                                       tree-open path, the document CRUD
-                                      round-trip, run-selected-fragment, and the
-                                      empty-result / invalid-query error paths
+                                      round-trip, run-selected-fragment, the
+                                      empty-result / invalid-query error paths,
+                                      and the Duplicate-tab control
 ```
 
 ## Query Editor coverage (`@queryEditor`)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -54,6 +54,10 @@ Use `closeAllEditorTabs(vscodeWindow)` from `fixtures/webviewHelpers.ts`.
 # seeds the test DB, runs Playwright, then tears the emulator down)
 npm run e2e
 
+# Coverage-enabled runs (collect Playwright JS coverage from the VS Code webview)
+npm run e2e:coverage
+npm run e2e:coverage:query-editor
+
 # Author / debug
 npm run e2e:ui         # Playwright's UI mode — step through tests, time-travel
 npm run e2e:debug      # Playwright Inspector — pause + step + REPL at each action
@@ -144,7 +148,8 @@ test/e2e/
 ## Query Editor coverage (`@queryEditor`)
 
 The bulk of the suite drives the Query Editor webview. Every Query Editor spec
-shares two fixtures:
+shares two fixtures, and coverage is now enabled automatically for runs started
+with `npm run e2e:coverage`:
 
 - **`fixtures/queryEditor.ts`** — the `QueryEditorPage` page-object. It wraps the
   webview `Frame` with intention-revealing actions (`run`, `setViewMode`,
@@ -158,6 +163,19 @@ shares two fixtures:
   failing on any non-allowlisted `console.error` from the panel.
   `CONSOLE_ERROR_ALLOWLIST` is intentionally **empty** — add an entry only for a
   real, unavoidable error and document why inline.
+- **`fixtures/coverage.ts`** — auto fixture for coverage-enabled runs
+  (`COSMOSDB_E2E_COVERAGE=1`). It collects Playwright's built-in **V8** coverage
+  for the VS Code window (no `nyc`/`istanbul`/`c8` dependency), then projects the
+  executed byte ranges back onto component **source lines** through the webview
+  bundle's source maps. Per test it writes
+  `test/e2e/.results/<run-id>/<test-name>/coverage.json` (per-component
+  `mapped`/`covered` line numbers); `globalTeardown` aggregates every artifact
+  into `test/e2e/.reports/<run-id>/coverage-summary.{json,md}` — a per-component
+  covered/uncovered-line report. Two things make this work and are wired up
+  automatically for coverage runs: `globalSetup` rebuilds `dist/` **unminified +
+  with source maps** (`vite.config.views.mjs` keys off the same env var), and the
+  VS Code window is launched with site isolation disabled so the webview iframe
+  runs in the page renderer where `page.coverage` can see it.
 
 Run just this slice while iterating:
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -134,8 +134,8 @@ test/e2e/
                                       round-trip, run-selected-fragment, the
                                       empty-result / invalid-query error paths,
                                       the Duplicate-tab control, the
-                                      column-resize dialog, and the Cancel
-                                      control
+                                      column-resize dialog, the Cancel control,
+                                      and the global keyboard hotkeys
 ```
 
 ## Query Editor coverage (`@queryEditor`)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -130,8 +130,9 @@ test/e2e/
                                       result view modes, result toolbar + Stats,
                                       paging + page-size, table selection +
                                       drill-in, query history, the production
-                                      tree-open path, and the document CRUD
-                                      round-trip
+                                      tree-open path, the document CRUD
+                                      round-trip, run-selected-fragment, and the
+                                      empty-result / invalid-query error paths
 ```
 
 ## Query Editor coverage (`@queryEditor`)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -133,7 +133,8 @@ test/e2e/
                                       tree-open path, the document CRUD
                                       round-trip, run-selected-fragment, the
                                       empty-result / invalid-query error paths,
-                                      and the Duplicate-tab control
+                                      the Duplicate-tab control, and the
+                                      column-resize dialog
 ```
 
 ## Query Editor coverage (`@queryEditor`)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -107,12 +107,70 @@ test/e2e/
 │   │                             pushes emulator env vars into the launched
 │   │                             VS Code process
 │   ├── webviewHelpers.ts      — runCommand, getWebviewByPredicate,
-│   │                             closeAllEditorTabs
+│   │                             closeAllEditorTabs, maximize/resizeWindow,
+│   │                             native-dialog stubs (stubMessageBoxButton /
+│   │                             resetNativeDialogStubs), screenshot capture
+│   ├── webviews.ts            — per-panel openers (Query Editor / Document /
+│   │                             Migration) + attachEmulator
+│   ├── queryEditor.ts         — Query Editor page-object (open / run / view
+│   │                             modes / result toolbar / paging / Stats /
+│   │                             selection / drill-in / run history)
+│   ├── consoleHealth.ts       — webview console-error monitor +
+│   │                             CONSOLE_ERROR_ALLOWLIST (kept empty)
 │   └── workspace/             — source-of-truth workspace opened by every
 │                                worker (.nosql samples, .vscode/settings.json)
 └── specs/
-    └── smoke.spec.ts          — opens Migration Assistant, asserts React mount
+    ├── smoke.spec.ts              — opens Migration Assistant, asserts React mount
+    ├── emulator-connected.spec.ts — Query Editor connects + runs the seed query
+    └── queryEditor-*.spec.ts      — Query Editor coverage (tag `@queryEditor`):
+                                      open, query toolbar, toolbar overflow,
+                                      result view modes, result toolbar + Stats,
+                                      paging + page-size, table selection +
+                                      drill-in, query history, and the
+                                      production tree-open path
 ```
+
+## Query Editor coverage (`@queryEditor`)
+
+The bulk of the suite drives the Query Editor webview. Every Query Editor spec
+shares two fixtures:
+
+- **`fixtures/queryEditor.ts`** — the `QueryEditorPage` page-object. It wraps the
+  webview `Frame` with intention-revealing actions (`run`, `setViewMode`,
+  `setPageSize`, `goToNextPage`, `selectRow`, `openRunHistoryMenu`, …) so specs
+  read as user stories. `QueryEditorPage.open(window)` mounts the editor via the
+  `cosmosDB.e2e.openQueryEditor` test command; `QueryEditorPage.fromOpenTab(window)`
+  attaches to an editor opened by some other affordance (used by the tree-open
+  spec).
+- **`fixtures/consoleHealth.ts`** — attaches a console listener to the webview
+  frame at mount. Every spec ends with `qe.consoleHealth.assertNoConsoleErrors()`,
+  failing on any non-allowlisted `console.error` from the panel.
+  `CONSOLE_ERROR_ALLOWLIST` is intentionally **empty** — add an entry only for a
+  real, unavoidable error and document why inline.
+
+Run just this slice while iterating:
+
+```bash
+npx playwright test --grep "@queryEditor"      # all Query Editor specs
+npx playwright test queryEditor-paging         # one file by name substring
+```
+
+Conventions every Query Editor spec follows:
+
+- tag the describe block `{ tag: '@queryEditor' }` and `test.skip` when
+  `COSMOSDB_E2E_SKIP_EMULATOR=1`;
+- `beforeEach`: `maximizeWindow` → `attachEmulator` → `QueryEditorPage.open` →
+  `waitForConnected`;
+- `afterEach`: `captureNamedScreenshot(vscodeWindow, 'final')` → `dispose()` →
+  `closeAllEditorTabs` (plus `resetNativeDialogStubs` / close any Document tab a
+  test opened);
+- the **page-size confirmation** is a _native_ Electron dialog, so drive it with
+  `stubMessageBoxButton(vscodeApp, 'Continue' | 'Close')` and restore with
+  `resetNativeDialogStubs` — never expect a `.monaco-dialog-box`;
+- **`queryEditor-tree-open.spec.ts`** is the only tree-driven spec: it expands the
+  attached emulator in the Cosmos DB Workspaces tree and invokes the production
+  "Open Query Editor" container action. Keep tree navigation out of the other
+  specs (it is slower and more brittle than the command shortcut).
 
 ## Cosmos DB emulator
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -114,7 +114,10 @@ test/e2e/
 │   │                             Migration) + attachEmulator
 │   ├── queryEditor.ts         — Query Editor page-object (open / run / view
 │   │                             modes / result toolbar / paging / Stats /
-│   │                             selection / drill-in / run history)
+│   │                             selection / drill-in / run history / CRUD)
+│   ├── documentPanel.ts       — Document webview page-object (mode banner,
+│   │                             clipboard-paste content, Save) used by the
+│   │                             CRUD spec
 │   ├── consoleHealth.ts       — webview console-error monitor +
 │   │                             CONSOLE_ERROR_ALLOWLIST (kept empty)
 │   └── workspace/             — source-of-truth workspace opened by every
@@ -126,8 +129,9 @@ test/e2e/
                                       open, query toolbar, toolbar overflow,
                                       result view modes, result toolbar + Stats,
                                       paging + page-size, table selection +
-                                      drill-in, query history, and the
-                                      production tree-open path
+                                      drill-in, query history, the production
+                                      tree-open path, and the document CRUD
+                                      round-trip
 ```
 
 ## Query Editor coverage (`@queryEditor`)
@@ -171,6 +175,12 @@ Conventions every Query Editor spec follows:
   attached emulator in the Cosmos DB Workspaces tree and invokes the production
   "Open Query Editor" container action. Keep tree navigation out of the other
   specs (it is slower and more brittle than the command shortcut).
+- **`queryEditor-crud.spec.ts`** is **self-contained**: it creates its OWN
+  document with a unique id, queries for exactly that document, then deletes it —
+  so it never mutates the shared seed data. Document content is set via the OS
+  clipboard (`DocumentPanel.setContent` → Electron `clipboard.writeText` + paste)
+  because Monaco's auto-closing brackets/indent corrupt typed JSON. The delete
+  confirmation is a native modal — stub it with `stubMessageBoxButton(app, 'Yes')`.
 
 ## Cosmos DB emulator
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -135,7 +135,10 @@ test/e2e/
                                       empty-result / invalid-query error paths,
                                       the Duplicate-tab control, the
                                       column-resize dialog, the Cancel control,
-                                      and the global keyboard hotkeys
+                                      and the keyboard hotkeys (global tab /
+                                      duplicate shortcuts plus each toolbar,
+                                      paging and item shortcut verified in the
+                                      same case as its button action)
 ```
 
 ## Query Editor coverage (`@queryEditor`)
@@ -185,6 +188,15 @@ Conventions every Query Editor spec follows:
   clipboard (`DocumentPanel.setContent` → Electron `clipboard.writeText` + paste)
   because Monaco's auto-closing brackets/indent corrupt typed JSON. The delete
   confirmation is a native modal — stub it with `stubMessageBoxButton(app, 'Yes')`.
+- **keyboard hotkeys** are verified alongside the button actions they mirror, in
+  the same spec/case: editor-scoped shortcuts (Ctrl+O / Ctrl+S) via
+  `pressEditorHotkey`, result-panel-scoped ones (paging, Refresh, Copy/Export,
+  item View/Edit/New/Delete) via `pressResultHotkey` / `focusResultPanel` + key.
+  A hotkey only fires when focus is inside its bound scope, so always focus the
+  editor or result panel first; item shortcuts (Alt+V/E/D) additionally need a
+  selected row, and focusing the result panel before Alt+V/E avoids the host
+  menu-bar mnemonics swallowing them. Global shortcuts (Alt+1/2, Alt+Shift+D)
+  live in `queryEditor-hotkeys.spec.ts`.
 
 ## Cosmos DB emulator
 

--- a/test/e2e/fixtures/consoleHealth.ts
+++ b/test/e2e/fixtures/consoleHealth.ts
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Console-health monitor for Query Editor (and other webview) e2e specs.
+ *
+ * Why: the requirement for the Query Editor coverage is "no errors in the
+ * console while driving the UI". Playwright surfaces every `console.*` call
+ * made inside a page — including those emitted from nested webview iframes —
+ * as a `console` event on the owning `Page`. We attach a single listener at
+ * the moment the webview mounts, buffer the messages, and let the spec assert
+ * at the end of each interaction.
+ *
+ * Scoping: VS Code loads webview content from the `vscode-webview://` origin
+ * (see the iframe structure documented in `webviewHelpers.ts`). We therefore
+ * only record messages whose `location().url` lives under that origin, so the
+ * workbench's own renderer/extension-host noise never trips a Query Editor
+ * test. In our specs the Query Editor is the only webview open at a time, so
+ * this origin filter is effectively scoped to the panel under test.
+ *
+ * Policy (per PRD): FAIL on `console.error` not matched by
+ * {@link CONSOLE_ERROR_ALLOWLIST}; only LOG warnings (they are collected and
+ * exposed via {@link ConsoleHealth.warnings} but never fail a test on their
+ * own).
+ */
+
+import { type ConsoleMessage, type Frame } from '@playwright/test';
+
+/**
+ * Documented, intentional exceptions to the "no console errors" rule.
+ *
+ * Each entry MUST carry a comment explaining why the error is benign and
+ * cannot reasonably be eliminated from the webview. Keep this list as small
+ * as possible — an empty list is the goal. Matched against the full console
+ * message text (`ConsoleMessage.text()`).
+ */
+export const CONSOLE_ERROR_ALLOWLIST: RegExp[] = [
+    // (intentionally empty — add documented entries only as real, unavoidable
+    //  errors are discovered while building out the suite)
+];
+
+export interface ConsoleHealth {
+    /**
+     * Throws if any non-allowlisted `console.error` was observed in the
+     * webview since this monitor started (or since the last {@link reset}).
+     */
+    assertNoConsoleErrors(): void;
+    /** Snapshot of the `console.warn` messages seen so far. */
+    warnings(): string[];
+    /** Snapshot of the non-allowlisted `console.error` messages seen so far. */
+    errors(): string[];
+    /** Clears the buffered errors/warnings without detaching the listener. */
+    reset(): void;
+    /** Detaches the listener. Safe to call multiple times. */
+    dispose(): void;
+}
+
+const WEBVIEW_ORIGIN = 'vscode-webview://';
+
+/**
+ * Starts buffering console errors/warnings emitted from webview frames on the
+ * page that owns {@link frame}. Call {@link ConsoleHealth.dispose} (typically
+ * in `afterEach`) to detach.
+ */
+export function startConsoleHealth(frame: Frame): ConsoleHealth {
+    const page = frame.page();
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const listener = (msg: ConsoleMessage): void => {
+        const url = msg.location().url ?? '';
+        // Only consider messages originating from webview content, not the
+        // VS Code workbench shell.
+        if (!url.startsWith(WEBVIEW_ORIGIN)) {
+            return;
+        }
+
+        const text = msg.text();
+        switch (msg.type()) {
+            case 'error':
+                if (CONSOLE_ERROR_ALLOWLIST.some((re) => re.test(text))) {
+                    return;
+                }
+                errors.push(`${text}  (${url})`);
+                break;
+            case 'warning':
+                warnings.push(`${text}  (${url})`);
+                break;
+            default:
+                break;
+        }
+    };
+
+    page.on('console', listener);
+
+    let disposed = false;
+    return {
+        assertNoConsoleErrors(): void {
+            if (errors.length > 0) {
+                throw new Error(
+                    `Unexpected webview console.error output (${errors.length}):\n` +
+                        errors.map((e) => `  - ${e}`).join('\n'),
+                );
+            }
+        },
+        warnings: () => [...warnings],
+        errors: () => [...errors],
+        reset(): void {
+            errors.length = 0;
+            warnings.length = 0;
+        },
+        dispose(): void {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            page.off('console', listener);
+        },
+    };
+}

--- a/test/e2e/fixtures/coverage.ts
+++ b/test/e2e/fixtures/coverage.ts
@@ -1,0 +1,478 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Lightweight, dependency-free webview coverage for the e2e suite.
+ *
+ * How it works (and why it's shaped this way):
+ *
+ *  - Coverage runs build the webview bundle **unminified + with source maps**
+ *    (`COSMOSDB_E2E_COVERAGE=1` flips `vite.config.views.mjs`; `globalSetup`
+ *    rebuilds `dist/` when needed). The webview still loads that bundle from the
+ *    extension's `dist/` over `vscode-resource`, same-origin with the webview
+ *    frame — no dev server required.
+ *  - We use Playwright's built-in **V8** coverage (`page.coverage`), which is
+ *    part of `@playwright/test` — no `nyc` / `istanbul` / `c8` dependencies.
+ *  - The webview iframe is forced into the page's renderer process for coverage
+ *    runs (see the `--disable-site-isolation-trials` launch flags in
+ *    `fixtures/vscode.ts`), so `page.coverage` actually sees its scripts. Without
+ *    that flag the webview is an out-of-process iframe and reports nothing.
+ *  - For each executed bundle chunk we read its source map (the adjacent
+ *    `dist/*.js.map`, or an inline data URI), decode it with a hand-rolled VLQ
+ *    reader (~40 lines, no library), and project the executed byte ranges back
+ *    onto the original component source lines. The result per component is
+ *    simply: which source lines ran and which didn't.
+ *
+ * This is intentionally approximate (line-level, nearest-enclosing-range
+ * semantics) — enough to answer "what's covered for each component?" without
+ * pulling in a coverage toolchain.
+ */
+
+import { type Page, type TestInfo } from '@playwright/test';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+/** Per-component line coverage, written to each test's `coverage.json`. */
+export interface FileCoverage {
+    /** Repo-relative source path, e.g. `src/webviews/QueryEditor/QueryEditorTab.tsx`. */
+    path: string;
+    /** Count of executable (source-mapped) lines. */
+    totalLines: number;
+    /** Count of executable lines that ran at least once. */
+    coveredLines: number;
+    lineCoveragePercent: number;
+    /** 1-based line numbers that carry executable code. */
+    mappedLineNumbers: number[];
+    /** 1-based line numbers that ran at least once. */
+    coveredLineNumbers: number[];
+}
+
+interface CoveragePayload {
+    testTitle: string;
+    testFile: string;
+    enabled: boolean;
+    files: FileCoverage[];
+}
+
+interface V8Range {
+    startOffset: number;
+    endOffset: number;
+    count: number;
+}
+
+interface V8Function {
+    ranges: V8Range[];
+}
+
+interface V8ScriptCoverage {
+    url: string;
+    source?: string;
+    functions: V8Function[];
+}
+
+export function isCoverageEnabled(): boolean {
+    return process.env.COSMOSDB_E2E_COVERAGE === '1';
+}
+
+export async function startCoverage(page: Page): Promise<void> {
+    if (!isCoverageEnabled()) {
+        return;
+    }
+    try {
+        await page.coverage.startJSCoverage({ resetOnNavigation: false });
+    } catch {
+        // Coverage is best-effort: never fail the run if this Chromium build
+        // doesn't expose the API or the page is already closing.
+    }
+}
+
+export async function stopAndPersistCoverage(page: Page, testInfo: TestInfo): Promise<void> {
+    if (!isCoverageEnabled()) {
+        return;
+    }
+
+    let entries: V8ScriptCoverage[] = [];
+    try {
+        entries = (await page.coverage.stopJSCoverage()) as unknown as V8ScriptCoverage[];
+    } catch {
+        // Ignore — emit an empty (but valid) artifact below so aggregation
+        // still has something to read.
+    }
+
+    const files = buildFileCoverage(entries);
+
+    if (process.env.COSMOSDB_E2E_COVERAGE_DEBUG === '1') {
+        const debugFile = testInfo.outputPath('coverage-urls.json');
+        try {
+            writeFileSync(
+                debugFile,
+                JSON.stringify(
+                    {
+                        total: entries.length,
+                        urls: entries.map((e) => ({
+                            url: e.url,
+                            hasSource: !!e.source,
+                            functions: e.functions.length,
+                        })),
+                    },
+                    null,
+                    2,
+                ),
+                'utf-8',
+            );
+        } catch {
+            // best-effort debug only
+        }
+    }
+
+    const payload: CoveragePayload = {
+        testTitle: testInfo.title,
+        testFile: testInfo.file,
+        enabled: true,
+        files,
+    };
+
+    const file = testInfo.outputPath('coverage.json');
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify(payload, null, 2), 'utf-8');
+
+    try {
+        await testInfo.attach('coverage', { path: file, contentType: 'application/json' });
+    } catch {
+        // Best-effort — never fail the test if the reporter can't attach.
+    }
+}
+
+/**
+ * Projects V8 byte-range coverage of the webview bundle chunks back onto their
+ * original component source lines, merging per source file across chunks.
+ */
+function buildFileCoverage(entries: V8ScriptCoverage[]): FileCoverage[] {
+    // path -> { mapped: Set<line>, covered: Set<line> }
+    const perFile = new Map<string, { mapped: Set<number>; covered: Set<number> }>();
+
+    for (const entry of entries) {
+        if (!entry.source || !isWebviewBundleUrl(entry.url)) {
+            continue;
+        }
+        const map = readSourceMap(entry.url, entry.source);
+        if (!map) {
+            continue;
+        }
+        // Skip vendor/runtime chunks: only decode maps that carry our component
+        // sources (monaco's map alone is huge — never pay to decode it).
+        if (!map.sources.some((s) => normalizeSourcePath(s, entry.url) !== undefined)) {
+            continue;
+        }
+
+        const coveredGenLines = computeCoveredGeneratedLines(entry.source, entry.functions);
+        const decoded = decodeMappings(map.mappings);
+
+        for (const segment of decoded) {
+            const sourcePath = normalizeSourcePath(map.sources[segment.sourceIndex], entry.url);
+            if (!sourcePath) {
+                continue;
+            }
+            let bucket = perFile.get(sourcePath);
+            if (!bucket) {
+                bucket = { mapped: new Set<number>(), covered: new Set<number>() };
+                perFile.set(sourcePath, bucket);
+            }
+            const sourceLine = segment.sourceLine + 1; // 0-based -> 1-based
+            bucket.mapped.add(sourceLine);
+            if (coveredGenLines.has(segment.generatedLine)) {
+                bucket.covered.add(sourceLine);
+            }
+        }
+    }
+
+    const result: FileCoverage[] = [];
+    for (const [filePath, bucket] of perFile) {
+        const mappedLineNumbers = [...bucket.mapped].sort((a, b) => a - b);
+        // A line can be mapped from several generated lines; it counts as
+        // covered if any of them ran.
+        const coveredLineNumbers = mappedLineNumbers.filter((line) => bucket.covered.has(line));
+        const totalLines = mappedLineNumbers.length;
+        const coveredLines = coveredLineNumbers.length;
+        result.push({
+            path: filePath,
+            totalLines,
+            coveredLines,
+            lineCoveragePercent: totalLines === 0 ? 100 : Math.round((coveredLines / totalLines) * 1000) / 10,
+            mappedLineNumbers,
+            coveredLineNumbers,
+        });
+    }
+    return result.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/**
+ * True for the extension's own webview bundle chunks (loaded from `dist/` over
+ * `vscode-resource`). Excludes VS Code's own workbench scripts, electron
+ * internals and anything outside `dist/`.
+ */
+function isWebviewBundleUrl(url: string): boolean {
+    if (!url.endsWith('.js') && !url.includes('.js?')) {
+        return false;
+    }
+    const local = urlToLocalPath(url);
+    return local !== undefined && local.replace(/\\/g, '/').includes('/dist/');
+}
+
+/**
+ * Maps a `vscode-resource` / `file://` webview URL back to its on-disk path so
+ * we can read the adjacent `.map`. Returns `undefined` for non-local schemes.
+ */
+function urlToLocalPath(url: string): string | undefined {
+    const withoutQuery = url.split('?')[0];
+    // vscode-resource webview URLs look like
+    // `https://file+.vscode-resource.vscode-cdn.net/c:/path/dist/chunk.js`.
+    const cdnMatch = /vscode-(?:resource|cdn)[^/]*\/(.+)$/.exec(withoutQuery);
+    if (cdnMatch) {
+        try {
+            return decodeURIComponent(cdnMatch[1]);
+        } catch {
+            return cdnMatch[1];
+        }
+    }
+    if (withoutQuery.startsWith('file://')) {
+        try {
+            return decodeURIComponent(new URL(withoutQuery).pathname.replace(/^\/([a-zA-Z]:)/, '$1'));
+        } catch {
+            return undefined;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Turns a source-map `sources` entry into a stable repo-relative key, or
+ * `undefined` for anything outside the webview source trees we care about.
+ * Bundle source maps store `sources` relative to the chunk (e.g.
+ * `../src/webviews/...`), so we resolve against the chunk URL first.
+ */
+function normalizeSourcePath(rawSource: string | undefined, moduleUrl: string): string | undefined {
+    if (!rawSource) {
+        return undefined;
+    }
+    let resolved: string;
+    try {
+        resolved = new URL(rawSource, moduleUrl).pathname;
+    } catch {
+        resolved = rawSource;
+    }
+    const source = resolved.split('?')[0].replace(/\\/g, '/').replace(/^\//, '');
+    const webviewsIdx = source.indexOf('src/webviews/');
+    if (webviewsIdx >= 0) {
+        return source.slice(webviewsIdx);
+    }
+    const packagesIdx = source.indexOf('packages/');
+    if (packagesIdx >= 0) {
+        return source.slice(packagesIdx);
+    }
+    return undefined;
+}
+
+interface ParsedSourceMap {
+    mappings: string;
+    sources: string[];
+}
+
+/**
+ * Resolves a chunk's source map from the trailing `//# sourceMappingURL=`
+ * comment. Supports both an inline `data:...;base64,<...>` URI and an adjacent
+ * `chunk.js.map` file on disk (the shape Vite's production build emits). Returns
+ * `undefined` when no usable map is found.
+ */
+function readSourceMap(scriptUrl: string, source: string): ParsedSourceMap | undefined {
+    const marker = '//# sourceMappingURL=';
+    const idx = source.lastIndexOf(marker);
+    if (idx < 0) {
+        return undefined;
+    }
+    const ref = source
+        .slice(idx + marker.length)
+        .trim()
+        .split(/\s/)[0];
+
+    const inline = /^data:application\/json[^,]*;base64,(.*)$/.exec(ref);
+    if (inline) {
+        return parseSourceMapJson(Buffer.from(inline[1], 'base64').toString('utf-8'));
+    }
+    if (ref.startsWith('data:')) {
+        const comma = ref.indexOf(',');
+        return comma >= 0 ? parseSourceMapJson(decodeURIComponent(ref.slice(comma + 1))) : undefined;
+    }
+
+    // External `.map` next to the chunk on disk.
+    const scriptPath = urlToLocalPath(scriptUrl);
+    if (!scriptPath) {
+        return undefined;
+    }
+    try {
+        const mapPath = path.resolve(path.dirname(scriptPath), ref);
+        return parseSourceMapJson(readFileSync(mapPath, 'utf-8'));
+    } catch {
+        return undefined;
+    }
+}
+
+function parseSourceMapJson(json: string): ParsedSourceMap | undefined {
+    try {
+        const parsed = JSON.parse(json) as { mappings?: string; sources?: string[] };
+        if (typeof parsed.mappings !== 'string' || !Array.isArray(parsed.sources)) {
+            return undefined;
+        }
+        return { mappings: parsed.mappings, sources: parsed.sources };
+    } catch {
+        return undefined;
+    }
+}
+
+const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const BASE64_LOOKUP: Record<string, number> = {};
+for (let i = 0; i < BASE64_CHARS.length; i++) {
+    BASE64_LOOKUP[BASE64_CHARS[i]] = i;
+}
+
+/** Decodes one Base64-VLQ group (a comma-delimited segment) into integers. */
+function decodeVlq(segment: string): number[] {
+    const result: number[] = [];
+    let shift = 0;
+    let value = 0;
+    for (const char of segment) {
+        const integer = BASE64_LOOKUP[char];
+        if (integer === undefined) {
+            break;
+        }
+        const hasContinuation = integer & 32;
+        value += (integer & 31) << shift;
+        if (hasContinuation) {
+            shift += 5;
+        } else {
+            const shouldNegate = value & 1;
+            value >>>= 1;
+            result.push(shouldNegate ? -value : value);
+            value = 0;
+            shift = 0;
+        }
+    }
+    return result;
+}
+
+interface DecodedSegment {
+    generatedLine: number; // 0-based generated line
+    sourceIndex: number;
+    sourceLine: number; // 0-based original line
+}
+
+/**
+ * Decodes a source-map `mappings` string into the subset of fields we need:
+ * which original (source, line) each generated line maps to. Column data is
+ * intentionally dropped — we work at line granularity.
+ */
+function decodeMappings(mappings: string): DecodedSegment[] {
+    const decoded: DecodedSegment[] = [];
+    let sourceIndex = 0;
+    let sourceLine = 0;
+    // `generatedColumn`, `sourceColumn` and `nameIndex` deltas are consumed but
+    // not retained.
+    const generatedLineGroups = mappings.split(';');
+    for (let generatedLine = 0; generatedLine < generatedLineGroups.length; generatedLine++) {
+        const group = generatedLineGroups[generatedLine];
+        if (group.length === 0) {
+            continue;
+        }
+        for (const segment of group.split(',')) {
+            if (segment.length === 0) {
+                continue;
+            }
+            const fields = decodeVlq(segment);
+            // A segment with only a generated column carries no source mapping.
+            if (fields.length < 4) {
+                continue;
+            }
+            sourceIndex += fields[1];
+            sourceLine += fields[2];
+            decoded.push({ generatedLine, sourceIndex, sourceLine });
+        }
+    }
+    return decoded;
+}
+
+/**
+ * Returns the set of 0-based generated line numbers that V8 reports as executed,
+ * using nearest-enclosing-range semantics (a line is covered iff the innermost
+ * V8 range overlapping the start of its content has a non-zero hit count).
+ */
+function computeCoveredGeneratedLines(source: string, functions: V8Function[]): Set<number> {
+    const lineStarts = computeLineStartOffsets(source);
+    const firstContentOffset = computeFirstContentOffsets(source, lineStarts);
+
+    const ranges: V8Range[] = [];
+    for (const fn of functions) {
+        for (const range of fn.ranges) {
+            ranges.push(range);
+        }
+    }
+
+    const covered = new Set<number>();
+    for (let line = 0; line < lineStarts.length; line++) {
+        const offset = firstContentOffset[line];
+        if (offset < 0) {
+            continue; // blank line — nothing executable here
+        }
+        let innermost: V8Range | undefined;
+        for (const range of ranges) {
+            if (range.startOffset <= offset && offset < range.endOffset) {
+                if (
+                    !innermost ||
+                    range.startOffset > innermost.startOffset ||
+                    (range.startOffset === innermost.startOffset && range.endOffset < innermost.endOffset)
+                ) {
+                    innermost = range;
+                }
+            }
+        }
+        if (innermost && innermost.count > 0) {
+            covered.add(line);
+        }
+    }
+    return covered;
+}
+
+/** Byte offset at which each 0-based line begins. */
+function computeLineStartOffsets(source: string): number[] {
+    const starts = [0];
+    for (let i = 0; i < source.length; i++) {
+        if (source.charCodeAt(i) === 10 /* \n */) {
+            starts.push(i + 1);
+        }
+    }
+    return starts;
+}
+
+/**
+ * Byte offset of the first non-whitespace character on each line, or -1 for a
+ * blank line. Using the first real token (rather than the raw line start) makes
+ * the nearest-enclosing-range lookup land inside the statement's range.
+ */
+function computeFirstContentOffsets(source: string, lineStarts: number[]): number[] {
+    const offsets: number[] = [];
+    for (let line = 0; line < lineStarts.length; line++) {
+        const start = lineStarts[line];
+        const end = line + 1 < lineStarts.length ? lineStarts[line + 1] - 1 : source.length;
+        let found = -1;
+        for (let i = start; i < end; i++) {
+            const code = source.charCodeAt(i);
+            if (code !== 32 /* space */ && code !== 9 /* tab */ && code !== 13 /* \r */) {
+                found = i;
+                break;
+            }
+        }
+        offsets.push(found);
+    }
+    return offsets;
+}

--- a/test/e2e/fixtures/documentPanel.ts
+++ b/test/e2e/fixtures/documentPanel.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Page-object for the Cosmos DB **Document** webview (`src/webviews/cosmosdb/Document`).
+ *
+ * The Query Editor opens this panel for every row-level action — "Add new item"
+ * (add mode), double-click / "View selected item" (read-only view mode), and
+ * "Edit selected item" (edit mode). It hosts a Monaco JSON editor plus a small
+ * toolbar (Save / Edit / Refresh) and a set of status banners
+ * ("This item is read-only." / "…editable." / "…unsaved changes." / validation).
+ *
+ * The CRUD spec (`queryEditor-crud.spec.ts`) drives it to create, inspect and
+ * delete a throwaway document, so this object exposes just enough surface for
+ * that flow: read the mode banner, replace the JSON, and Save.
+ */
+
+import { type ElectronApplication, expect, type Frame, type Page } from '@playwright/test';
+import { type ConsoleHealth, startConsoleHealth } from './consoleHealth';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export class DocumentPanel {
+    private constructor(
+        /** The Document webview content frame. */
+        public readonly frame: Frame,
+        /** The VS Code main window page. */
+        public readonly window: Page,
+        /** The Electron application (used to drive the OS clipboard for paste). */
+        public readonly app: ElectronApplication,
+        /** Console-health monitor attached at mount time. */
+        public readonly consoleHealth: ConsoleHealth,
+    ) {}
+
+    /**
+     * Wraps an already-mounted Document frame (typically the value returned by
+     * `QueryEditorPage.waitForDocumentPanel()`), attaching a console-health
+     * monitor and waiting until the editor has painted.
+     */
+    static async attach(frame: Frame, window: Page, app: ElectronApplication): Promise<DocumentPanel> {
+        const consoleHealth = startConsoleHealth(frame);
+        await expect(frame.locator('#root')).toBeVisible();
+        await frame.locator('.monaco-editor').first().waitFor({ state: 'visible', timeout: DEFAULT_TIMEOUT_MS });
+        return new DocumentPanel(frame, window, app, consoleHealth);
+    }
+
+    /** True once the read-only banner is shown (view mode). */
+    async isReadOnly(): Promise<boolean> {
+        return (await this.frame.getByText('This item is read-only.', { exact: false }).count()) > 0;
+    }
+
+    /** Asserts the panel is in read-only (view) mode. */
+    async expectReadOnly(): Promise<void> {
+        await expect(this.frame.getByText('This item is read-only.', { exact: false })).toBeVisible({
+            timeout: DEFAULT_TIMEOUT_MS,
+        });
+    }
+
+    /** Asserts the panel is editable (add / edit mode). */
+    async expectEditable(): Promise<void> {
+        await expect(this.frame.getByText('This item is editable.', { exact: false })).toBeVisible({
+            timeout: DEFAULT_TIMEOUT_MS,
+        });
+    }
+
+    private saveButton() {
+        return this.frame.getByRole('button', { name: 'Save item to the database' });
+    }
+
+    /**
+     * Replaces the Monaco editor content with `json`.
+     *
+     * Uses `keyboard.insertText` rather than `keyboard.type`: Monaco auto-closes
+     * brackets and quotes on individual keystrokes, which would corrupt typed
+     * JSON. `insertText` dispatches a single input event (paste-like), so the
+     * text lands verbatim.
+     */
+    async setContent(json: string): Promise<void> {
+        // Paste via the OS clipboard rather than typing. Monaco's auto-closing
+        // brackets/quotes and auto-indent corrupt both typed and `insertText`ed
+        // JSON (stray `}` and cascading indentation); a paste is inserted
+        // verbatim. Electron's `clipboard` module sets the OS clipboard directly.
+        await this.app.evaluate(({ clipboard }, text) => clipboard.writeText(text), json);
+        await this.frame.locator('.monaco-editor').first().click();
+        await this.frame.locator('textarea.inputarea').first().waitFor({ state: 'attached', timeout: 5_000 });
+        await this.window.keyboard.press('Control+A');
+        await this.window.keyboard.press('Control+V');
+    }
+
+    /**
+     * Clicks Save and waits for the save to settle — the button re-disables once
+     * the document is no longer dirty (`isSaveDisabled` when `!isDirty`), which
+     * is the cleanest in-DOM signal that the round-trip to the emulator
+     * completed.
+     */
+    async save(): Promise<void> {
+        await expect(this.saveButton()).toBeEnabled({ timeout: DEFAULT_TIMEOUT_MS });
+        await this.saveButton().click();
+        await expect(this.saveButton()).toBeDisabled({ timeout: DEFAULT_TIMEOUT_MS });
+    }
+
+    dispose(): void {
+        this.consoleHealth.dispose();
+    }
+}

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -24,7 +24,7 @@
 
 import { expect, type Frame, type Page } from '@playwright/test';
 import { startConsoleHealth, type ConsoleHealth } from './consoleHealth';
-import { captureNamedScreenshot } from './webviewHelpers';
+import { captureNamedScreenshot, getWebviewByPredicate } from './webviewHelpers';
 import { openQueryEditor } from './webviews';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -134,6 +134,22 @@ export const RESULT_CONTROLS = {
 
 /** Clipboard / file export formats offered by the Copy and Export split menus. */
 export type ExportFormat = 'CSV' | 'JSON';
+
+/**
+ * Accessible-name substrings of the selection-aware item buttons in the
+ * result tab toolbar (`ResultTabToolbar`). They only render in edit mode (a
+ * `SELECT *`-style query) and are enabled only while at least one row is
+ * selected. Substring matching tolerates the trailing period
+ * (`ensureStopSymbol`) and the `(s)` plural on Delete.
+ */
+export const SELECTION_ACTIONS = {
+    view: 'View selected item',
+    edit: 'Edit selected item',
+    delete: 'Delete selected item',
+} as const;
+
+/** A selection-aware item action whose enablement tracks the row selection. */
+export type SelectionAction = keyof typeof SELECTION_ACTIONS;
 
 export class QueryEditorPage {
     private constructor(
@@ -406,6 +422,73 @@ export class QueryEditorPage {
         await this.viewModeDropdown().click();
         await this.frame.getByRole('option', { name: RESULT_VIEW.options[mode], exact: true }).click();
         await this.activeViewContainer(mode).waitFor({ state: 'visible', timeout: timeoutMs });
+    }
+
+    // ─── Table selection + drill-in (edit-mode `SELECT *` results) ─────────
+
+    /** The active Table-view data grid (react-data-grid). */
+    private tableGrid() {
+        return this.frame.getByRole('grid', { name: 'Query results table' });
+    }
+
+    /** Data rows of the Table view (excludes the header row). */
+    tableRows() {
+        return this.tableGrid().locator('.rdg-row');
+    }
+
+    /** The first data cell of the 0-based table row `index` — the click target. */
+    private tableRowCell(index: number) {
+        return this.tableRows().nth(index).locator('.rdg-cell').first();
+    }
+
+    /** Count of currently selected (highlighted) table rows. */
+    async getSelectedRowCount(): Promise<number> {
+        return this.tableGrid().locator(".rdg-row[aria-selected='true']").count();
+    }
+
+    /** Plain click: selects only row `index` (clears any prior selection). */
+    async selectRow(index: number): Promise<void> {
+        await this.tableRowCell(index).click();
+    }
+
+    /** Ctrl/Cmd+click: toggles row `index` in/out of the current selection. */
+    async ctrlClickRow(index: number): Promise<void> {
+        await this.tableRowCell(index).click({ modifiers: ['ControlOrMeta'] });
+    }
+
+    /** Shift+click: extends the selection from the anchor row to `index`. */
+    async shiftClickRow(index: number): Promise<void> {
+        await this.tableRowCell(index).click({ modifiers: ['Shift'] });
+    }
+
+    /** Double-click: drills into row `index`, opening its Document webview. */
+    async doubleClickRow(index: number): Promise<void> {
+        await this.tableRowCell(index).dblclick();
+    }
+
+    /** Locator for a selection-aware item button (View / Edit / Delete). */
+    selectionActionButton(action: SelectionAction) {
+        return this.resultRegion().getByRole('button', { name: SELECTION_ACTIONS[action] });
+    }
+
+    /**
+     * Waits for the Document webview opened by a row drill-in (double-click or
+     * the View / Edit item buttons) to mount, returning its content frame. The
+     * Document panel is identified by its read-only / editable banner, which the
+     * Query Editor frame never renders, so the predicate also skips this page's
+     * own frame.
+     */
+    async waitForDocumentPanel(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<Frame> {
+        return getWebviewByPredicate(
+            this.window,
+            async (frame) => {
+                if (frame === this.frame) {
+                    return false;
+                }
+                return (await frame.getByText(/This item is (read-only|editable)/).count()) > 0;
+            },
+            timeoutMs,
+        );
     }
 
     // ─── Editor text ──────────────────────────────────────────────────────

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -1,0 +1,349 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Page-object for the Query Editor webview (`QueryEditorTab`, viewType
+ * `cosmosDbQuery`). Wraps the raw Playwright `Frame` with intention-revealing
+ * actions so specs read as user stories rather than selector soup.
+ *
+ * This is the *minimal* Phase 0 surface (open / run / wait for results /
+ * inspect rows) plus the console-health monitor that every Query Editor spec
+ * shares. Later phases grow this object with toolbar, view-mode, paging,
+ * selection and history helpers.
+ *
+ * Notes baked in from the existing emulator spec:
+ *  - The Run control is a Fluent UI `SplitButton` whose visible label is
+ *    "Run" — `getByRole('button', { name: 'Run', exact: true })` targets the
+ *    primary action, not the history split arrow.
+ *  - Result cells render inside a virtualized Fluent data grid, so text
+ *    assertions poll `body.innerText` (mirrors `waitForFrameText` in
+ *    `emulator-connected.spec.ts`) instead of one-shot `toContainText`.
+ */
+
+import { expect, type Frame, type Page } from '@playwright/test';
+import { startConsoleHealth, type ConsoleHealth } from './consoleHealth';
+import { captureNamedScreenshot } from './webviewHelpers';
+import { openQueryEditor } from './webviews';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Accessible names (English) of the query-toolbar controls. Buttons built via
+ * `ToolbarOverflowButton` get a trailing period appended to their aria-label
+ * (`ensureStopSymbol`), but Playwright's `name` option matches as a
+ * case-insensitive substring, so the period-free names below match both the
+ * toolbar button and its overflow-menu counterpart.
+ */
+export const QUERY_TOOLBAR = {
+    run: 'Run',
+    cancel: 'Cancel',
+    open: 'Open',
+    save: 'Save query',
+    duplicate: 'Duplicate',
+    learn: 'Learn more',
+    schema: 'Schema',
+    /** The connection picker is a Fluent `Dropdown` (role `combobox`). */
+    connection: 'Connect to',
+    /** Overflow menu trigger, present only when the toolbar is overflowing. */
+    moreItems: 'More items',
+} as const;
+
+/** Role of a toolbar control's inline (un-collapsed) form. */
+export type ToolbarControlRole = 'button' | 'combobox';
+
+/**
+ * Descriptor for a single query-toolbar control, capturing the two faces it can
+ * present depending on the available width:
+ *
+ *   - inline in the `Toolbar` — located by `role` + accessible name `toolbarName`;
+ *   - collapsed into the "More items" overflow menu — a `MenuItem` whose visible
+ *     label is `menuText` (menu items expose different text/roles than their
+ *     toolbar form — submenu triggers in particular are NOT matched by the
+ *     `menuitem` role — so the menu side is matched by visible text).
+ *
+ * On a small display (e.g. a CI virtual screen) many controls start collapsed,
+ * so specs must look for a control in the toolbar first and the overflow menu
+ * second. The page-object helpers below (`expectControlReachable`,
+ * `clickControl`, `openControlSubmenu`) do exactly that.
+ */
+export interface ToolbarControl {
+    toolbarName: string;
+    role: ToolbarControlRole;
+    menuText: string;
+    /** Match `toolbarName` exactly — needed for the `Run` SplitButton. */
+    exact?: boolean;
+}
+
+/** Registry of the always-present query-toolbar controls. */
+export const QUERY_CONTROLS = {
+    run: { toolbarName: QUERY_TOOLBAR.run, role: 'button', menuText: 'Run', exact: true },
+    cancel: { toolbarName: QUERY_TOOLBAR.cancel, role: 'button', menuText: 'Cancel' },
+    open: { toolbarName: QUERY_TOOLBAR.open, role: 'button', menuText: 'Open' },
+    save: { toolbarName: QUERY_TOOLBAR.save, role: 'button', menuText: 'Save' },
+    duplicate: { toolbarName: QUERY_TOOLBAR.duplicate, role: 'button', menuText: 'Duplicate' },
+    learn: { toolbarName: QUERY_TOOLBAR.learn, role: 'button', menuText: 'Learn' },
+    schema: { toolbarName: QUERY_TOOLBAR.schema, role: 'button', menuText: 'Schema' },
+    connection: { toolbarName: QUERY_TOOLBAR.connection, role: 'combobox', menuText: 'Connect to…' },
+} as const satisfies Record<string, ToolbarControl>;
+
+export class QueryEditorPage {
+    private constructor(
+        /** The Query Editor webview content frame. */
+        public readonly frame: Frame,
+        /** The VS Code main window page (for window-level modals etc.). */
+        public readonly window: Page,
+        /** Console-health monitor attached at mount time. */
+        public readonly consoleHealth: ConsoleHealth,
+    ) {}
+
+    /**
+     * Opens the Query Editor against the seeded emulator connection and starts
+     * the console-health monitor. Resolves once the webview has rendered its
+     * toolbar and editor (not merely mounted an empty `#root`).
+     */
+    static async open(window: Page): Promise<QueryEditorPage> {
+        const frame = await openQueryEditor(window);
+        const consoleHealth = startConsoleHealth(frame);
+        await expect(frame.locator('#root')).toBeVisible();
+        // Wait until the webview has actually painted its content — not just the
+        // empty `#root` host — before snapshotting: the toolbar and its Run
+        // button must be rendered and the Monaco editor mounted. This is the
+        // "before" half of each test's screenshot pair (the "after" is taken in
+        // the spec's afterEach).
+        await expect(frame.getByRole('toolbar').first()).toBeVisible({ timeout: DEFAULT_TIMEOUT_MS });
+        await expect(frame.getByRole('button', { name: QUERY_TOOLBAR.run, exact: true })).toBeVisible({
+            timeout: DEFAULT_TIMEOUT_MS,
+        });
+        await frame.locator('.monaco-editor').first().waitFor({ state: 'visible', timeout: DEFAULT_TIMEOUT_MS });
+        await captureNamedScreenshot(window, 'loaded');
+        return new QueryEditorPage(frame, window, consoleHealth);
+    }
+
+    /**
+     * Clicks the primary Run action on the default (or current) query. Does
+     * not wait for results — call {@link waitForResults} / {@link expectRow}.
+     */
+    async run(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
+        await this.frame.getByRole('button', { name: 'Run', exact: true }).click({ timeout: timeoutMs });
+    }
+
+    /**
+     * Waits until a known seeded row id is visible in the results, proving the
+     * query round-tripped to the emulator and rendered. Defaults to
+     * `prod-00000` — the deterministic first product of the seed.
+     */
+    async waitForResults(needle: string = 'prod-00000', timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
+        await this.waitForFrameText(needle, timeoutMs);
+    }
+
+    /** Asserts that `text` appears somewhere in the result frame body. */
+    async expectRow(text: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
+        await this.waitForFrameText(text, timeoutMs);
+    }
+
+    /**
+     * Best-effort count of rendered data-grid rows (excluding the header row).
+     * The grid is virtualized, so this reflects what is currently realized in
+     * the DOM, not the total page size — use it for relative assertions only.
+     */
+    async getResultRowCount(): Promise<number> {
+        const total = await this.frame.locator('[role="row"]').count();
+        // Subtract the header row when present.
+        const headers = await this.frame.locator('[role="row"] [role="columnheader"]').count();
+        return headers > 0 ? Math.max(0, total - 1) : total;
+    }
+
+    /** Detaches the console-health listener. Call from `afterEach`. */
+    dispose(): void {
+        this.consoleHealth.dispose();
+    }
+
+    // ─── Query toolbar ────────────────────────────────────────────────────
+
+    /**
+     * Waits until the toolbar reflects a live connection — the Run button is
+     * enabled only once `state.isConnected` is true.
+     */
+    async waitForConnected(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
+        await expect(this.frame.getByRole('button', { name: QUERY_TOOLBAR.run, exact: true })).toBeEnabled({
+            timeout: timeoutMs,
+        });
+    }
+
+    /** True when the toolbar collapsed some items into the "More items" menu. */
+    async isOverflowing(): Promise<boolean> {
+        const more = this.frame.getByRole('button', { name: QUERY_TOOLBAR.moreItems });
+        return (
+            (await more.count()) > 0 &&
+            (await more
+                .first()
+                .isVisible()
+                .catch(() => false))
+        );
+    }
+
+    /** Locator for the Fluent toolbar element (excludes the overflow popover). */
+    toolbar() {
+        return this.frame.getByRole('toolbar').first();
+    }
+
+    /**
+     * Waits until the toolbar's overflow state matches `shouldOverflow`. When
+     * the toolbar is not overflowing the `OverflowMenu` renders nothing, so the
+     * "More items" trigger is absent (count 0); when it is, the trigger is
+     * visible.
+     */
+    async waitForOverflowState(shouldOverflow: boolean, timeoutMs: number = 10_000): Promise<void> {
+        const more = this.frame.getByRole('button', { name: QUERY_TOOLBAR.moreItems });
+        if (shouldOverflow) {
+            await expect(more.first()).toBeVisible({ timeout: timeoutMs });
+        } else {
+            await expect(more).toHaveCount(0, { timeout: timeoutMs });
+        }
+    }
+
+    /** Opens the overflow menu if present. Returns false when not overflowing. */
+    async openOverflowMenu(): Promise<boolean> {
+        if (!(await this.isOverflowing())) {
+            return false;
+        }
+        const more = this.frame.getByRole('button', { name: QUERY_TOOLBAR.moreItems }).first();
+        const menu = this.frame.getByRole('menu').first();
+        // The Fluent menu trigger occasionally swallows the first click (the
+        // toolbar is still settling its overflow layout right after a resize),
+        // so retry — but bail out early if a click already opened the menu, to
+        // avoid a second click toggling it back closed.
+        for (let attempt = 0; attempt < 3; attempt++) {
+            if (await menu.isVisible().catch(() => false)) {
+                return true;
+            }
+            await more.click();
+            try {
+                await menu.waitFor({ state: 'visible', timeout: 2_000 });
+                return true;
+            } catch {
+                // Menu didn't open this attempt — loop and try again.
+            }
+        }
+        await menu.waitFor({ state: 'visible', timeout: 3_000 });
+        return true;
+    }
+
+    /** Dismisses any open Fluent menu / dropdown by pressing Escape. */
+    async dismissMenus(): Promise<void> {
+        await this.frame.locator('body').press('Escape');
+    }
+
+    /**
+     * Reports whether a toolbar control is reachable — either visible directly
+     * in the toolbar or available inside the overflow menu. Leaves the toolbar
+     * in its resting state (closes the overflow menu if it had to open it).
+     */
+    async expectControlReachable(control: ToolbarControl): Promise<void> {
+        if (await this.isControlInline(control)) {
+            return;
+        }
+        const opened = await this.openOverflowMenu();
+        expect(opened, `Control "${control.toolbarName}" is neither inline nor in an overflow menu.`).toBe(true);
+        await expect(this.overflowMenu()).toContainText(control.menuText);
+        await this.dismissMenus();
+    }
+
+    /**
+     * Locator for a control's inline (toolbar) form. Scoped to the toolbar so it
+     * never matches the same control's overflow-menu counterpart.
+     */
+    inlineControl(control: ToolbarControl) {
+        return this.toolbar()
+            .getByRole(control.role, { name: control.toolbarName, exact: control.exact ?? false })
+            .first();
+    }
+
+    /** True when the control is currently shown inline in the toolbar. */
+    async isControlInline(control: ToolbarControl): Promise<boolean> {
+        return this.inlineControl(control)
+            .isVisible()
+            .catch(() => false);
+    }
+
+    /** Locator for the open overflow popover menu (its top-level list). */
+    overflowMenu() {
+        return this.frame.getByRole('menu').first();
+    }
+
+    /**
+     * Clicks/activates a control, routing through the overflow menu when the
+     * control has collapsed into it (looks in the toolbar first, the overflow
+     * menu second). For plain action buttons (Open / Save / Duplicate) this
+     * fires the action; for menu-trigger controls (Learn / Schema) it opens
+     * their menu — use {@link openControlSubmenu} when you need to await it.
+     */
+    async clickControl(control: ToolbarControl): Promise<void> {
+        if (await this.isControlInline(control)) {
+            await this.inlineControl(control).click();
+            return;
+        }
+        if (!(await this.openOverflowMenu())) {
+            throw new Error(`Control "${control.toolbarName}" is neither inline nor available in the overflow menu.`);
+        }
+        await this.overflowMenu().getByText(control.menuText, { exact: true }).first().click();
+    }
+
+    /**
+     * Opens a menu-trigger control's popover (Learn / Schema) and resolves once
+     * the submenu is visible. Works whether the trigger is inline or collapsed
+     * into the overflow menu. Caller should {@link dismissMenus} afterwards.
+     */
+    async openControlSubmenu(control: ToolbarControl): Promise<void> {
+        await this.clickControl(control);
+        await this.frame.getByRole('menu').last().waitFor({ state: 'visible', timeout: 5_000 });
+    }
+
+    /** Locator for the connection picker combobox (inline form). */
+    connectionPicker() {
+        return this.frame.getByRole('combobox', { name: QUERY_TOOLBAR.connection });
+    }
+
+    /**
+     * Runs the current query via the keyboard. The `queryEditor` hotkey scope
+     * is bound to the editor subtree, so focus must be inside Monaco first.
+     * `ExecuteQuery` is bound to F5 (Monaco leaves F5 unhandled, so it reaches
+     * the app's document-level hotkey listener; Shift+Enter is swallowed by the
+     * editor as a newline).
+     */
+    async runViaHotkey(): Promise<void> {
+        await this.frame.locator('.monaco-editor').first().click();
+        await this.frame.locator('textarea.inputarea').first().waitFor({ state: 'attached', timeout: 5_000 });
+        await this.window.keyboard.press('F5');
+    }
+
+    /**
+     * Polls the frame body's innerText for `needle` until the deadline. Mirrors
+     * the proven `waitForFrameText` loop in `emulator-connected.spec.ts` to
+     * sidestep data-grid virtualization races.
+     */
+    private async waitForFrameText(needle: string, timeoutMs: number): Promise<void> {
+        const deadline = Date.now() + timeoutMs;
+        let lastSnapshot = '';
+        // Sequential by design — this is a "wait until ready" probe.
+        while (Date.now() < deadline) {
+            try {
+                lastSnapshot = await this.frame.locator('body').innerText({ timeout: 1_000 });
+                if (lastSnapshot.includes(needle)) {
+                    return;
+                }
+            } catch {
+                // Frame may navigate during load — retry.
+            }
+            // oxlint-disable-next-line no-await-in-loop
+            await new Promise((r) => setTimeout(r, 250));
+        }
+
+        throw new Error(
+            `Result frame did not contain "${needle}" within ${timeoutMs} ms. ` +
+                `Last snapshot (first 600 chars): ${lastSnapshot.slice(0, 600)}`,
+        );
+    }
+}

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -76,6 +76,30 @@ export interface ToolbarControl {
     exact?: boolean;
 }
 
+/** The three result renderers the "Change view mode" dropdown switches between. */
+export type ResultViewMode = 'Tree' | 'JSON' | 'Table';
+
+/**
+ * Names attached to the result-panel "Change view mode" dropdown
+ * (`ChangeViewModeDropdown.tsx`):
+ *
+ *  - `dropdown` — the combobox's accessible name (a Fluent `Tooltip` with
+ *    `relationship="label"` supplies it as the `aria-label`);
+ *  - `options` — the visible label of each `Option` in the open listbox
+ *    (note the trailing "view": `Tree view` / `JSON view` / `Table view`);
+ *  - `valueText` — the short label the closed dropdown shows for the active
+ *    mode (`Tree` / `JSON` / `Table`), used by {@link QueryEditorPage.getActiveViewMode}.
+ */
+export const RESULT_VIEW = {
+    dropdown: 'Change view mode',
+    options: { Tree: 'Tree view', JSON: 'JSON view', Table: 'Table view' },
+    valueText: { Tree: 'Tree', JSON: 'JSON', Table: 'Table' },
+} as const satisfies {
+    dropdown: string;
+    options: Record<ResultViewMode, string>;
+    valueText: Record<ResultViewMode, string>;
+};
+
 /** Registry of the always-present query-toolbar controls. */
 export const QUERY_CONTROLS = {
     run: { toolbarName: QUERY_TOOLBAR.run, role: 'button', menuText: 'Run', exact: true },
@@ -304,6 +328,61 @@ export class QueryEditorPage {
     /** Locator for the connection picker combobox (inline form). */
     connectionPicker() {
         return this.frame.getByRole('combobox', { name: QUERY_TOOLBAR.connection });
+    }
+
+    // ─── Result view modes (Tree / JSON / Table) ──────────────────────────
+
+    /**
+     * Locator for the result-panel "Change view mode" dropdown (a Fluent
+     * `Dropdown`, role `combobox`). It lives in the result toolbar and is
+     * present whenever a result tab is shown.
+     */
+    viewModeDropdown() {
+        return this.frame.getByRole('combobox', { name: RESULT_VIEW.dropdown });
+    }
+
+    /**
+     * Reads the currently active result view mode from the dropdown's value.
+     * The closed dropdown shows the short label (`Tree` / `JSON` / `Table`).
+     */
+    async getActiveViewMode(): Promise<ResultViewMode> {
+        const text = (await this.viewModeDropdown().innerText()).trim();
+        if (text.includes(RESULT_VIEW.valueText.Tree)) {
+            return 'Tree';
+        }
+        if (text.includes(RESULT_VIEW.valueText.JSON)) {
+            return 'JSON';
+        }
+        return 'Table';
+    }
+
+    /**
+     * Locator for the renderer that backs a given view mode. Used to assert the
+     * correct view is actually mounted (not merely selected in the dropdown):
+     *  - Table / Tree are `react-data-grid`s exposing role `grid` with a
+     *    distinct accessible name;
+     *  - JSON is a read-only Monaco editor inside the results display area.
+     */
+    activeViewContainer(mode: ResultViewMode) {
+        switch (mode) {
+            case 'Table':
+                return this.frame.getByRole('grid', { name: 'Query results table' });
+            case 'Tree':
+                return this.frame.getByRole('grid', { name: 'Query results tree' });
+            case 'JSON':
+                return this.frame.locator('.resultsDisplayArea .monaco-editor').first();
+        }
+    }
+
+    /**
+     * Switches the result view via the "Change view mode" dropdown and waits
+     * until the target renderer has mounted. Switching triggers an async
+     * recalculation (brief spinner) before the new view paints.
+     */
+    async setViewMode(mode: ResultViewMode, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
+        await this.viewModeDropdown().click();
+        await this.frame.getByRole('option', { name: RESULT_VIEW.options[mode], exact: true }).click();
+        await this.activeViewContainer(mode).waitFor({ state: 'visible', timeout: timeoutMs });
     }
 
     /**

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -573,6 +573,59 @@ export class QueryEditorPage {
         await this.tableRowCell(index).dblclick();
     }
 
+    // ─── Column resize (Table-view header menu → Resize dialog) ────────────
+
+    /** The Table-view column header cell for the column named `name`. */
+    columnHeader(name: string) {
+        return this.tableGrid().getByRole('columnheader', { name, exact: false });
+    }
+
+    /** Current on-screen width (px) of the named Table-view column header. */
+    async columnWidth(name: string): Promise<number> {
+        const box = await this.columnHeader(name).boundingBox();
+        return box?.width ?? 0;
+    }
+
+    /**
+     * Opens the named Table-view column's "Resize" dialog: hovers the header,
+     * opens the chevron context menu (its button is `aria-hidden` until opened,
+     * so it is targeted by DOM rather than role) and picks "Resize". Returns the
+     * dialog locator so callers can apply or cancel.
+     */
+    async openColumnResizeDialog(name: string) {
+        const header = this.columnHeader(name);
+        await header.scrollIntoViewIfNeeded();
+        await header.hover();
+        await header.locator('button').first().click();
+        await this.frame.getByRole('menuitem', { name: 'Resize.', exact: false }).click();
+        const dialog = this.frame.getByRole('dialog');
+        await dialog.getByText('Resize Column').waitFor({ state: 'visible', timeout: 5_000 });
+        return dialog;
+    }
+
+    /**
+     * Sets an explicit width on the named Table-view column via its header menu:
+     * opens the Resize dialog, types `width` into the "Column Width (px)" field
+     * and applies. The grid re-lays out synchronously once the dialog closes.
+     */
+    async resizeColumn(name: string, width: number): Promise<void> {
+        const dialog = await this.openColumnResizeDialog(name);
+        await dialog.locator('#column-width').fill(String(width));
+        await dialog.getByRole('button', { name: 'Apply', exact: true }).click();
+        await dialog.waitFor({ state: 'hidden', timeout: 5_000 });
+    }
+
+    /**
+     * Opens the named column's Resize dialog, types `width`, then dismisses it
+     * with Cancel — used to prove a cancelled resize leaves the column untouched.
+     */
+    async cancelColumnResize(name: string, width: number): Promise<void> {
+        const dialog = await this.openColumnResizeDialog(name);
+        await dialog.locator('#column-width').fill(String(width));
+        await dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+        await dialog.waitFor({ state: 'hidden', timeout: 5_000 });
+    }
+
     /** Locator for a selection-aware item button (View / Edit / Delete). */
     selectionActionButton(action: SelectionAction) {
         return this.resultRegion().getByRole('button', { name: SELECTION_ACTIONS[action] });

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -112,6 +112,29 @@ export const QUERY_CONTROLS = {
     connection: { toolbarName: QUERY_TOOLBAR.connection, role: 'combobox', menuText: 'Connect to…' },
 } as const satisfies Record<string, ToolbarControl>;
 
+/**
+ * Registry of the result-panel toolbar controls (`ResultPanelToolbarOverflow`).
+ * Same two-faced shape as {@link QUERY_CONTROLS}: an inline toolbar button
+ * (matched by its aria-label substring) or a collapsed overflow-menu entry
+ * (matched by visible text). The result toolbar shares the `Default` aria-label
+ * with the query toolbar, so the page-object scopes these lookups to the
+ * "Result Panel" region.
+ *
+ * Note: `copy` and `export` are split menus — activating either (inline button
+ * or overflow entry) opens a CSV/JSON submenu; pick the format afterwards.
+ */
+export const RESULT_CONTROLS = {
+    reload: { toolbarName: 'Reload query results', role: 'button', menuText: 'Refresh' },
+    firstPage: { toolbarName: 'Go to first page', role: 'button', menuText: 'Go to first page' },
+    prevPage: { toolbarName: 'Go to previous page', role: 'button', menuText: 'Go to previous page' },
+    nextPage: { toolbarName: 'Go to next page', role: 'button', menuText: 'Go to next page' },
+    copy: { toolbarName: 'Copy', role: 'button', menuText: 'Copy to clipboard' },
+    export: { toolbarName: 'Export', role: 'button', menuText: 'Export' },
+} as const satisfies Record<string, ToolbarControl>;
+
+/** Clipboard / file export formats offered by the Copy and Export split menus. */
+export type ExportFormat = 'CSV' | 'JSON';
+
 export class QueryEditorPage {
     private constructor(
         /** The Query Editor webview content frame. */
@@ -383,6 +406,237 @@ export class QueryEditorPage {
         await this.viewModeDropdown().click();
         await this.frame.getByRole('option', { name: RESULT_VIEW.options[mode], exact: true }).click();
         await this.activeViewContainer(mode).waitFor({ state: 'visible', timeout: timeoutMs });
+    }
+
+    // ─── Editor text ──────────────────────────────────────────────────────
+
+    /**
+     * Replaces the Monaco query text. Focuses the editor, selects all, and
+     * types the new query. The caller still triggers execution ({@link run} /
+     * {@link runViaHotkey}); typing alone does not run anything.
+     */
+    async setQueryText(text: string): Promise<void> {
+        await this.frame.locator('.monaco-editor').first().click();
+        await this.frame.locator('textarea.inputarea').first().waitFor({ state: 'attached', timeout: 5_000 });
+        await this.window.keyboard.press('Control+A');
+        await this.window.keyboard.press('Delete');
+        await this.window.keyboard.type(text);
+    }
+
+    // ─── Result toolbar (reload / paging / copy / export) ─────────────────
+
+    /** The Result Panel `section` (role `region`), scoping result-side lookups. */
+    resultRegion() {
+        return this.frame.getByRole('region', { name: 'Result Panel' });
+    }
+
+    /**
+     * The result-panel toolbar. Both the query and result toolbars expose the
+     * `Default` accessible name, so this is scoped to the Result Panel region to
+     * disambiguate from the query toolbar.
+     */
+    resultToolbar() {
+        return this.resultRegion().getByRole('toolbar', { name: 'Default' });
+    }
+
+    /** Inline (toolbar) locator for a result control, scoped to the region. */
+    inlineResultControl(control: ToolbarControl) {
+        return this.resultToolbar()
+            .getByRole(control.role, { name: control.toolbarName, exact: control.exact ?? false })
+            .first();
+    }
+
+    /**
+     * Opens the result toolbar's "More items" overflow menu if it is present.
+     * Toggle-safe (mirrors {@link openOverflowMenu}); returns false when the
+     * result toolbar is not overflowing.
+     */
+    async openResultOverflowMenu(): Promise<boolean> {
+        const more = this.resultToolbar().getByRole('button', { name: QUERY_TOOLBAR.moreItems });
+        if (
+            (await more.count()) === 0 ||
+            !(await more
+                .first()
+                .isVisible()
+                .catch(() => false))
+        ) {
+            return false;
+        }
+        const menu = this.frame.getByRole('menu').first();
+        for (let attempt = 0; attempt < 3; attempt++) {
+            if (await menu.isVisible().catch(() => false)) {
+                return true;
+            }
+            await more.first().click();
+            try {
+                await menu.waitFor({ state: 'visible', timeout: 2_000 });
+                return true;
+            } catch {
+                // Menu didn't open this attempt — retry.
+            }
+        }
+        await menu.waitFor({ state: 'visible', timeout: 3_000 });
+        return true;
+    }
+
+    /**
+     * Activates a result control, looking in the toolbar first and the overflow
+     * menu second. For plain action buttons (Reload / paging) this fires the
+     * action; for the split menus (Copy / Export) it opens their submenu — use
+     * {@link copyResults} / {@link exportResults} for those.
+     */
+    async clickResultControl(control: ToolbarControl): Promise<void> {
+        const inline = this.inlineResultControl(control);
+        if (await inline.isVisible().catch(() => false)) {
+            await inline.click();
+            return;
+        }
+        if (!(await this.openResultOverflowMenu())) {
+            throw new Error(`Result control "${control.toolbarName}" is neither inline nor in the overflow menu.`);
+        }
+        await this.frame.getByRole('menu').first().getByText(control.menuText, { exact: true }).first().click();
+    }
+
+    /** Re-runs the current query via the Reload button. */
+    async reloadResults(): Promise<void> {
+        await this.clickResultControl(RESULT_CONTROLS.reload);
+    }
+
+    /** Navigates result pages (disabled controls are simply no-ops in the UI). */
+    async goToNextPage(): Promise<void> {
+        await this.clickResultControl(RESULT_CONTROLS.nextPage);
+    }
+    async goToPrevPage(): Promise<void> {
+        await this.clickResultControl(RESULT_CONTROLS.prevPage);
+    }
+    async goToFirstPage(): Promise<void> {
+        await this.clickResultControl(RESULT_CONTROLS.firstPage);
+    }
+
+    /**
+     * Reads the status-bar record range (e.g. `0 - 10`) shown in the result
+     * toolbar for the current page. Polls because it briefly shows a timer
+     * while a query is executing.
+     */
+    async getStatusRange(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<string> {
+        const range = this.resultToolbar()
+            .getByText(/^\d+\s*-\s*\d+$/)
+            .first();
+        await range.waitFor({ state: 'visible', timeout: timeoutMs });
+        return (await range.innerText()).trim();
+    }
+
+    /**
+     * Opens the Copy split menu (toolbar or overflow) and picks a format,
+     * copying the current page / selection to the clipboard.
+     */
+    async copyResults(format: ExportFormat = 'JSON'): Promise<void> {
+        await this.openResultSplitMenu(RESULT_CONTROLS.copy);
+        await this.frame.getByRole('menuitem', { name: format, exact: true }).first().click();
+    }
+
+    /**
+     * Opens the Export split menu (toolbar or overflow) and picks a format. The
+     * underlying save dialog is stubbed by the fixture, so this is a safe no-op
+     * that only proves the action wires up without error.
+     */
+    async exportResults(format: ExportFormat = 'JSON'): Promise<void> {
+        await this.openResultSplitMenu(RESULT_CONTROLS.export);
+        await this.frame.getByRole('menuitem', { name: format, exact: true }).first().click();
+    }
+
+    /** Opens a Copy/Export split menu so its CSV/JSON items become available. */
+    private async openResultSplitMenu(control: ToolbarControl): Promise<void> {
+        const inline = this.inlineResultControl(control);
+        if (await inline.isVisible().catch(() => false)) {
+            await inline.click();
+            return;
+        }
+        if (!(await this.openResultOverflowMenu())) {
+            throw new Error(`Result control "${control.toolbarName}" is neither inline nor in the overflow menu.`);
+        }
+        await this.frame.getByRole('menu').first().getByText(control.menuText, { exact: true }).first().click();
+    }
+
+    // ─── Result tabs (Result / Stats) ─────────────────────────────────────
+
+    /** Switches to the Stats tab (query metrics + index metrics). */
+    async switchToStatsTab(): Promise<void> {
+        await this.resultRegion().getByRole('tab', { name: 'Stats' }).click();
+    }
+
+    /** Switches back to the Result tab (the data views). */
+    async switchToResultTab(): Promise<void> {
+        await this.resultRegion().getByRole('tab', { name: 'Result' }).click();
+    }
+
+    /**
+     * True once the Stats tab's query-metrics panel is populated. Anchored on
+     * the panel's "Learn more about query metrics" link, whose accessible name
+     * is stable regardless of which metrics the backend returned.
+     */
+    async hasQueryMetrics(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<boolean> {
+        return this.resultRegion()
+            .getByRole('link', { name: 'Learn more about query metrics' })
+            .first()
+            .isVisible({ timeout: timeoutMs })
+            .catch(() => false);
+    }
+
+    /**
+     * True when the Stats tab's index-metrics panel is rendered. The panel only
+     * appears when the query result carried a non-empty `indexMetrics` payload.
+     * Anchored on its "Learn more about index metrics" link.
+     */
+    async hasIndexMetrics(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<boolean> {
+        return this.resultRegion()
+            .getByRole('link', { name: 'Learn more about index metrics' })
+            .first()
+            .isVisible({ timeout: timeoutMs })
+            .catch(() => false);
+    }
+
+    // ─── Page size (incl. the re-run confirmation modal) ──────────────────
+
+    /** The page-size dropdown (Fluent combobox) in the result toolbar. */
+    pageSizeDropdown() {
+        return this.resultRegion().getByRole('combobox', { name: 'Change page size' });
+    }
+
+    /** Reads the current page-size value shown by the dropdown (e.g. `10`, `All`). */
+    async getPageSizeValue(): Promise<string> {
+        return (await this.pageSizeDropdown().first().innerText()).trim();
+    }
+
+    /**
+     * Selects a page size via the dropdown. `size` is the option label (`10`,
+     * `50`, `100`, `500`, or `All`). Does NOT handle the re-run confirmation
+     * modal that the backend raises when a query has already executed — drive
+     * it via {@link confirmPageSizeModal} / {@link dismissPageSizeModal}.
+     */
+    async setPageSize(size: '10' | '50' | '100' | '500' | 'All'): Promise<void> {
+        const dropdown = this.pageSizeDropdown().first();
+        if (await dropdown.isVisible().catch(() => false)) {
+            await dropdown.click();
+        } else {
+            // Collapsed: open the result overflow menu, then the "Change page
+            // size" submenu, before picking the value.
+            if (!(await this.openResultOverflowMenu())) {
+                throw new Error('Page-size control is neither inline nor in the overflow menu.');
+            }
+            await this.frame.getByRole('menu').first().getByText('Change page size', { exact: true }).first().click();
+        }
+        await this.frame.getByRole('option', { name: size, exact: true }).first().click();
+    }
+
+    /**
+     * Best-effort check that no native page-size confirmation modal is pending.
+     * The confirmation is a native Electron dialog (auto-resolved by the test
+     * dialog stub), so there is no in-DOM modal to assert against — this simply
+     * confirms no stray workbench dialog leaked onto the main window.
+     */
+    pageSizeModal() {
+        return this.window.locator('.monaco-dialog-box');
     }
 
     /**

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -548,6 +548,23 @@ export class QueryEditorPage {
         return this.resultRegion().getByRole('button', { name: SELECTION_ACTIONS[action] });
     }
 
+    /** The "Add new item" button — present in edit mode regardless of selection. */
+    newItemButton() {
+        return this.resultRegion().getByRole('button', { name: 'Add new item' });
+    }
+
+    /** Clicks "Add new item", which opens a Document webview in 'add' mode. */
+    async addNewItem(): Promise<void> {
+        await this.newItemButton().click();
+    }
+
+    /** Selects row `index` then invokes its View/Edit/Delete item action. */
+    async invokeSelectionAction(index: number, action: SelectionAction): Promise<void> {
+        await this.selectRow(index);
+        await expect(this.selectionActionButton(action)).toBeEnabled();
+        await this.selectionActionButton(action).click();
+    }
+
     /**
      * Waits for the Document webview opened by a row drill-in (double-click or
      * the View / Edit item buttons) to mount, returning its content frame. The

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -207,8 +207,38 @@ export class QueryEditorPage {
         await captureNamedScreenshot(window, 'loaded');
         return new QueryEditorPage(frame, window, consoleHealth);
     }
+
+    /**
+     * Attaches to a Query Editor webview *other than* `exclude` — the second
+     * tab that {@link duplicateTab} spawns. Finds a content frame that is not
+     * the excluded one, renders the Run button, and has its Monaco editor
+     * mounted, then starts a fresh console-health monitor for it. Caller owns
+     * the returned page-object and should {@link dispose} it.
+     */
+    static async attachOther(window: Page, exclude: Frame): Promise<QueryEditorPage> {
+        const frame = await getWebviewByPredicate(window, async (candidate) => {
+            if (candidate === exclude) {
+                return false;
+            }
+            return (await candidate.getByRole('button', { name: QUERY_TOOLBAR.run, exact: true }).count()) > 0;
+        });
+        const consoleHealth = startConsoleHealth(frame);
+        await expect(frame.locator('#root')).toBeVisible();
+        await frame.locator('.monaco-editor').first().waitFor({ state: 'visible', timeout: DEFAULT_TIMEOUT_MS });
+        return new QueryEditorPage(frame, window, consoleHealth);
+    }
     async run(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
         await this.frame.getByRole('button', { name: 'Run', exact: true }).click({ timeout: timeoutMs });
+    }
+
+    /**
+     * Activates the "Duplicate" toolbar control, which opens a second Query
+     * Editor tab seeded with the current editor text (routing through the
+     * overflow menu when the toolbar has collapsed it). Use
+     * {@link QueryEditorPage.attachOther} to drive the resulting tab.
+     */
+    async duplicateTab(): Promise<void> {
+        await this.clickControl(QUERY_CONTROLS.duplicate);
     }
 
     /**

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -600,6 +600,29 @@ export class QueryEditorPage {
         await this.window.keyboard.type(text);
     }
 
+    /**
+     * Selects the whole of (0-based) editor line `lineIndex`, leaving it as the
+     * active selection. The Query Editor tracks the Monaco selection into
+     * `querySelectedValue`, and Run executes that selection in preference to the
+     * full editor text — so this drives the "run only the selected fragment"
+     * path. Navigates by keyboard (Ctrl+Home + ArrowDown) to avoid fragile
+     * per-line click coordinates; the first `Home` lands on the first
+     * non-whitespace column, so any auto-indent is excluded from the selection.
+     */
+    async selectQueryLine(lineIndex: number): Promise<void> {
+        await this.frame.locator('.monaco-editor').first().click();
+        await this.frame.locator('textarea.inputarea').first().waitFor({ state: 'attached', timeout: 5_000 });
+        await this.window.keyboard.press('Control+Home');
+        for (let i = 0; i < lineIndex; i++) {
+            await this.window.keyboard.press('ArrowDown');
+        }
+        await this.window.keyboard.press('Home');
+        await this.window.keyboard.press('Shift+End');
+        // Let the selection-change event flush into querySelectedValue before the
+        // caller triggers Run.
+        await this.window.waitForTimeout(200);
+    }
+
     // ─── Result toolbar (reload / paging / copy / export) ─────────────────
 
     /** The Result Panel `section` (role `region`), scoping result-side lookups. */

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -969,9 +969,34 @@ export class QueryEditorPage {
      * editor as a newline).
      */
     async runViaHotkey(): Promise<void> {
+        await this.focusEditor();
+        await this.window.keyboard.press('F5');
+    }
+
+    /**
+     * Moves keyboard focus into the Monaco editor so the `queryEditor`-scoped
+     * hotkeys (ExecuteQuery, SaveToDisk, OpenQuery, Cancel) reach the webview's
+     * document-level listener bound to the QueryPanel subtree.
+     */
+    async focusEditor(): Promise<void> {
         await this.frame.locator('.monaco-editor').first().click();
         await this.frame.locator('textarea.inputarea').first().waitFor({ state: 'attached', timeout: 5_000 });
-        await this.window.keyboard.press('F5');
+    }
+
+    /** Focuses the editor, then presses an editor-scoped hotkey (e.g. `Control+O`). */
+    async pressEditorHotkey(key: string): Promise<void> {
+        await this.focusEditor();
+        await this.window.keyboard.press(key);
+    }
+
+    /**
+     * Focuses the result panel, then presses a `resultPanel`-scoped hotkey
+     * (paging, Refresh, Copy, Export). Focus lands on the result tablist, which
+     * is inside the ResultPanel subtree the scope is bound to.
+     */
+    async pressResultHotkey(key: string): Promise<void> {
+        await this.focusResultPanel();
+        await this.window.keyboard.press(key);
     }
 
     /**

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -872,6 +872,26 @@ export class QueryEditorPage {
         await this.resultRegion().getByRole('tab', { name: 'Result' }).click();
     }
 
+    /** Locator for the named result tab (`Result` / `Stats`). */
+    resultTab(name: 'Result' | 'Stats') {
+        return this.resultRegion().getByRole('tab', { name, exact: true });
+    }
+
+    /** True when the named result tab is the currently selected one. */
+    async isResultTabSelected(name: 'Result' | 'Stats'): Promise<boolean> {
+        return (await this.resultTab(name).getAttribute('aria-selected')) === 'true';
+    }
+
+    /**
+     * Moves keyboard focus into the result panel (without selecting a data row)
+     * so the webview's document-level hotkey listeners receive subsequent
+     * keystrokes. Clicks the result tablist, which is a focusable, side-effect
+     * free target.
+     */
+    async focusResultPanel(): Promise<void> {
+        await this.resultRegion().getByRole('tablist').first().click();
+    }
+
     /**
      * True once the Stats tab's query-metrics panel is populated. Anchored on
      * the panel's "Learn more about query metrics" link, whose accessible name

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -369,6 +369,64 @@ export class QueryEditorPage {
         return this.frame.getByRole('combobox', { name: QUERY_TOOLBAR.connection });
     }
 
+    // ─── Run history ──────────────────────────────────────────────────────
+
+    /**
+     * The Run split-button's history menu trigger (the dropdown arrow next to
+     * the primary "Run" action). Its accessible name is "Show history of
+     * previous queries" (`RunQueryButton.tsx`). On a wide window it stays inline
+     * in the query toolbar; the history specs maximize to keep it there.
+     */
+    runHistoryTrigger() {
+        return this.frame.getByRole('button', { name: 'Show history of previous queries' });
+    }
+
+    /**
+     * Opens the Run split-button history menu and waits for it to render. The
+     * Fluent popover here does not expose a `role="menu"` container, so this
+     * waits on the first `menuitem` instead.
+     */
+    async openRunHistoryMenu(): Promise<void> {
+        const trigger = this.runHistoryTrigger().first();
+        const anyItem = this.frame.getByRole('menuitem').first();
+        // The Fluent SplitButton menu trigger occasionally swallows the first
+        // click, so retry — but bail out early once an item is visible to avoid
+        // a second click toggling it shut (mirrors {@link openOverflowMenu}).
+        for (let attempt = 0; attempt < 3; attempt++) {
+            if (await anyItem.isVisible().catch(() => false)) {
+                return;
+            }
+            await trigger.click();
+            try {
+                await anyItem.waitFor({ state: 'visible', timeout: 2_000 });
+                return;
+            } catch {
+                // Menu didn't open this attempt — loop and try again.
+            }
+        }
+        await anyItem.waitFor({ state: 'visible', timeout: 3_000 });
+    }
+
+    /**
+     * Visible text of every entry in the open Run history menu. Includes the
+     * disabled "No history" placeholder when the history is empty, plus any
+     * configuration submenu triggers (Throughput Bucket / Priority Level) when
+     * the connection exposes them — neither appears on the emulator.
+     */
+    async getHistoryEntries(): Promise<string[]> {
+        return this.frame.getByRole('menuitem').allInnerTexts();
+    }
+
+    /**
+     * Reads the current Monaco editor text (the rendered query buffer). Monaco
+     * renders inter-token gaps as non-breaking spaces, so they are normalized
+     * back to regular spaces for stable substring assertions.
+     */
+    async getQueryText(): Promise<string> {
+        const rendered = await this.frame.locator('.monaco-editor .view-lines').first().innerText();
+        return rendered.replace(/\u00a0/g, ' ').trim();
+    }
+
     // ─── Result view modes (Tree / JSON / Table) ──────────────────────────
 
     /**

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -889,7 +889,14 @@ export class QueryEditorPage {
      * free target.
      */
     async focusResultPanel(): Promise<void> {
-        await this.resultRegion().getByRole('tablist').first().click();
+        // Closing a Document panel just before this call can briefly tear down
+        // and re-render the result webview, surfacing a transient "context
+        // destroyed"/"target closed" error on the click. Retry until the
+        // tablist is clickable so the focus action rides through that churn.
+        const tablist = this.resultRegion().getByRole('tablist').first();
+        await expect(async () => {
+            await tablist.click({ timeout: 2_000 });
+        }).toPass({ timeout: 15_000 });
     }
 
     /**

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -241,6 +241,25 @@ export class QueryEditorPage {
         await this.clickControl(QUERY_CONTROLS.duplicate);
     }
 
+    /** The query toolbar's Run split-button (primary action). */
+    runButton() {
+        return this.toolbar().getByRole('button', { name: 'Run', exact: true });
+    }
+
+    /**
+     * The query toolbar's Cancel button. It is disabled at rest and enabled only
+     * while a query is executing (`state.isExecuting`), so it doubles as an
+     * observable "a query is in flight" signal.
+     */
+    cancelButton() {
+        return this.toolbar().getByRole('button', { name: QUERY_TOOLBAR.cancel });
+    }
+
+    /** Clicks the Cancel button to abort the in-flight query. */
+    async cancelQuery(): Promise<void> {
+        await this.cancelButton().click();
+    }
+
     /**
      * Waits until a known seeded row id is visible in the results, proving the
      * query round-tripped to the emulator and rendered. Defaults to

--- a/test/e2e/fixtures/queryEditor.ts
+++ b/test/e2e/fixtures/queryEditor.ts
@@ -185,9 +185,28 @@ export class QueryEditorPage {
     }
 
     /**
-     * Clicks the primary Run action on the default (or current) query. Does
-     * not wait for results — call {@link waitForResults} / {@link expectRow}.
+     * Attaches to a Query Editor webview that some *other* affordance already
+     * opened — e.g. the production "Open Query Editor" tree action exercised by
+     * the tree-open spec — rather than opening one via the e2e command. Finds
+     * the content frame by its rendered Run button (so it never matches another
+     * panel's frame) and starts the console-health monitor.
      */
+    static async fromOpenTab(window: Page): Promise<QueryEditorPage> {
+        const frame = await getWebviewByPredicate(
+            window,
+            async (candidate) =>
+                (await candidate.getByRole('button', { name: QUERY_TOOLBAR.run, exact: true }).count()) > 0,
+        );
+        const consoleHealth = startConsoleHealth(frame);
+        await expect(frame.locator('#root')).toBeVisible();
+        await expect(frame.getByRole('toolbar').first()).toBeVisible({ timeout: DEFAULT_TIMEOUT_MS });
+        await expect(frame.getByRole('button', { name: QUERY_TOOLBAR.run, exact: true })).toBeVisible({
+            timeout: DEFAULT_TIMEOUT_MS,
+        });
+        await frame.locator('.monaco-editor').first().waitFor({ state: 'visible', timeout: DEFAULT_TIMEOUT_MS });
+        await captureNamedScreenshot(window, 'loaded');
+        return new QueryEditorPage(frame, window, consoleHealth);
+    }
     async run(timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<void> {
         await this.frame.getByRole('button', { name: 'Run', exact: true }).click({ timeout: timeoutMs });
     }

--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -47,6 +47,7 @@ import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
 import { ensureE2eIsolationContext } from '../helpers/e2eIsolation';
 import { waitForWorkbenchReady } from '../helpers/workbenchReady';
 import { waitForExtensionsActivated } from '../setup/activation';
+import { isCoverageEnabled, startCoverage, stopAndPersistCoverage } from './coverage';
 import { closeAuxiliaryBar } from './webviewHelpers';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -162,6 +163,11 @@ interface VsCodeTestFixtures {
      * `COSMOSDB_E2E_SCREENSHOT` selects a `trace` mode. See the fixture body.
      */
     windowTrace: void;
+    /**
+     * Auto fixture that captures JS coverage for the VS Code webview window
+     * when `COSMOSDB_E2E_COVERAGE=1` is set.
+     */
+    coverage: void;
 }
 
 export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
@@ -213,6 +219,14 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
                     // Headless/CI envs without a real GPU surface — avoid GPU init crashes.
                     '--disable-gpu',
                     '--disable-gpu-sandbox',
+                    // Coverage runs only: keep the webview iframe in the page's
+                    // renderer process so Playwright's page-level V8 coverage
+                    // (`page.coverage`) can see its scripts. With site isolation
+                    // on, the webview is an out-of-process iframe and its
+                    // coverage is never reported. No effect on normal runs.
+                    ...(isCoverageEnabled()
+                        ? ['--disable-site-isolation-trials', '--disable-features=IsolateOrigins,site-per-process']
+                        : []),
                     // Force a new window so the launcher doesn't try to attach to a
                     // running instance (which would fail Playwright's CDP attach).
                     '--new-window',
@@ -396,6 +410,17 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
             } catch {
                 // Best-effort — never fail a test on trace capture/teardown.
             }
+        },
+        { auto: true },
+    ],
+
+    coverage: [
+        async ({ vscodeWindow }, use, testInfo) => {
+            await startCoverage(vscodeWindow);
+
+            await use();
+
+            await stopAndPersistCoverage(vscodeWindow, testInfo);
         },
         { auto: true },
     ],

--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -47,6 +47,7 @@ import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
 import { ensureE2eIsolationContext } from '../helpers/e2eIsolation';
 import { waitForWorkbenchReady } from '../helpers/workbenchReady';
 import { waitForExtensionsActivated } from '../setup/activation';
+import { closeAuxiliaryBar } from './webviewHelpers';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..', '..', '..');
@@ -96,8 +97,15 @@ function seedUserSettings(userDataDir: string): void {
         // worker should start with an empty workbench.
         'files.hotExit': 'onExitAndWindowClose',
         // Chat / secondary sidebar can autopopup on fresh installs and steal
-        // 30 % of horizontal space, hiding webview content.
+        // 30 % of horizontal space, hiding webview content. The setting below
+        // is best-effort (auxiliary-bar visibility is mostly persisted UI
+        // state, not a real setting), so we also explicitly close the
+        // auxiliary bar once the workbench is ready — see `closeAuxiliaryBar`
+        // in the `vscodeWindow` fixture.
         'workbench.secondarySideBar.visible': false,
+        // Drop the Chat entry from the title-bar command center so a fresh
+        // profile doesn't surface the chat affordance at all.
+        'chat.commandCenter.enabled': false,
         // Silence "do you trust this folder" — we already pass --disable-workspace-trust.
         'security.workspace.trust.enabled': false,
         // Cosmos DB emulator (linux/vnext-preview) advertises its writable
@@ -116,14 +124,15 @@ function seedUserSettings(userDataDir: string): void {
 
 /**
  * Monkey-patch Electron's main-process `dialog` module so native
- * save / message dialogs never block the test. Untitled SQL editors,
- * unsaved changes on tab close, etc. would otherwise pop an OS dialog
- * that Playwright cannot interact with.
+ * save / open / message dialogs never block the test. Untitled SQL editors,
+ * unsaved changes on tab close, the Query Editor's "Open query" file picker,
+ * etc. would otherwise pop an OS dialog that Playwright cannot interact with.
  */
 async function disableNativeDialogs(app: ElectronApplication): Promise<void> {
     await app
         .evaluate(({ dialog }) => {
             dialog.showSaveDialog = () => Promise.resolve({ canceled: true, filePath: '' });
+            dialog.showOpenDialog = () => Promise.resolve({ canceled: true, filePaths: [] });
             dialog.showMessageBoxSync = () => 1; // Typically "Don't Save"
             dialog.showMessageBox = () => Promise.resolve({ response: 1, checkboxChecked: false });
         })
@@ -316,6 +325,12 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
             // exactly once even with dozens of specs. See activation.ts for
             // the full rationale.
             await waitForExtensionsActivated(page);
+
+            // A fresh VS Code profile can auto-open the Chat view in the
+            // auxiliary (secondary) side bar, which eats ~30 % of horizontal
+            // space and squeezes the webview under test. Close it once here so
+            // every spec starts with the editor area at full width.
+            await closeAuxiliaryBar(page);
 
             await use(page);
         },

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -23,7 +23,7 @@
  * the webview to be fully populated (React mounted, expected UI present).
  */
 
-import { test, type Frame, type Page } from '@playwright/test';
+import { test, type ElectronApplication, type Frame, type Page } from '@playwright/test';
 import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
 
 const COMMAND_PALETTE_SHORTCUT = process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P';
@@ -31,6 +31,71 @@ const QUICK_INPUT_SELECTOR = '.quick-input-widget input';
 const TAB_SELECTOR = 'div[role="tab"]';
 const WEBVIEW_FRAME_TIMEOUT_MS = 30_000;
 const WEBVIEW_POLL_INTERVAL_MS = 250;
+
+/**
+ * Maximizes (and enlarges) the VS Code window so webview toolbars render all of
+ * their controls inline instead of collapsing into a Fluent UI "More items"
+ * overflow menu. Several Query Editor specs assert on toolbar buttons directly;
+ * a wide, deterministic window removes overflow-driven flakiness. Best-effort —
+ * never throws.
+ */
+export async function maximizeWindow(app: ElectronApplication): Promise<void> {
+    await app
+        .evaluate(({ BrowserWindow }) => {
+            const [win] = BrowserWindow.getAllWindows();
+            if (!win) {
+                return;
+            }
+            win.setBounds({ x: 0, y: 0, width: 1920, height: 1200 });
+            win.maximize();
+        })
+        .catch(() => {
+            /* No window yet / context torn down — callers tolerate this. */
+        });
+}
+
+/**
+ * Resizes the VS Code window to an explicit width/height (un-maximizing first
+ * if needed). Use this to make the editor area — and therefore a webview's
+ * toolbar — narrow enough to force Fluent UI's `Overflow` to collapse controls
+ * into the "More items" menu. Best-effort — never throws.
+ */
+export async function resizeWindow(app: ElectronApplication, width: number, height: number): Promise<void> {
+    await app
+        .evaluate(
+            ({ BrowserWindow }, bounds) => {
+                const [win] = BrowserWindow.getAllWindows();
+                if (!win) {
+                    return;
+                }
+                if (win.isMaximized()) {
+                    win.unmaximize();
+                }
+                win.setBounds({ x: 0, y: 0, width: bounds.width, height: bounds.height });
+            },
+            { width, height },
+        )
+        .catch(() => {
+            /* No window yet / context torn down — callers tolerate this. */
+        });
+}
+
+/**
+ * Closes the auxiliary (secondary) side bar — where a fresh VS Code profile may
+ * auto-open the Chat view. Leaving it open steals horizontal space from the
+ * editor area and squeezes webviews under test. Best-effort — never throws.
+ */
+export async function closeAuxiliaryBar(page: Page): Promise<void> {
+    if (page.isClosed()) {
+        return;
+    }
+    try {
+        await runCommand(page, 'workbench.action.closeAuxiliaryBar');
+    } catch {
+        // The command may be unavailable (older builds) or the bar already
+        // closed — either way there's nothing to clean up.
+    }
+}
 
 /** Frames whose parent is non-null = nested = webview content frames. */
 function getWebviewFrames(page: Page): Frame[] {
@@ -149,6 +214,48 @@ export async function captureWindowScreenshot(page: Page, name = 'vscode-window'
             const file = info.outputPath(`${name}.png`);
             await page.screenshot({ path: file });
             await info.attach(`${name} (${info.title})`, { path: file, contentType: 'image/png' });
+        });
+    } catch {
+        // Best-effort — never fail a test on screenshot capture.
+    }
+}
+
+/**
+ * Captures a screenshot of the whole VS Code window to a file named after the
+ * current test (plus a `label` such as `loaded` / `final`), attaches it to the
+ * HTML report, and writes it under the per-test results directory.
+ *
+ * Unlike {@link captureWindowScreenshot} (which honours the only-on-failure
+ * default), this fires for *every* test so you can eyeball what each test
+ * actually rendered — useful while building out coverage. It is suppressed only
+ * when `COSMOSDB_E2E_SCREENSHOT=off`. Best-effort: never fails a test.
+ */
+export async function captureNamedScreenshot(page: Page, label: string): Promise<void> {
+    if (page.isClosed()) return;
+
+    let info: ReturnType<typeof test.info>;
+    try {
+        info = test.info();
+    } catch {
+        // Not running inside a test (e.g. called from a non-test context).
+        return;
+    }
+
+    if (resolveCapturePlan().screenshot === 'off') return;
+
+    const slug = (value: string, max: number): string =>
+        value
+            .trim()
+            .replace(/[^a-z0-9-_]+/gi, '-')
+            .replace(/(^-+|-+$)/g, '')
+            .toLowerCase()
+            .slice(0, max) || 'shot';
+
+    try {
+        await test.step(`📸 ${label}`, async () => {
+            const file = info.outputPath(`${slug(info.title, 60)}-${slug(label, 20)}.png`);
+            await page.screenshot({ path: file });
+            await info.attach(`${label} (${info.title})`, { path: file, contentType: 'image/png' });
         });
     } catch {
         // Best-effort — never fail a test on screenshot capture.

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -81,6 +81,50 @@ export async function resizeWindow(app: ElectronApplication, width: number, heig
 }
 
 /**
+ * Overrides the native Electron message-box (used by VS Code modal
+ * `showWarningMessage`/`showInformationMessage` prompts when the default
+ * `window.dialogStyle: 'native'` is in effect) so a test can deterministically
+ * "click" a specific button without a real, non-interactable OS dialog.
+ *
+ * `buttonLabelPattern` is a case-insensitive RegExp source matched against the
+ * dialog's button labels; the first matching button's index is returned as the
+ * response (falling back to 0 when nothing matches). Restore the fixture's
+ * default with {@link resetNativeDialogStubs} afterwards (the Electron app is
+ * worker-scoped, so the override otherwise leaks into later tests).
+ */
+export async function stubMessageBoxButton(app: ElectronApplication, buttonLabelPattern: string): Promise<void> {
+    await app.evaluate(({ dialog }, pattern) => {
+        const re = new RegExp(pattern, 'i');
+        // VS Code calls dialog.showMessageBox either as (window, options) or
+        // (options); pick whichever argument carries the `buttons` array.
+        dialog.showMessageBox = ((...args: unknown[]) => {
+            const opts = (args.length > 1 ? args[1] : args[0]) as { buttons?: string[] } | undefined;
+            const buttons = opts?.buttons ?? [];
+            const index = buttons.findIndex((label) => re.test(label));
+            return Promise.resolve({ response: index >= 0 ? index : 0, checkboxChecked: false });
+        }) as typeof dialog.showMessageBox;
+    }, buttonLabelPattern);
+}
+
+/**
+ * Restores the native dialog stubs to the fixture defaults (cancel/decline
+ * everything). Mirrors `disableNativeDialogs` in `vscode.ts`; call this in a
+ * test's cleanup after {@link stubMessageBoxButton}.
+ */
+export async function resetNativeDialogStubs(app: ElectronApplication): Promise<void> {
+    await app
+        .evaluate(({ dialog }) => {
+            dialog.showSaveDialog = () => Promise.resolve({ canceled: true, filePath: '' });
+            dialog.showOpenDialog = () => Promise.resolve({ canceled: true, filePaths: [] });
+            dialog.showMessageBoxSync = () => 1;
+            dialog.showMessageBox = () => Promise.resolve({ response: 1, checkboxChecked: false });
+        })
+        .catch(() => {
+            /* Context may be torn down during teardown — tolerate. */
+        });
+}
+
+/**
  * Closes the auxiliary (secondary) side bar — where a fresh VS Code profile may
  * auto-open the Chat view. Leaving it open steals horizontal space from the
  * editor area and squeezes webviews under test. Best-effort — never throws.

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -382,3 +382,12 @@ export async function closeActiveEditorTab(page: Page): Promise<void> {
         // Best-effort — never fail a test on cleanup.
     }
 }
+
+/**
+ * Counts the open editor tabs in the workbench. Used to assert that an action
+ * (e.g. the Query Editor "Duplicate" control) actually spawned a new tab.
+ */
+export async function countEditorTabs(page: Page): Promise<number> {
+    if (page.isClosed()) return 0;
+    return page.locator(TAB_SELECTOR).count();
+}

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -346,3 +346,39 @@ export async function closeAllEditorTabs(page: Page): Promise<void> {
         // Best-effort cleanup — never fail a test on cleanup.
     }
 }
+
+/**
+ * Closes only the *active* editor tab via
+ * `workbench.action.revertAndCloseActiveEditor`, reverting any unsaved changes
+ * so no save prompt blocks the test. Use this to dismiss a Document panel that a
+ * Query Editor drill-in (New / View / Edit item) opened while keeping the Query
+ * Editor tab itself open. Returns once the tab count has dropped (or after a
+ * best-effort timeout).
+ */
+export async function closeActiveEditorTab(page: Page): Promise<void> {
+    if (page.isClosed()) return;
+
+    const before = await page.locator(TAB_SELECTOR).count();
+    if (before === 0) return;
+
+    try {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(150);
+
+        const input = page.locator(QUICK_INPUT_SELECTOR).first();
+        await page.keyboard.press(COMMAND_PALETTE_SHORTCUT);
+        await input.waitFor({ state: 'visible', timeout: 2_000 });
+        await input.fill('>workbench.action.revertAndCloseActiveEditor');
+        await page.waitForTimeout(150);
+        await page.keyboard.press('Enter');
+
+        // Wait for the tab count to actually drop so callers can rely on the
+        // previous editor regaining focus.
+        for (let attempt = 0; attempt < 20; attempt++) {
+            if ((await page.locator(TAB_SELECTOR).count()) < before) return;
+            await page.waitForTimeout(150);
+        }
+    } catch {
+        // Best-effort — never fail a test on cleanup.
+    }
+}

--- a/test/e2e/helpers/e2eIsolation.ts
+++ b/test/e2e/helpers/e2eIsolation.ts
@@ -32,7 +32,7 @@ const RESULTS_ROOT_ENV = 'COSMOSDB_E2E_RESULTS_ROOT';
 const REPORTS_ROOT_ENV = 'COSMOSDB_E2E_REPORTS_ROOT';
 
 export interface E2eIsolationContext {
-    /** Short random token unique per invocation (env-overridable). */
+    /** Sortable run token, `YYYYMMDD-HHMMSS-xxxx` by default (env-overridable). */
     readonly runId: string;
     /** Root for everything ephemeral — user-data dirs, workspace dirs, etc. */
     readonly tempRootDir: string;
@@ -56,9 +56,22 @@ function resolveRunId(): string {
         process.env[RUN_ID_ENV] = fromEnv;
         return fromEnv;
     }
-    const generated = randomBytes(4).toString('hex');
+    // Default to a sortable timestamp so `.results` / `.reports` list in
+    // chronological order; a short random suffix keeps two runs started in the
+    // same second from colliding.
+    const generated = `${timestampToken()}-${randomBytes(2).toString('hex')}`;
     process.env[RUN_ID_ENV] = generated;
     return generated;
+}
+
+/** Compact, filesystem- and sort-friendly local timestamp: `YYYYMMDD-HHMMSS`. */
+function timestampToken(): string {
+    const now = new Date();
+    const pad = (value: number): string => String(value).padStart(2, '0');
+    return (
+        `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+        `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
+    );
 }
 
 /**

--- a/test/e2e/setup/aggregateCoverage.ts
+++ b/test/e2e/setup/aggregateCoverage.ts
@@ -1,0 +1,269 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { ensureE2eIsolationContext } from '../helpers/e2eIsolation';
+
+interface CoverageFileEntry {
+    path: string;
+    mappedLineNumbers?: number[];
+    coveredLineNumbers?: number[];
+}
+
+interface CoverageArtifact {
+    testTitle?: string;
+    files?: CoverageFileEntry[];
+}
+
+interface SummaryEntry {
+    path: string;
+    totalLines: number;
+    coveredLines: number;
+    lineCoveragePercent: number;
+    testCount: number;
+    coveredLineNumbers: number[];
+    uncoveredLineNumbers: number[];
+}
+
+interface CoverageReport {
+    generatedAt: string;
+    resultsRootDir: string;
+    reportsRootDir: string;
+    artifactCount: number;
+    totals: {
+        components: number;
+        totalLines: number;
+        coveredLines: number;
+        lineCoveragePercent: number;
+    };
+    entries: SummaryEntry[];
+}
+
+function collectCoverageArtifacts(rootDir: string): string[] {
+    if (!existsSync(rootDir)) {
+        return [];
+    }
+
+    const result: string[] = [];
+    const stack: string[] = [rootDir];
+    while (stack.length > 0) {
+        const current = stack.pop();
+        if (!current || !existsSync(current)) {
+            continue;
+        }
+        for (const entry of readdirSync(current, { withFileTypes: true })) {
+            const fullPath = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                stack.push(fullPath);
+            } else if (entry.isFile() && entry.name === 'coverage.json') {
+                result.push(fullPath);
+            }
+        }
+    }
+    return result.sort((a, b) => a.localeCompare(b));
+}
+
+function renderMarkdown(report: CoverageReport): string {
+    const lines: string[] = [
+        '# E2E webview coverage summary',
+        '',
+        `- Generated: ${report.generatedAt}`,
+        `- Coverage artifacts: ${report.artifactCount}`,
+        `- Results root: ${report.resultsRootDir}`,
+        `- Total: ${report.totals.coveredLines}/${report.totals.totalLines} lines ` +
+            `(${report.totals.lineCoveragePercent}%) across ${report.totals.components} components`,
+        '',
+        '## Components',
+        '',
+    ];
+
+    if (report.entries.length === 0) {
+        lines.push('No coverage data collected.');
+        return lines.join('\n');
+    }
+
+    const tree = buildTree(report.entries);
+    renderTreeNode(tree, lines, 0);
+
+    return lines.join('\n');
+}
+
+interface TreeNode {
+    children: Map<string, TreeNode>;
+    entry?: SummaryEntry;
+    coveredLines: number;
+    totalLines: number;
+}
+
+function createTreeNode(): TreeNode {
+    return { children: new Map(), coveredLines: 0, totalLines: 0 };
+}
+
+function buildTree(entries: SummaryEntry[]): TreeNode {
+    const root = createTreeNode();
+    for (const entry of entries) {
+        const segments = entry.path.split('/');
+        let node = root;
+        node.coveredLines += entry.coveredLines;
+        node.totalLines += entry.totalLines;
+        for (let i = 0; i < segments.length; i++) {
+            const segment = segments[i];
+            let child = node.children.get(segment);
+            if (!child) {
+                child = createTreeNode();
+                node.children.set(segment, child);
+            }
+            child.coveredLines += entry.coveredLines;
+            child.totalLines += entry.totalLines;
+            if (i === segments.length - 1) {
+                child.entry = entry;
+            }
+            node = child;
+        }
+    }
+    return root;
+}
+
+function percent(covered: number, total: number): number {
+    return total === 0 ? 100 : Math.round((covered / total) * 1000) / 10;
+}
+
+function renderTreeNode(node: TreeNode, lines: string[], depth: number): void {
+    const sorted = [...node.children.entries()].sort((a, b) => {
+        const aDir = a[1].children.size > 0;
+        const bDir = b[1].children.size > 0;
+        if (aDir !== bDir) {
+            return aDir ? -1 : 1;
+        }
+        return a[0].localeCompare(b[0]);
+    });
+
+    for (const [name, child] of sorted) {
+        const indent = '  '.repeat(depth);
+        const stats = `${child.coveredLines}/${child.totalLines} (${percent(child.coveredLines, child.totalLines)}%)`;
+        if (child.entry) {
+            lines.push(`${indent}- 📄 ${name} — ${stats}`);
+            if (child.entry.uncoveredLineNumbers.length > 0) {
+                lines.push(`${indent}  - Uncovered: ${formatLineRanges(child.entry.uncoveredLineNumbers)}`);
+            }
+        } else {
+            // Collapse single-child directory chains (e.g. `a/b/c`) into one line.
+            let label = name;
+            let current = child;
+            while (current.children.size === 1 && !current.entry) {
+                const [onlyName, onlyChild] = [...current.children.entries()][0];
+                if (onlyChild.entry) {
+                    break;
+                }
+                label += `/${onlyName}`;
+                current = onlyChild;
+            }
+            lines.push(`${indent}- 📁 ${label}/ — ${stats}`);
+            renderTreeNode(current, lines, depth + 1);
+        }
+    }
+}
+
+/** Collapses a sorted list of line numbers into compact `a-b, c, e-f` ranges. */
+function formatLineRanges(sortedLines: number[]): string {
+    const ranges: string[] = [];
+    let start = sortedLines[0];
+    let prev = sortedLines[0];
+    for (let i = 1; i < sortedLines.length; i++) {
+        const n = sortedLines[i];
+        if (n === prev + 1) {
+            prev = n;
+            continue;
+        }
+        ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+        start = n;
+        prev = n;
+    }
+    ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+    return ranges.join(', ');
+}
+
+export function aggregateCoverageArtifacts(): void {
+    const isolation = ensureE2eIsolationContext();
+    const reportsDir = isolation.reportsRootDir;
+    mkdirSync(reportsDir, { recursive: true });
+
+    const artifactFiles = collectCoverageArtifacts(isolation.resultsRootDir);
+    if (artifactFiles.length === 0) {
+        console.log('[e2e coverage] No coverage artifacts found.');
+        return;
+    }
+
+    const perArtifact: CoverageArtifact[] = artifactFiles.map(
+        (file) => JSON.parse(readFileSync(file, 'utf-8')) as CoverageArtifact,
+    );
+    // path -> { mapped: Set<line>, covered: Set<line>, tests: Set<title> }
+    const aggregateMap = new Map<string, { mapped: Set<number>; covered: Set<number>; tests: Set<string> }>();
+
+    for (const artifact of perArtifact) {
+        const files = artifact.files ?? [];
+        for (const entry of files) {
+            let current = aggregateMap.get(entry.path);
+            if (!current) {
+                current = { mapped: new Set(), covered: new Set(), tests: new Set() };
+                aggregateMap.set(entry.path, current);
+            }
+            for (const line of entry.mappedLineNumbers ?? []) {
+                current.mapped.add(line);
+            }
+            for (const line of entry.coveredLineNumbers ?? []) {
+                current.covered.add(line);
+            }
+            current.tests.add(artifact.testTitle ?? '');
+        }
+    }
+
+    const entries: SummaryEntry[] = Array.from(aggregateMap.entries())
+        .map(([filePath, data]) => {
+            const mappedLineNumbers = [...data.mapped].sort((a, b) => a - b);
+            // A line counts as covered if it ran in *any* test.
+            const coveredLineNumbers = mappedLineNumbers.filter((line) => data.covered.has(line));
+            const uncoveredLineNumbers = mappedLineNumbers.filter((line) => !data.covered.has(line));
+            const totalLines = mappedLineNumbers.length;
+            const coveredLines = coveredLineNumbers.length;
+            return {
+                path: filePath,
+                totalLines,
+                coveredLines,
+                lineCoveragePercent: totalLines === 0 ? 100 : Math.round((coveredLines / totalLines) * 1000) / 10,
+                testCount: data.tests.size,
+                coveredLineNumbers,
+                uncoveredLineNumbers,
+            };
+        })
+        .sort((a, b) => a.path.localeCompare(b.path));
+
+    const totalMapped = entries.reduce((sum, e) => sum + e.totalLines, 0);
+    const totalCovered = entries.reduce((sum, e) => sum + e.coveredLines, 0);
+
+    const report: CoverageReport = {
+        generatedAt: new Date().toISOString(),
+        resultsRootDir: isolation.resultsRootDir,
+        reportsRootDir: reportsDir,
+        artifactCount: perArtifact.length,
+        totals: {
+            components: entries.length,
+            totalLines: totalMapped,
+            coveredLines: totalCovered,
+            lineCoveragePercent: totalMapped === 0 ? 100 : Math.round((totalCovered / totalMapped) * 1000) / 10,
+        },
+        entries,
+    };
+
+    const reportFile = path.join(reportsDir, 'coverage-summary.json');
+    const markdownFile = path.join(reportsDir, 'coverage-summary.md');
+    writeFileSync(reportFile, JSON.stringify(report, null, 2), 'utf-8');
+    writeFileSync(markdownFile, renderMarkdown(report), 'utf-8');
+    console.log(
+        `[e2e coverage] Aggregated ${artifactFiles.length} artifacts → ${entries.length} components ` +
+            `(${report.totals.lineCoveragePercent}% lines) at ${reportFile}`,
+    );
+}

--- a/test/e2e/setup/globalSetup.ts
+++ b/test/e2e/setup/globalSetup.ts
@@ -42,12 +42,14 @@ import {
     readdirSync,
     readFileSync,
     realpathSync,
+    rmSync,
     statSync,
     writeFileSync,
     type Dirent,
 } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isCoverageEnabled } from '../fixtures/coverage';
 import {
     E2E_DATABASE_ID,
     E2E_DEFAULT_CONTAINER_ID,
@@ -71,6 +73,14 @@ const VSCODE_VERSION = 'stable';
  * webview rendering under the harness).
  */
 const PROD_BUILD_MARKER = '.e2e-prod-build';
+
+/**
+ * Sidecar written into `dist/` when the webview bundle was built for coverage
+ * (unminified + source maps, via `COSMOSDB_E2E_COVERAGE=1`). Lets the next run
+ * detect a coverage⇄production mismatch and rebuild so normal runs never ship
+ * the slower coverage bundle and coverage runs always have source maps.
+ */
+const COVERAGE_BUILD_MARKER = '.e2e-coverage-build';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..', '..', '..');
@@ -171,11 +181,21 @@ function runViteProd(extensionDevelopmentPath: string): void {
     // (vite-watch:ext) is detected as "not a production build" on the next run.
     const mainMjs = path.join(extensionDevelopmentPath, 'main.mjs');
     writeFileSync(path.join(extensionDevelopmentPath, PROD_BUILD_MARKER), String(statSync(mainMjs).mtimeMs), 'utf-8');
+    // Record whether this was a coverage build (the vite views config keys off
+    // the same env var, so `dist/` and the marker stay in sync).
+    const coverageMarker = path.join(extensionDevelopmentPath, COVERAGE_BUILD_MARKER);
+    if (isCoverageEnabled()) {
+        writeFileSync(coverageMarker, '1', 'utf-8');
+    } else if (existsSync(coverageMarker)) {
+        rmSync(coverageMarker);
+    }
 }
 
 export default async function globalSetup(): Promise<void> {
     // 1. Ensure the extension build is fresh — auto-rebuild if stale.
     const extensionDevelopmentPath = path.resolve(repoRoot, 'dist');
+    const wantCoverageBuild = isCoverageEnabled();
+    const haveCoverageBuild = existsSync(path.join(extensionDevelopmentPath, COVERAGE_BUILD_MARKER));
     if (process.env.COSMOSDB_E2E_SKIP_BUILD === '1') {
         if (!existsSync(path.join(extensionDevelopmentPath, 'main.mjs'))) {
             throw new Error(
@@ -190,10 +210,25 @@ export default async function globalSetup(): Promise<void> {
                     `Webviews can fail to render. Run \`npm run vite-prod\` or drop COSMOSDB_E2E_SKIP_BUILD=1.`,
             );
         }
+        if (wantCoverageBuild !== haveCoverageBuild) {
+            console.warn(
+                `[e2e setup] WARNING: COSMOSDB_E2E_SKIP_BUILD=1 but dist/ is a ${
+                    haveCoverageBuild ? 'coverage' : 'production'
+                } build while a ${wantCoverageBuild ? 'coverage' : 'production'} build was requested. ` +
+                    `Webview coverage may be missing source maps — drop COSMOSDB_E2E_SKIP_BUILD=1 to rebuild.`,
+            );
+        }
     } else {
         const { stale, reason } = isDistStale(extensionDevelopmentPath);
-        if (stale) {
-            console.log(`[e2e setup] dist/ is stale (${reason}) — rebuilding…`);
+        // A coverage⇄production switch also forces a rebuild: coverage builds
+        // are unminified + source-mapped, production builds are minified.
+        if (stale || wantCoverageBuild !== haveCoverageBuild) {
+            const why = stale
+                ? reason
+                : `dist/ is a ${haveCoverageBuild ? 'coverage' : 'production'} build but a ${
+                      wantCoverageBuild ? 'coverage' : 'production'
+                  } build is needed`;
+            console.log(`[e2e setup] Rebuilding dist/ (${why})…`);
             runViteProd(extensionDevelopmentPath);
         } else {
             console.log('[e2e setup] dist/ is up to date');

--- a/test/e2e/setup/globalTeardown.ts
+++ b/test/e2e/setup/globalTeardown.ts
@@ -19,6 +19,7 @@ import { existsSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ensureE2eIsolationContext } from '../helpers/e2eIsolation';
+import { aggregateCoverageArtifacts } from './aggregateCoverage';
 import { clearEmulatorOwnership, isEmulatorOwned, isEmulatorSkipped, stopEmulator } from './emulator';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -35,6 +36,8 @@ export default function globalTeardown(): void {
         }
         clearEmulatorOwnership(repoRoot);
     }
+
+    aggregateCoverageArtifacts();
 
     const isolation = ensureE2eIsolationContext();
     if (!existsSync(isolation.tempRootDir)) return;

--- a/test/e2e/specs/queryEditor-cancel.spec.ts
+++ b/test/e2e/specs/queryEditor-cancel.spec.ts
@@ -77,4 +77,25 @@ test.describe('queryEditor-cancel', { tag: '@queryEditor' }, () => {
 
         qe.consoleHealth.assertNoConsoleErrors();
     });
+
+    test('Esc cancels an in-flight query from the editor', async () => {
+        const qe = queryEditor!;
+
+        await expect(qe.cancelButton()).toBeDisabled();
+
+        await qe.setQueryText(HEAVY_QUERY);
+        await qe.run();
+
+        await expect(qe.cancelButton()).toBeEnabled({ timeout: 15_000 });
+
+        // Cancel via the editor-scoped Esc hotkey instead of the button. Focus
+        // the editor so the QueryPanel listener claims the keystroke.
+        await qe.focusEditor();
+        await qe.window.keyboard.press('Escape');
+
+        await expect(qe.runButton()).toBeEnabled({ timeout: 20_000 });
+        await expect(qe.cancelButton()).toBeDisabled();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
 });

--- a/test/e2e/specs/queryEditor-cancel.spec.ts
+++ b/test/e2e/specs/queryEditor-cancel.spec.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 14 of the Query Editor e2e coverage: the Cancel control.
+ *
+ * The Cancel button is disabled at rest and enabled only while a query is
+ * executing (`state.isExecuting`). Clicking it aborts the in-flight query and
+ * returns the toolbar to the idle state (Run re-enabled, Cancel disabled).
+ *
+ * The seeded emulator answers simple queries near-instantly, so to keep the
+ * "executing" window observable we run a deliberately expensive cross-partition
+ * self-join over the `tags` arrays — its combinatorial blow-up keeps the query
+ * busy long enough to catch and cancel.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/**
+ * A deliberately heavy query: ten self-joins over each document's `tags` array
+ * produce a large combinatorial intermediate the emulator must enumerate before
+ * the COUNT resolves — slow enough that the Cancel button is reliably catchable.
+ */
+const HEAVY_QUERY = [
+    'SELECT VALUE COUNT(1) FROM c',
+    'JOIN a IN c.tags JOIN b IN c.tags JOIN d IN c.tags JOIN e IN c.tags JOIN f IN c.tags',
+    'JOIN g IN c.tags JOIN h IN c.tags JOIN i IN c.tags JOIN j IN c.tags JOIN k IN c.tags',
+].join(' ');
+
+test.describe('queryEditor-cancel', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('Cancel aborts an in-flight query and restores the idle toolbar', async () => {
+        const qe = queryEditor!;
+
+        // At rest: nothing is executing, so Cancel is disabled and Run is live.
+        await expect(qe.cancelButton()).toBeDisabled();
+        await expect(qe.runButton()).toBeEnabled();
+
+        await qe.setQueryText(HEAVY_QUERY);
+        await qe.run();
+
+        // While the heavy query runs, the toolbar flips: Cancel becomes enabled
+        // (and Run goes disabled).
+        await expect(qe.cancelButton()).toBeEnabled({ timeout: 15_000 });
+        await expect(qe.runButton()).toBeDisabled();
+
+        await qe.cancelQuery();
+
+        // Cancelling ends execution and restores the idle toolbar.
+        await expect(qe.runButton()).toBeEnabled({ timeout: 20_000 });
+        await expect(qe.cancelButton()).toBeDisabled();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-column-resize.spec.ts
+++ b/test/e2e/specs/queryEditor-column-resize.spec.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 13 of the Query Editor e2e coverage: the per-column "Resize" dialog.
+ *
+ * Each Table-view column header carries a chevron context menu whose "Resize"
+ * entry opens the `ColumnResizeDialog` — a Fluent dialog with a numeric
+ * "Column Width (px)" field and Apply / Cancel actions. Applying a value pins
+ * the column to that width; cancelling leaves it untouched.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** A `SELECT *` query so the result renders as an edit-mode Table with columns. */
+const TABLE_QUERY = 'SELECT * FROM c';
+/** A column present in every seeded product document. */
+const COLUMN = 'price';
+/** A distinctive target width, comfortably away from the default. */
+const TARGET_WIDTH = 333;
+
+test.describe('queryEditor-column-resize', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('the column header Resize dialog pins an explicit width', async () => {
+        const qe = queryEditor!;
+
+        await qe.setQueryText(TABLE_QUERY);
+        await qe.run();
+        await qe.waitForResults();
+        await qe.setViewMode('Table');
+        await expect.poll(() => qe.tableRows().count()).toBeGreaterThan(0);
+
+        const before = await qe.columnWidth(COLUMN);
+        expect(before).toBeGreaterThan(0);
+        // Pick a target that is unambiguously different from the current width.
+        expect(Math.abs(before - TARGET_WIDTH)).toBeGreaterThan(20);
+
+        await qe.resizeColumn(COLUMN, TARGET_WIDTH);
+
+        // The header settles to (approximately) the applied width, in either
+        // direction from its default.
+        await expect.poll(() => qe.columnWidth(COLUMN), { timeout: 10_000 }).toBeGreaterThan(TARGET_WIDTH - 6);
+        expect(Math.abs((await qe.columnWidth(COLUMN)) - TARGET_WIDTH)).toBeLessThanOrEqual(5);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('cancelling the Resize dialog leaves the column width untouched', async () => {
+        const qe = queryEditor!;
+
+        await qe.setQueryText(TABLE_QUERY);
+        await qe.run();
+        await qe.waitForResults();
+        await qe.setViewMode('Table');
+        await expect.poll(() => qe.tableRows().count()).toBeGreaterThan(0);
+
+        const before = await qe.columnWidth(COLUMN);
+        expect(before).toBeGreaterThan(0);
+
+        await qe.cancelColumnResize(COLUMN, TARGET_WIDTH);
+
+        // No resize was committed, so the width holds steady at its default.
+        await qe.window.waitForTimeout(300);
+        expect(Math.abs((await qe.columnWidth(COLUMN)) - before)).toBeLessThanOrEqual(2);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-crud.spec.ts
+++ b/test/e2e/specs/queryEditor-crud.spec.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DocumentPanel } from '../fixtures/documentPanel';
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import {
+    captureNamedScreenshot,
+    closeActiveEditorTab,
+    closeAllEditorTabs,
+    maximizeWindow,
+    resetNativeDialogStubs,
+    stubMessageBoxButton,
+} from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 9 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * the full document CRUD round-trip, driven end-to-end against the seeded
+ * emulator.
+ *
+ * The test is **self-contained** so it never pollutes the shared seed data: it
+ * creates its OWN document with a unique id, queries for exactly that document,
+ * and deletes it again. The verification query (`WHERE c.id = '<unique>'`)
+ * isolates the probe from the 200 seeded products.
+ *
+ * Flow:
+ *   1. Run the default query so the edit-mode result toolbar (with the item
+ *      actions) renders.
+ *   2. **Add** — "Add new item" opens a Document panel in add mode; we replace
+ *      its JSON with our probe document and Save.
+ *   3. **Query back** — `SELECT * FROM c WHERE c.id = '<id>'` returns exactly the
+ *      one probe row.
+ *   4. **View** — double-clicking the row opens a read-only Document panel.
+ *   5. **Edit** — "Edit selected item" opens an editable Document panel.
+ *   6. **Delete** — "Delete selected item" + the native confirmation removes the
+ *      document. The grid is NOT auto-refreshed, so the row is still shown
+ *      (stale) until the query is re-run.
+ *   7. **Re-run** — the same query now returns zero rows, proving the delete and
+ *      cleaning up after ourselves.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** The deterministic first product of the seed — proves the default query ran. */
+const SEEDED_ID = 'prod-00000';
+
+test.describe('queryEditor-crud', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+        // The default `SELECT * FROM c` is edit mode, so the New / View / Edit /
+        // Delete item buttons render in the result toolbar.
+        await queryEditor.run();
+        await queryEditor.waitForResults(SEEDED_ID);
+    });
+
+    test.afterEach(async ({ vscodeApp, vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        await resetNativeDialogStubs(vscodeApp);
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('creates, views, edits and deletes a document end-to-end', async ({ vscodeApp, vscodeWindow }) => {
+        const qe = queryEditor!;
+
+        // A unique id per run so a leftover probe from a previously-failed run
+        // never collides with this Save (409) — the container has no volume so
+        // it's normally pristine, but be defensive.
+        const docId = `e2e-crud-${Date.now()}`;
+        const probe = JSON.stringify(
+            { id: docId, name: 'E2E CRUD probe', category: 'E2E', _partitionKey: 'e2e-test' },
+            null,
+            2,
+        );
+        const fetchById = `SELECT * FROM c WHERE c.id = '${docId}'`;
+
+        // ── Add ───────────────────────────────────────────────────────────────
+        await qe.addNewItem();
+        const addPanel = await DocumentPanel.attach(await qe.waitForDocumentPanel(), vscodeWindow, vscodeApp);
+        await addPanel.expectEditable();
+        await addPanel.setContent(probe);
+        await addPanel.save();
+        addPanel.consoleHealth.assertNoConsoleErrors();
+        addPanel.dispose();
+        await closeActiveEditorTab(vscodeWindow);
+
+        // ── Query back: exactly our one probe document ─────────────────────────
+        await qe.setQueryText(fetchById);
+        await qe.run();
+        await qe.waitForResults(docId);
+        await expect.poll(() => qe.tableRows().count()).toBe(1);
+
+        // ── View (read-only) ───────────────────────────────────────────────────
+        await qe.doubleClickRow(0);
+        const viewPanel = await DocumentPanel.attach(await qe.waitForDocumentPanel(), vscodeWindow, vscodeApp);
+        await viewPanel.expectReadOnly();
+        expect(await viewPanel.frame.getByText(docId).count()).toBeGreaterThan(0);
+        viewPanel.consoleHealth.assertNoConsoleErrors();
+        viewPanel.dispose();
+        await closeActiveEditorTab(vscodeWindow);
+
+        // ── Edit (editable) ────────────────────────────────────────────────────
+        await qe.invokeSelectionAction(0, 'edit');
+        const editPanel = await DocumentPanel.attach(await qe.waitForDocumentPanel(), vscodeWindow, vscodeApp);
+        await editPanel.expectEditable();
+        editPanel.consoleHealth.assertNoConsoleErrors();
+        editPanel.dispose();
+        await closeActiveEditorTab(vscodeWindow);
+
+        // ── Delete (confirmed via the native modal) ────────────────────────────
+        await stubMessageBoxButton(vscodeApp, 'Yes');
+        await qe.invokeSelectionAction(0, 'delete');
+
+        // The result grid is not refreshed by a delete, so the row is still
+        // shown (stale) until the query is re-run.
+        await expect(qe.tableRows()).toHaveCount(1);
+
+        // ── Re-run: the document is gone, confirming the delete + cleanup ──────
+        await qe.run();
+        await expect.poll(() => qe.tableRows().count(), { timeout: 15_000 }).toBe(0);
+        // The id still appears in the query text, so scope the "gone" assertion
+        // to the result grid rather than the whole frame.
+        await expect(qe.resultRegion().getByText(docId)).toHaveCount(0);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-crud.spec.ts
+++ b/test/e2e/specs/queryEditor-crud.spec.ts
@@ -136,4 +136,43 @@ test.describe('queryEditor-crud', { tag: '@queryEditor' }, () => {
 
         qe.consoleHealth.assertNoConsoleErrors();
     });
+
+    test('deletes a document via the Alt+D hotkey', async ({ vscodeApp, vscodeWindow }) => {
+        const qe = queryEditor!;
+
+        const docId = `e2e-crud-hk-${Date.now()}`;
+        const probe = JSON.stringify(
+            { id: docId, name: 'E2E CRUD hotkey probe', category: 'E2E', _partitionKey: 'e2e-test' },
+            null,
+            2,
+        );
+        const fetchById = `SELECT * FROM c WHERE c.id = '${docId}'`;
+
+        // Add our own disposable probe so the delete never touches seeded data.
+        await qe.addNewItem();
+        const addPanel = await DocumentPanel.attach(await qe.waitForDocumentPanel(), vscodeWindow, vscodeApp);
+        await addPanel.expectEditable();
+        await addPanel.setContent(probe);
+        await addPanel.save();
+        addPanel.dispose();
+        await closeActiveEditorTab(vscodeWindow);
+
+        await qe.setQueryText(fetchById);
+        await qe.run();
+        await qe.waitForResults(docId);
+        await expect.poll(() => qe.tableRows().count()).toBe(1);
+
+        // Delete via the result-panel Alt+D hotkey (same outcome as the Delete
+        // item button), confirming the native modal via the stub.
+        await stubMessageBoxButton(vscodeApp, 'Yes');
+        await qe.selectRow(0);
+        await qe.window.keyboard.press('Alt+D');
+
+        // Re-run: the document is gone, proving the hotkey delete + cleanup.
+        await qe.run();
+        await expect.poll(() => qe.tableRows().count(), { timeout: 15_000 }).toBe(0);
+        await expect(qe.resultRegion().getByText(docId)).toHaveCount(0);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
 });

--- a/test/e2e/specs/queryEditor-duplicate-tab.spec.ts
+++ b/test/e2e/specs/queryEditor-duplicate-tab.spec.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import {
+    captureNamedScreenshot,
+    closeAllEditorTabs,
+    countEditorTabs,
+    maximizeWindow,
+} from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 12 of the Query Editor e2e coverage: the "Duplicate" toolbar control
+ * spawns a second Query Editor tab pre-seeded with the current editor text
+ * (`QueryEditorTab.render(..., query)` via the `duplicateTab` tRPC mutation).
+ *
+ * The test sets a distinctive query in the first tab, duplicates it, and proves
+ * a *second*, independent webview opened carrying the same query text — without
+ * disturbing the original tab.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** A distinctive, single-line query so the duplicate's text is unambiguous. */
+const DISTINCT_QUERY = 'SELECT c.id FROM c WHERE c.price > 987654';
+const DISTINCT_FRAGMENT = 'c.price > 987654';
+
+test.describe('queryEditor-duplicate-tab', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+    let duplicate: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        duplicate?.dispose();
+        duplicate = undefined;
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('the Duplicate control opens a second tab carrying the same query', async ({ vscodeWindow }) => {
+        const qe = queryEditor!;
+
+        await qe.setQueryText(DISTINCT_QUERY);
+        await expect.poll(() => qe.getQueryText()).toContain(DISTINCT_FRAGMENT);
+        await expect.poll(() => countEditorTabs(vscodeWindow)).toBe(1);
+
+        await qe.duplicateTab();
+
+        // A brand-new editor tab appears…
+        await expect.poll(() => countEditorTabs(vscodeWindow), { timeout: 15_000 }).toBe(2);
+
+        // …and it is a distinct webview whose editor holds the same query text.
+        duplicate = await QueryEditorPage.attachOther(vscodeWindow, qe.frame);
+        expect(duplicate.frame).not.toBe(qe.frame);
+        await expect.poll(() => duplicate!.getQueryText(), { timeout: 15_000 }).toContain(DISTINCT_FRAGMENT);
+
+        // The original tab is untouched.
+        await expect.poll(() => qe.getQueryText()).toContain(DISTINCT_FRAGMENT);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+        duplicate.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-errors.spec.ts
+++ b/test/e2e/specs/queryEditor-errors.spec.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 11 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * the two non-happy paths.
+ *
+ *  - **Empty result** — a syntactically valid query that matches nothing renders
+ *    an empty grid (zero data rows) without error.
+ *  - **Invalid query** — a malformed query surfaces a VS Code error
+ *    notification (the extension catches the backend 400 and routes it
+ *    through the error pipeline rather than crashing the panel).
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+const SEEDED_ID = 'prod-00000';
+const NO_MATCH_QUERY = 'SELECT TOP 10 * FROM c WHERE c.price > 1000000';
+const INVALID_QUERY = 'SELECT undefinedFunction(c.id) FROM c';
+
+test.describe('queryEditor-errors', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('a query that matches nothing renders an empty result grid', async () => {
+        const qe = queryEditor!;
+
+        // Run the default query first so there are rows to clear — proves the
+        // grid actually transitions to empty rather than starting empty.
+        await qe.run();
+        await qe.waitForResults(SEEDED_ID);
+        await expect.poll(() => qe.tableRows().count()).toBeGreaterThan(0);
+
+        await qe.setQueryText(NO_MATCH_QUERY);
+        await qe.run();
+        await expect.poll(() => qe.tableRows().count(), { timeout: 15_000 }).toBe(0);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('an invalid query surfaces a backend error notification', async ({ vscodeWindow }) => {
+        const qe = queryEditor!;
+
+        await qe.setQueryText(INVALID_QUERY);
+        await qe.run();
+
+        // The backend rejects the malformed query with a 400; the extension
+        // catches it and raises a VS Code error notification instead of
+        // crashing the panel. The grid stays empty.
+        await expect(vscodeWindow.getByText(/Query failed with status code/i).first()).toBeVisible({
+            timeout: 15_000,
+        });
+        await expect.poll(() => qe.tableRows().count()).toBe(0);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-history.spec.ts
+++ b/test/e2e/specs/queryEditor-history.spec.ts
@@ -74,7 +74,7 @@ test.describe('queryEditor-history', { tag: '@queryEditor' }, () => {
         await qe.run();
         await qe.waitForResults('prod-');
         await qe.setQueryText('');
-        expect(await qe.getQueryText()).not.toContain('c.price > 1.5');
+        await expect.poll(() => qe.getQueryText()).not.toContain('c.price > 1.5');
 
         // Pick the history entry from the Run menu → it repopulates the editor.
         await qe.openRunHistoryMenu();

--- a/test/e2e/specs/queryEditor-history.spec.ts
+++ b/test/e2e/specs/queryEditor-history.spec.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 6 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * the Run split-button query history. Executing a query records its (cleaned)
+ * text in the Run button's history menu; selecting a history entry loads it
+ * back into the editor.
+ *
+ * History is persisted per container in the extension's storage, so other
+ * specs sharing the worker may have already populated it — these tests never
+ * assert an empty baseline, only that a freshly-run, distinctive query shows
+ * up and round-trips.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/**
+ * A distinctive, non-`SELECT *` query touching the indexed `price` path. Kept
+ * under 50 characters so the history menu shows it verbatim (longer entries are
+ * truncated with an ellipsis).
+ */
+const HISTORY_QUERY = 'SELECT c.id FROM c WHERE c.price > 1.5';
+
+test.describe('queryEditor-history', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('records an executed query in the Run history menu', async () => {
+        const qe = queryEditor!;
+
+        await qe.setQueryText(HISTORY_QUERY);
+        await qe.run();
+        await qe.waitForResults('prod-');
+
+        await qe.openRunHistoryMenu();
+        const entries = await qe.getHistoryEntries();
+        expect(entries.some((entry) => entry.includes('c.price > 1.5'))).toBe(true);
+
+        // Leave the menu closed so cleanup isn't blocked by an open popover.
+        await qe.dismissMenus();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('selecting a history entry loads it back into the editor', async () => {
+        const qe = queryEditor!;
+
+        // Record the query, then wipe the editor so the insert is observable.
+        await qe.setQueryText(HISTORY_QUERY);
+        await qe.run();
+        await qe.waitForResults('prod-');
+        await qe.setQueryText('');
+        expect(await qe.getQueryText()).not.toContain('c.price > 1.5');
+
+        // Pick the history entry from the Run menu → it repopulates the editor.
+        await qe.openRunHistoryMenu();
+        await qe.frame
+            .getByRole('menuitem', { name: /c\.price > 1\.5/ })
+            .first()
+            .click();
+
+        await expect.poll(() => qe.getQueryText()).toContain('c.price > 1.5');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-hotkeys.spec.ts
+++ b/test/e2e/specs/queryEditor-hotkeys.spec.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import {
+    captureNamedScreenshot,
+    closeAllEditorTabs,
+    countEditorTabs,
+    maximizeWindow,
+} from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 15 of the Query Editor e2e coverage: the global keyboard hotkeys
+ * (`QueryEditorGlobalHotkeys`). These fire from the webview's document-level
+ * listener regardless of which sub-panel holds focus, so they are the most
+ * robust to drive from an e2e test:
+ *
+ *  - **Alt+1 / Alt+2** — switch between the Result and Stats result tabs.
+ *  - **Alt+Shift+D** — duplicate the editor into a second tab.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+const DISTINCT_QUERY = 'SELECT c.id FROM c WHERE c.price > 123456';
+const DISTINCT_FRAGMENT = 'c.price > 123456';
+
+test.describe('queryEditor-hotkeys', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+    let duplicate: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        duplicate?.dispose();
+        duplicate = undefined;
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('Alt+2 / Alt+1 switch between the Stats and Result tabs', async () => {
+        const qe = queryEditor!;
+
+        await qe.run();
+        await qe.waitForResults();
+
+        // Move focus into the result panel so the document-level hotkey listener
+        // receives the keystrokes, and confirm the Result tab starts active.
+        await qe.focusResultPanel();
+        await expect.poll(() => qe.isResultTabSelected('Result')).toBe(true);
+
+        await qe.window.keyboard.press('Alt+2');
+        await expect.poll(() => qe.isResultTabSelected('Stats'), { timeout: 10_000 }).toBe(true);
+
+        await qe.window.keyboard.press('Alt+1');
+        await expect.poll(() => qe.isResultTabSelected('Result'), { timeout: 10_000 }).toBe(true);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('Alt+Shift+D duplicates the editor into a second tab', async ({ vscodeWindow }) => {
+        const qe = queryEditor!;
+
+        await qe.setQueryText(DISTINCT_QUERY);
+        await expect.poll(() => qe.getQueryText()).toContain(DISTINCT_FRAGMENT);
+        await expect.poll(() => countEditorTabs(vscodeWindow)).toBe(1);
+
+        // The duplicate hotkey is global, so it fires with focus still in the
+        // editor after typing.
+        await qe.window.keyboard.press('Alt+Shift+D');
+
+        await expect.poll(() => countEditorTabs(vscodeWindow), { timeout: 15_000 }).toBe(2);
+
+        duplicate = await QueryEditorPage.attachOther(vscodeWindow, qe.frame);
+        await expect.poll(() => duplicate!.getQueryText(), { timeout: 15_000 }).toContain(DISTINCT_FRAGMENT);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+        duplicate.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-open.spec.ts
+++ b/test/e2e/specs/queryEditor-open.spec.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 0 tracer bullet for the Query Editor e2e coverage (see
+ * `plans/queryeditor-e2e-plan.md`). Proves the whole rig in one tiny slice and
+ * exercises the two shared helpers (`QueryEditorPage` + console-health) in
+ * their thinnest form:
+ *
+ *   open → run default `SELECT * FROM c` → assert a seeded row appears →
+ *   assert no webview console errors.
+ *
+ * Like `emulator-connected.spec.ts`, this needs a live, seeded emulator, so it
+ * is skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1` (the tRPC calls would hang
+ * with no backend).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+test.describe('queryEditor-open', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        // "After" screenshot — the end-of-test state, paired with the "loaded"
+        // shot taken when the editor opened.
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('open + run returns seeded rows with no console errors', async ({ vscodeWindow }) => {
+        // Ensure the seeded emulator is attached to the workspace (idempotent).
+        await attachEmulator(vscodeWindow);
+
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+
+        await queryEditor.run();
+        await queryEditor.waitForResults('prod-00000');
+
+        queryEditor.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-paging.spec.ts
+++ b/test/e2e/specs/queryEditor-paging.spec.ts
@@ -96,6 +96,37 @@ test.describe('queryEditor-paging', { tag: '@queryEditor' }, () => {
         qe.consoleHealth.assertNoConsoleErrors();
     });
 
+    test('navigates pages via Alt+Right / Alt+Left / Alt+Home hotkeys', async () => {
+        const qe = queryEditor!;
+
+        // Same scenario as the button-driven navigation test, but every page
+        // move is issued through the result-panel keyboard shortcuts.
+        await qe.setPageSize('10');
+        await qe.setQueryText(ORDERED_QUERY);
+        await qe.run();
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getStatusRange()).toBe('0 - 10');
+
+        // Alt+Right → next page.
+        await qe.pressResultHotkey('Alt+ArrowRight');
+        await qe.waitForResults('prod-00010');
+        expect(await qe.getStatusRange()).toBe('10 - 20');
+
+        // Alt+Left → previous page.
+        await qe.pressResultHotkey('Alt+ArrowLeft');
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getStatusRange()).toBe('0 - 10');
+
+        // Advance again, then Alt+Home jumps straight back to the first page.
+        await qe.pressResultHotkey('Alt+ArrowRight');
+        await qe.waitForResults('prod-00010');
+        await qe.pressResultHotkey('Alt+Home');
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getStatusRange()).toBe('0 - 10');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
     test('confirms a page-size change after a query and re-runs at the new size', async ({ vscodeApp }) => {
         const qe = queryEditor!;
 

--- a/test/e2e/specs/queryEditor-paging.spec.ts
+++ b/test/e2e/specs/queryEditor-paging.spec.ts
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import {
+    captureNamedScreenshot,
+    closeAllEditorTabs,
+    maximizeWindow,
+    resetNativeDialogStubs,
+    stubMessageBoxButton,
+} from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 4 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * paging and the page-size control. Exercises both page-size paths — changing
+ * it before a query runs is silent, while changing it after a query has run
+ * re-runs the query behind a VS Code workbench confirmation modal — plus the
+ * First/Prev/Next page navigation and the status-bar record range.
+ *
+ * The `products` container holds 200 seeded, deterministically-ordered
+ * documents (`prod-00000`…`prod-00199`), so a page size of 10 yields a stable
+ * `0 - 10` / `10 - 20` range with `prod-00000` and `prod-00010` as page anchors.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** A stable, ascending-id query so page N starts at prod-000N0. */
+const ORDERED_QUERY = 'SELECT * FROM c ORDER BY c.id';
+
+test.describe('queryEditor-paging', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeApp, vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        // Restore the default native-dialog stubs in case a test overrode them.
+        await resetNativeDialogStubs(vscodeApp);
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('changes page size silently before a query has run', async () => {
+        const qe = queryEditor!;
+
+        // No query has executed yet, so changing the page size just updates the
+        // value — no confirmation modal should appear.
+        await qe.setPageSize('10');
+        expect(await qe.getPageSizeValue()).toBe('10');
+        await expect(qe.pageSizeModal()).toHaveCount(0);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('navigates First / Prev / Next pages with the expected record range', async () => {
+        const qe = queryEditor!;
+
+        // Set a small page size up front (silent — no query has run yet), then
+        // run so the small page takes effect without a confirmation modal.
+        await qe.setPageSize('10');
+        await qe.setQueryText(ORDERED_QUERY);
+        await qe.run();
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getStatusRange()).toBe('0 - 10');
+
+        // Next page → second slice of ids.
+        await qe.goToNextPage();
+        await qe.waitForResults('prod-00010');
+        expect(await qe.getStatusRange()).toBe('10 - 20');
+
+        // Prev page → back to the first slice.
+        await qe.goToPrevPage();
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getStatusRange()).toBe('0 - 10');
+
+        // Advance again, then First page jumps straight back to the start.
+        await qe.goToNextPage();
+        await qe.waitForResults('prod-00010');
+        await qe.goToFirstPage();
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getStatusRange()).toBe('0 - 10');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('confirms a page-size change after a query and re-runs at the new size', async ({ vscodeApp }) => {
+        const qe = queryEditor!;
+
+        // Run at the default page size (100) first.
+        await qe.setQueryText(ORDERED_QUERY);
+        await qe.run();
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getStatusRange()).toBe('0 - 100');
+
+        // Changing the page size now re-runs the query, which the backend guards
+        // with a confirmation prompt. That prompt is a native Electron dialog,
+        // so we deterministically "click" its Continue button via the stub.
+        await stubMessageBoxButton(vscodeApp, 'Continue');
+        await qe.setPageSize('10');
+
+        // Confirmed → query re-ran at the new size.
+        await qe.waitForResults('prod-00000');
+        await expect.poll(() => qe.getPageSizeValue()).toBe('10');
+        expect(await qe.getStatusRange()).toBe('0 - 10');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('declining the page-size confirmation leaves the page size unchanged', async ({ vscodeApp }) => {
+        const qe = queryEditor!;
+
+        await qe.setQueryText(ORDERED_QUERY);
+        await qe.run();
+        await qe.waitForResults('prod-00000');
+        expect(await qe.getPageSizeValue()).toBe('100');
+
+        // Trigger the re-run confirmation, then decline it via the native dialog
+        // stub (pick the close/cancel affordance).
+        await stubMessageBoxButton(vscodeApp, 'Close');
+        await qe.setPageSize('10');
+
+        // Declined → no re-run; the original page size and range stand. Give the
+        // (async) decline a beat to settle before asserting nothing changed.
+        await qe.window.waitForTimeout(1_500);
+        expect(await qe.getPageSizeValue()).toBe('100');
+        expect(await qe.getStatusRange()).toBe('0 - 100');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-query-toolbar.spec.ts
+++ b/test/e2e/specs/queryEditor-query-toolbar.spec.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QUERY_CONTROLS, QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 1 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * the query toolbar. Verifies every non-gated toolbar control is present, in the
+ * correct initial enabled/disabled state, and interactable (menus open/close,
+ * actions fire) — all without producing webview console errors.
+ *
+ * The toolbar is responsive: on a narrow editor area (e.g. a CI virtual screen)
+ * the lower-priority controls collapse into a "More items" overflow menu, while
+ * Run and Cancel stay pinned. These tests therefore never assume a control is
+ * inline — they resolve each control via the page-object helpers that look in
+ * the toolbar first and the overflow menu second.
+ *
+ * Gated controls (AI, Provide Feedback) are environment-dependent and out of
+ * scope; the assertions below only target the always-rendered controls.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+test.describe('queryEditor-query-toolbar', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        // Maximize for the widest editor area available; the assertions below
+        // still tolerate a small screen where controls start collapsed (the
+        // page-object helpers look in the toolbar first, the overflow menu
+        // second). See `queryEditor-toolbar-overflow.spec.ts` for the collapse
+        // behaviour itself.
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('exposes every control in the correct initial state', async () => {
+        const qe = queryEditor!;
+
+        // Run and Cancel are the pinned, non-collapsing actions, so they are
+        // always inline regardless of window size.
+        await expect(qe.inlineControl(QUERY_CONTROLS.run)).toBeEnabled();
+        await expect(qe.inlineControl(QUERY_CONTROLS.cancel)).toBeVisible();
+        await expect(qe.inlineControl(QUERY_CONTROLS.cancel)).toBeDisabled();
+
+        // Every other control must be reachable — inline in the toolbar OR in
+        // the overflow menu (depending on how much width the screen affords).
+        for (const control of [
+            QUERY_CONTROLS.open,
+            QUERY_CONTROLS.save,
+            QUERY_CONTROLS.duplicate,
+            QUERY_CONTROLS.learn,
+            QUERY_CONTROLS.schema,
+            QUERY_CONTROLS.connection,
+        ]) {
+            await qe.expectControlReachable(control);
+        }
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('connection picker shows the seeded database/container', async () => {
+        const qe = queryEditor!;
+
+        if (await qe.isControlInline(QUERY_CONTROLS.connection)) {
+            // Inline Dropdown renders the current connection as its value.
+            const picker = qe.connectionPicker().first();
+            await expect(picker).toContainText('nosql-test-db');
+            await expect(picker).toContainText('products');
+        } else {
+            // Collapsed: open the Connect submenu and assert it lists the
+            // seeded database (its containers live in a further nested submenu).
+            await qe.openControlSubmenu(QUERY_CONTROLS.connection);
+            const submenu = qe.frame.getByRole('menu').last();
+            await expect(submenu).toContainText('nosql-test-db');
+            await qe.dismissMenus();
+        }
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('Learn and Schema menus open and close without console errors', async () => {
+        const qe = queryEditor!;
+
+        await qe.openControlSubmenu(QUERY_CONTROLS.learn);
+        await expect(qe.frame.getByText('Query examples', { exact: true })).toBeVisible();
+        await qe.dismissMenus();
+
+        await qe.openControlSubmenu(QUERY_CONTROLS.schema);
+        await expect(qe.frame.getByText('Generate schema', { exact: true })).toBeVisible();
+        await qe.dismissMenus();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('Open and Save actions fire without console errors', async () => {
+        const qe = queryEditor!;
+
+        // Open pops a host file picker that the fixture stubs to "cancelled",
+        // so the action is a safe no-op here.
+        await qe.clickControl(QUERY_CONTROLS.open);
+
+        // Save opens a new untitled query document (no dialog). Cleaned up by
+        // closeAllEditorTabs in afterEach.
+        await qe.clickControl(QUERY_CONTROLS.save);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('query runs via Run button and via F5 hotkey', async () => {
+        const qe = queryEditor!;
+
+        // Button path.
+        await qe.run();
+        await qe.waitForResults('prod-00000');
+
+        // Hotkey path (F5) — focus Monaco, then press the shortcut.
+        await qe.runViaHotkey();
+        await qe.waitForResults('prod-00000');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-query-toolbar.spec.ts
+++ b/test/e2e/specs/queryEditor-query-toolbar.spec.ts
@@ -124,6 +124,19 @@ test.describe('queryEditor-query-toolbar', { tag: '@queryEditor' }, () => {
         qe.consoleHealth.assertNoConsoleErrors();
     });
 
+    test('Open and Save also fire via the Ctrl+O / Ctrl+S hotkeys', async () => {
+        const qe = queryEditor!;
+
+        // Same actions as the button test, driven by their editor-scoped
+        // hotkeys. Ctrl+O (stubbed picker) leaves the Query Editor active, and
+        // Ctrl+S — which may open a save target — is issued last so a tab change
+        // can't strand a follow-up editor interaction.
+        await qe.pressEditorHotkey('Control+O');
+        await qe.pressEditorHotkey('Control+S');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
     test('query runs via Run button and via F5 hotkey', async () => {
         const qe = queryEditor!;
 

--- a/test/e2e/specs/queryEditor-result-toolbar-stats.spec.ts
+++ b/test/e2e/specs/queryEditor-result-toolbar-stats.spec.ts
@@ -54,6 +54,11 @@ test.describe('queryEditor-result-toolbar-stats', { tag: '@queryEditor' }, () =>
         await qe.reloadResults();
         await qe.waitForResults(SEEDED_ID);
 
+        // Same refresh via the result-panel hotkey (Ctrl+Shift+R) — focus the
+        // result panel so the resultPanel-scoped listener claims it.
+        await qe.pressResultHotkey('Control+Shift+R');
+        await qe.waitForResults(SEEDED_ID);
+
         qe.consoleHealth.assertNoConsoleErrors();
     });
 
@@ -87,6 +92,22 @@ test.describe('queryEditor-result-toolbar-stats', { tag: '@queryEditor' }, () =>
         // without throwing or logging console errors.
         await qe.copyResults('JSON');
         await qe.exportResults('JSON');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('Copy and Export also fire via the Ctrl+C / Ctrl+S hotkeys', async () => {
+        const qe = queryEditor!;
+
+        await qe.run();
+        await qe.waitForResults(SEEDED_ID);
+
+        // Same actions as the button test, driven by their result-panel-scoped
+        // hotkeys with focus inside the result panel: Ctrl+C copies the current
+        // page, Ctrl+S saves to disk (stubbed dialog). Run on a clean result
+        // panel so no export overlay/menu can intercept the focus click.
+        await qe.pressResultHotkey('Control+C');
+        await qe.pressResultHotkey('Control+S');
 
         qe.consoleHealth.assertNoConsoleErrors();
     });

--- a/test/e2e/specs/queryEditor-result-toolbar-stats.spec.ts
+++ b/test/e2e/specs/queryEditor-result-toolbar-stats.spec.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 3 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * the result toolbar and the Stats tab. After a query runs, Reload must re-run
+ * it, the Stats tab must surface query metrics, an index-using query must
+ * populate the index-metrics panel, and Copy/Export must be invocable without
+ * error (their clipboard / save-dialog side effects are environment-stubbed, so
+ * we only assert the actions wire up cleanly).
+ *
+ * Result-toolbar controls are resolved through the page-object helpers, which
+ * look in the toolbar first and the "More items" overflow menu second (the
+ * toolbar collapses on narrow screens).
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+const SEEDED_ID = 'prod-00000';
+
+test.describe('queryEditor-result-toolbar-stats', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('Reload re-runs the query and still shows rows', async () => {
+        const qe = queryEditor!;
+
+        await qe.run();
+        await qe.waitForResults(SEEDED_ID);
+
+        await qe.reloadResults();
+        await qe.waitForResults(SEEDED_ID);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('Stats tab shows query metrics and index metrics for an index-using query', async () => {
+        const qe = queryEditor!;
+
+        // ORDER BY forces the engine to use the (default, all-paths) index on
+        // /id, so the result carries index-utilization metrics. Ascending id
+        // keeps prod-00000 the first row.
+        await qe.setQueryText('SELECT * FROM c ORDER BY c.id');
+        await qe.run();
+        await qe.waitForResults(SEEDED_ID);
+
+        await qe.switchToStatsTab();
+
+        expect(await qe.hasQueryMetrics()).toBe(true);
+        await expect(qe.resultRegion()).toContainText('Request Charge');
+        expect(await qe.hasIndexMetrics()).toBe(true);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('Copy and Export actions are invocable without error', async () => {
+        const qe = queryEditor!;
+
+        await qe.run();
+        await qe.waitForResults(SEEDED_ID);
+
+        // Copy writes to the host clipboard via the extension; Export opens a
+        // save dialog that the fixture stubs to "cancelled". Both should run
+        // without throwing or logging console errors.
+        await qe.copyResults('JSON');
+        await qe.exportResults('JSON');
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-result-views.spec.ts
+++ b/test/e2e/specs/queryEditor-result-views.spec.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type ResultViewMode, QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 2 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * the three result view modes. After running the default query, the same seeded
+ * document (`prod-00000`) must be visible whether it is rendered as a Table, a
+ * Tree, or raw JSON, and switching modes must not emit webview console errors.
+ *
+ * The view-mode switch is driven through the result-panel "Change view mode"
+ * dropdown via the page-object helpers (`setViewMode` / `getActiveViewMode`),
+ * which also assert the matching renderer actually mounts.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** The deterministic first product of the seed — present on the first result page. */
+const SEEDED_ID = 'prod-00000';
+
+test.describe('queryEditor-result-views', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+        // Run the default `SELECT * FROM c` so every view mode has data to render.
+        await queryEditor.run();
+        await queryEditor.waitForResults(SEEDED_ID);
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('defaults to the Table view with the seeded data', async () => {
+        const qe = queryEditor!;
+
+        expect(await qe.getActiveViewMode()).toBe('Table');
+        await expect(qe.activeViewContainer('Table')).toBeVisible();
+        await qe.expectRow(SEEDED_ID);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('renders the seeded data in Tree, JSON and Table views', async () => {
+        const qe = queryEditor!;
+
+        // Cycle away from the default and back, asserting each renderer mounts
+        // and still surfaces the same seeded document id.
+        const modes: ResultViewMode[] = ['Tree', 'JSON', 'Table'];
+        for (const mode of modes) {
+            await qe.setViewMode(mode);
+            expect(await qe.getActiveViewMode()).toBe(mode);
+            await expect(qe.activeViewContainer(mode)).toBeVisible();
+            await qe.expectRow(SEEDED_ID);
+        }
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-selection-run.spec.ts
+++ b/test/e2e/specs/queryEditor-selection-run.spec.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 10 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * running only the **selected** query fragment.
+ *
+ * The editor tracks the Monaco text selection into `querySelectedValue`, and Run
+ * executes that selection in preference to the full editor text. The editor is
+ * loaded with two distinct single-row queries on separate lines; selecting one
+ * line and running must return that line's row only — not the other's.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+const ID_ONE = 'prod-00001';
+const ID_TWO = 'prod-00002';
+const TWO_QUERIES = `SELECT c.id FROM c WHERE c.id = '${ID_ONE}'\nSELECT c.id FROM c WHERE c.id = '${ID_TWO}'`;
+
+test.describe('queryEditor-selection-run', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+        await queryEditor.setQueryText(TWO_QUERIES);
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('runs only the selected query fragment', async () => {
+        const qe = queryEditor!;
+
+        // Select + run the first line → only prod-00001 comes back.
+        await qe.selectQueryLine(0);
+        await qe.run();
+        await qe.waitForResults(ID_ONE);
+        await expect.poll(() => qe.tableRows().count()).toBe(1);
+        await expect(qe.resultRegion().getByText(ID_TWO)).toHaveCount(0);
+
+        // Select + run the second line → the result flips to prod-00002 only.
+        await qe.selectQueryLine(1);
+        await qe.run();
+        await qe.waitForResults(ID_TWO);
+        await expect.poll(() => qe.tableRows().count()).toBe(1);
+        await expect(qe.resultRegion().getByText(ID_ONE)).toHaveCount(0);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-selection.spec.ts
+++ b/test/e2e/specs/queryEditor-selection.spec.ts
@@ -5,7 +5,12 @@
 
 import { QueryEditorPage } from '../fixtures/queryEditor';
 import { expect, test } from '../fixtures/vscode';
-import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import {
+    captureNamedScreenshot,
+    closeActiveEditorTab,
+    closeAllEditorTabs,
+    maximizeWindow,
+} from '../fixtures/webviewHelpers';
 import { attachEmulator } from '../fixtures/webviews';
 
 /**
@@ -98,6 +103,43 @@ test.describe('queryEditor-selection', { tag: '@queryEditor' }, () => {
         await expect(qe.selectionActionButton('view')).toBeEnabled();
         await expect(qe.selectionActionButton('edit')).toBeEnabled();
         await expect(qe.selectionActionButton('delete')).toBeEnabled();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('item hotkeys (Alt+V / Alt+E / Alt+I) open the Document panel', async ({ vscodeWindow }) => {
+        const qe = queryEditor!;
+
+        // These three result-panel hotkeys mirror the View / Edit / New item
+        // buttons. focusResultPanel() before every press is essential: opening a
+        // Document panel moves keyboard focus off the result grid, and Alt+E /
+        // Alt+V would otherwise be swallowed by the host menu-bar mnemonics
+        // (Edit / View) instead of the result-panel-scoped hotkey listener. Each
+        // panel is closed before the next press so the (single) open Document
+        // panel is unambiguous for waitForDocumentPanel.
+
+        // View (Alt+V) → a read-only panel.
+        await qe.focusResultPanel();
+        await qe.selectRow(0);
+        await qe.window.keyboard.press('Alt+V');
+        let panel = await qe.waitForDocumentPanel();
+        await expect(panel.getByText(/This item is read-only/)).toBeVisible();
+        await closeActiveEditorTab(vscodeWindow);
+
+        // Edit (Alt+E) → an editable panel.
+        await qe.focusResultPanel();
+        await qe.selectRow(0);
+        await qe.window.keyboard.press('Alt+E');
+        panel = await qe.waitForDocumentPanel();
+        await expect(panel.getByText(/This item is editable/)).toBeVisible();
+        await closeActiveEditorTab(vscodeWindow);
+
+        // New (Alt+I): no selection required → an add-mode (editable) panel.
+        // Left unsaved, so no document is created.
+        await qe.focusResultPanel();
+        await qe.window.keyboard.press('Alt+I');
+        panel = await qe.waitForDocumentPanel();
+        await expect(panel.getByText(/This item is editable/)).toBeVisible();
 
         qe.consoleHealth.assertNoConsoleErrors();
     });

--- a/test/e2e/specs/queryEditor-selection.spec.ts
+++ b/test/e2e/specs/queryEditor-selection.spec.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 5 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * table-row selection semantics and the row → document drill-in. These only
+ * exist in edit mode, which the Query Editor enables for `SELECT *`-style
+ * queries — so every test runs against the default `SELECT * FROM c`.
+ *
+ *  - single click selects exactly one row;
+ *  - Ctrl/Cmd+click toggles a row in and out of the selection;
+ *  - Shift+click selects a contiguous range from the anchor;
+ *  - the View / Edit / Delete item buttons are disabled with no selection and
+ *    enabled once a row is selected;
+ *  - double-clicking a row opens that document in a separate Document webview.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** The deterministic first product of the seed — present on the first page. */
+const SEEDED_ID = 'prod-00000';
+
+test.describe('queryEditor-selection', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+        // The default `SELECT * FROM c` puts the grid in edit mode so the
+        // selection + drill-in affordances exist.
+        await queryEditor.run();
+        await queryEditor.waitForResults(SEEDED_ID);
+        // Ensure rows have actually realized before any test interacts.
+        await expect(queryEditor.tableRows().first()).toBeVisible();
+    });
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        // Closes both the Query Editor and any Document tab a drill-in opened.
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('single click selects one row; Ctrl+click toggles add/remove', async () => {
+        const qe = queryEditor!;
+
+        // A plain click selects exactly the clicked row.
+        await qe.selectRow(0);
+        await expect.poll(() => qe.getSelectedRowCount()).toBe(1);
+
+        // Ctrl+click on another row adds it to the selection.
+        await qe.ctrlClickRow(2);
+        await expect.poll(() => qe.getSelectedRowCount()).toBe(2);
+
+        // Ctrl+click the same row again toggles it back out.
+        await qe.ctrlClickRow(2);
+        await expect.poll(() => qe.getSelectedRowCount()).toBe(1);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('Shift+click selects a contiguous range', async () => {
+        const qe = queryEditor!;
+
+        // Anchor on the first row, then Shift+click the fourth → rows 0..3.
+        await qe.selectRow(0);
+        await expect.poll(() => qe.getSelectedRowCount()).toBe(1);
+
+        await qe.shiftClickRow(3);
+        await expect.poll(() => qe.getSelectedRowCount()).toBe(4);
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('View / Edit / Delete item buttons reflect the selection state', async () => {
+        const qe = queryEditor!;
+
+        // Nothing selected yet → all three selection-aware actions are disabled.
+        await expect(qe.selectionActionButton('view')).toBeDisabled();
+        await expect(qe.selectionActionButton('edit')).toBeDisabled();
+        await expect(qe.selectionActionButton('delete')).toBeDisabled();
+
+        // Selecting a row enables them.
+        await qe.selectRow(0);
+        await expect(qe.selectionActionButton('view')).toBeEnabled();
+        await expect(qe.selectionActionButton('edit')).toBeEnabled();
+        await expect(qe.selectionActionButton('delete')).toBeEnabled();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+
+    test('double-clicking a row opens it in a Document webview', async () => {
+        const qe = queryEditor!;
+
+        // Drill into the first row; the extension host opens a read-only
+        // Document panel for that document.
+        await qe.doubleClickRow(0);
+
+        const documentFrame = await qe.waitForDocumentPanel();
+        await expect(documentFrame.locator('#root')).toBeVisible();
+        await expect(documentFrame.getByText(/This item is (read-only|editable)/)).toBeVisible();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-toolbar-overflow.spec.ts
+++ b/test/e2e/specs/queryEditor-toolbar-overflow.spec.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QUERY_CONTROLS, QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow, resizeWindow } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 1 (companion to `queryEditor-query-toolbar.spec.ts`): responsive
+ * overflow behaviour of the query toolbar.
+ *
+ * The toolbar is wrapped in a Fluent UI `Overflow`. When the editor area — and
+ * therefore the toolbar — is too narrow to show every control inline, the
+ * lower-priority controls collapse into a "More items" (⋯) overflow menu, while
+ * the two highest-priority actions, **Run** and **Cancel**, stay pinned in the
+ * toolbar.
+ *
+ * This spec verifies that:
+ *   - a wide window shows everything inline (no overflow trigger);
+ *   - a narrow window surfaces the ⋯ trigger;
+ *   - Run and Cancel remain visible in the toolbar when narrow;
+ *   - every other control genuinely *leaves* the toolbar (hidden there) and
+ *     reappears inside the overflow submenu — i.e. it moved, it didn't get
+ *     duplicated or stranded in the panel.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** Window widths (px) chosen to sit comfortably either side of the collapse. */
+const WIDE_WIDTH = 1600;
+const NARROW_WIDTH = 720;
+const WINDOW_HEIGHT = 1100;
+
+/**
+ * Controls that are expected to collapse into the overflow menu when narrow —
+ * everything except the pinned Run/Cancel actions. Drawn from the shared
+ * `QUERY_CONTROLS` registry so the inline accessible name, role and overflow
+ * menu text stay in one place.
+ */
+const COLLAPSING_CONTROLS = [
+    QUERY_CONTROLS.open,
+    QUERY_CONTROLS.save,
+    QUERY_CONTROLS.duplicate,
+    QUERY_CONTROLS.learn,
+    QUERY_CONTROLS.schema,
+    QUERY_CONTROLS.connection,
+];
+
+test.describe('queryEditor-toolbar-overflow', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.beforeEach(async ({ vscodeApp, vscodeWindow }) => {
+        // Start wide so the editor opens and connects without any overflow noise.
+        await resizeWindow(vscodeApp, WIDE_WIDTH, WINDOW_HEIGHT);
+        await attachEmulator(vscodeWindow);
+        queryEditor = await QueryEditorPage.open(vscodeWindow);
+        await queryEditor.waitForConnected();
+    });
+
+    test.afterEach(async ({ vscodeApp, vscodeWindow }) => {
+        // Capture the end-of-test (narrow / collapsed) state before restoring
+        // the window size.
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        // Restore a roomy window so a narrow size can't leak into later specs
+        // sharing this worker's VS Code instance.
+        await maximizeWindow(vscodeApp);
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('collapses non-pinned controls into the overflow submenu when narrow', async ({ vscodeApp }) => {
+        const qe = queryEditor!;
+
+        // ─── Wide: everything inline, no overflow ────────────────────────────
+        await qe.waitForOverflowState(false);
+        await expect(qe.inlineControl(QUERY_CONTROLS.run)).toBeVisible();
+        await expect(qe.inlineControl(QUERY_CONTROLS.cancel)).toBeVisible();
+        for (const control of COLLAPSING_CONTROLS) {
+            await expect(qe.inlineControl(control)).toBeVisible();
+        }
+
+        // ─── Narrow: force the toolbar to collapse ───────────────────────────
+        await resizeWindow(vscodeApp, NARROW_WIDTH, WINDOW_HEIGHT);
+        await qe.waitForOverflowState(true);
+
+        // Run and Cancel are the pinned, non-collapsing actions: still inline.
+        await expect(qe.inlineControl(QUERY_CONTROLS.run)).toBeVisible();
+        await expect(qe.inlineControl(QUERY_CONTROLS.cancel)).toBeVisible();
+
+        // Every other control has *left* the toolbar (present but hidden there).
+        for (const control of COLLAPSING_CONTROLS) {
+            await expect(qe.inlineControl(control)).toBeHidden();
+        }
+
+        // ─── The collapsed controls now live in the overflow submenu ─────────
+        expect(await qe.openOverflowMenu()).toBe(true);
+        const menu = qe.overflowMenu();
+        for (const control of COLLAPSING_CONTROLS) {
+            await expect(menu).toContainText(control.menuText);
+        }
+
+        // Run and Cancel stayed in the panel, so they are NOT duplicated into
+        // the submenu (`ToolbarOverflowMenuItem` renders nothing for an item
+        // that is still visible in the toolbar).
+        await expect(menu).not.toContainText('Run');
+        await expect(menu).not.toContainText('Cancel');
+
+        await qe.dismissMenus();
+
+        qe.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/test/e2e/specs/queryEditor-tree-open.spec.ts
+++ b/test/e2e/specs/queryEditor-tree-open.spec.ts
@@ -85,7 +85,13 @@ test.describe('queryEditor-tree-open', { tag: '@queryEditor' }, () => {
         await container.click({ button: 'right' });
         const contextMenu = win.locator('.context-view .monaco-menu').first();
         await contextMenu.waitFor({ state: 'visible', timeout: 10_000 });
-        await contextMenu.getByText('Open Query Editor', { exact: true }).click();
+        // VS Code's monaco context menu activates the *focused* item on Enter.
+        // A plain `.click()` on the label is flaky here (the menu item swallows
+        // it without dispatching the command), so hover to focus the row and
+        // press Enter to invoke it.
+        const openItem = contextMenu.getByText('Open Query Editor', { exact: true });
+        await openItem.hover();
+        await win.keyboard.press('Enter');
 
         // The tree action mounts a fully-wired Query Editor webview.
         queryEditor = await QueryEditorPage.fromOpenTab(win);

--- a/test/e2e/specs/queryEditor-tree-open.spec.ts
+++ b/test/e2e/specs/queryEditor-tree-open.spec.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type Locator, type Page } from '@playwright/test';
+import { QueryEditorPage } from '../fixtures/queryEditor';
+import { expect, test } from '../fixtures/vscode';
+import { captureNamedScreenshot, closeAllEditorTabs, maximizeWindow, runCommand } from '../fixtures/webviewHelpers';
+import { attachEmulator } from '../fixtures/webviews';
+
+/**
+ * Phase 7 of the Query Editor e2e coverage (see `plans/queryeditor-e2e-plan.md`):
+ * the production entry point. Every other spec opens the editor through the
+ * `cosmosDB.e2e.openQueryEditor` test command; this one instead drives the real
+ * user path — expanding the attached emulator in the Cosmos DB Workspaces tree
+ * down to a container and invoking the "Open Query Editor" context-menu action —
+ * to prove that production affordance still mounts a working editor.
+ *
+ * This is intentionally the *only* tree-driven spec: tree navigation is slower
+ * and more brittle than the command shortcut, so the rest of the suite avoids
+ * it.
+ *
+ * Needs a live, seeded emulator (skipped under `COSMOSDB_E2E_SKIP_EMULATOR=1`).
+ */
+const emulatorSkipped = process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1';
+
+/** The seeded database / container the tree path drills into. */
+const DATABASE_ID = 'nosql-test-db';
+const CONTAINER_ID = 'products';
+
+/** Matches a Workspaces-tree row by the start of its accessible name. Prefix
+ *  matching avoids the substring collision between the database node
+ *  (`nosql-test-db`) and the emulator account (`E2E Emulator (nosql-test-db)`). */
+function treeRow(pane: Locator, labelPrefix: string): Locator {
+    return pane.locator(`.monaco-list-row[aria-label^="${labelPrefix}"]`).first();
+}
+
+/** Expands a (collapsed) tree row and waits until its children are loaded. */
+async function expandTreeRow(row: Locator): Promise<void> {
+    await row.waitFor({ state: 'visible', timeout: 20_000 });
+    if ((await row.getAttribute('aria-expanded')) === 'false') {
+        await row.click();
+        await expect(row).toHaveAttribute('aria-expanded', 'true', { timeout: 30_000 });
+    }
+}
+
+test.describe('queryEditor-tree-open', { tag: '@queryEditor' }, () => {
+    test.skip(emulatorSkipped, 'COSMOSDB_E2E_SKIP_EMULATOR=1 — Query Editor tests need a live backend');
+
+    let queryEditor: QueryEditorPage | undefined;
+
+    test.afterEach(async ({ vscodeWindow }) => {
+        await captureNamedScreenshot(vscodeWindow, 'final');
+        queryEditor?.dispose();
+        queryEditor = undefined;
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('opens the editor from the Workspaces tree container action', async ({ vscodeApp, vscodeWindow }) => {
+        const win: Page = vscodeWindow;
+        await maximizeWindow(vscodeApp);
+        await attachEmulator(win);
+
+        // Reveal the Cosmos DB Workspaces tree and scope to its pane.
+        await runCommand(win, 'Azure: Focus on Workspace View');
+        await win.keyboard.press('Escape');
+        const workspacePane = win
+            .locator('.pane', { has: win.locator('.pane-header', { hasText: 'Workspace' }) })
+            .first();
+        await expect(treeRow(workspacePane, 'Cosmos DB Accounts')).toBeVisible({ timeout: 20_000 });
+
+        // Drill down: Cosmos DB Accounts → Local Emulators → E2E Emulator →
+        // database → container.
+        await expandTreeRow(treeRow(workspacePane, 'Cosmos DB Accounts'));
+        await expandTreeRow(treeRow(workspacePane, 'Local Emulators'));
+        await expandTreeRow(treeRow(workspacePane, 'E2E Emulator'));
+        await expandTreeRow(treeRow(workspacePane, DATABASE_ID));
+
+        const container = treeRow(workspacePane, CONTAINER_ID);
+        await expect(container).toBeVisible({ timeout: 30_000 });
+
+        // Invoke the production "Open Query Editor" context-menu action.
+        await container.click();
+        await container.click({ button: 'right' });
+        const contextMenu = win.locator('.context-view .monaco-menu').first();
+        await contextMenu.waitFor({ state: 'visible', timeout: 10_000 });
+        await contextMenu.getByText('Open Query Editor', { exact: true }).click();
+
+        // The tree action mounts a fully-wired Query Editor webview.
+        queryEditor = await QueryEditorPage.fromOpenTab(win);
+        await queryEditor.waitForConnected();
+
+        // Best-effort: the editor is connected, so the default query returns the
+        // seeded data end-to-end through the production path.
+        await queryEditor.run();
+        await queryEditor.waitForResults('prod-00000');
+
+        queryEditor.consoleHealth.assertNoConsoleErrors();
+    });
+});

--- a/vite.config.views.mjs
+++ b/vite.config.views.mjs
@@ -22,6 +22,10 @@ const __dirname = path.dirname(__filename);
 
 /** Opt-in HTML bundle report. @see [docs/webview-build.md#plugin-bundle-report](./docs/webview-build.md#plugin-bundle-report) */
 const analyze = !!process.env.BUNDLE_ANALYZE;
+// Coverage runs build the webview unminified + with source maps so e2e V8
+// coverage can be projected back onto component source lines. See
+// `test/e2e/fixtures/coverage.ts`.
+const enableCoverage = process.env.COSMOSDB_E2E_COVERAGE === '1';
 
 export default ({ mode }) => {
     const isDev = mode === 'development';
@@ -42,8 +46,8 @@ export default ({ mode }) => {
             target: 'esnext',
             outDir: 'dist',
             emptyOutDir: false, // Extension build also writes to dist.
-            sourcemap: isDev,
-            minify: !isDev,
+            sourcemap: isDev || enableCoverage,
+            minify: !isDev && !enableCoverage,
             rollupOptions: {
                 input: path.resolve(__dirname, 'src/webviews/index.tsx'),
                 /**


### PR DESCRIPTION
## Summary

Adds Playwright e2e coverage for the Query Editor webview against the seeded Cosmos DB emulator.

### New specs (all tagged `@queryEditor`)
- **queryEditor-open** — open + run smoke; asserts seeded rows render with no console errors.
- **queryEditor-query-toolbar** — toolbar control coverage using resilient toolbar-first / overflow-second lookups.
- **queryEditor-toolbar-overflow** — responsive overflow behavior: Run/Cancel stay pinned, other controls collapse into the `⋯` menu (asserts they move, not just hide).

### Supporting infra
- `QueryEditorPage` page-object with a `QUERY_CONTROLS` registry and small-screen-resilient helpers.
- Console-health monitoring (`consoleHealth`).
- Close the auto-opened Chat panel on VS Code startup.
- Timestamped results/reports folders.
- Per-test `loaded` + `final` screenshots; the `loaded` snapshot now waits for the toolbar and editor to actually render.

### Notes
- No production code changed; test-only.
- Subsequent phases (result views, stats, paging, selection, history) to follow.