### PR TITLE
test: reusable LanguageModelChat mock + LM unit-test infrastructure

### DIFF
--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -45,9 +45,17 @@ class LanguageModelToolResultPart {
 
 const LanguageModelChatMessageRole = { User: 1, Assistant: 2 };
 
+// Mirror the real API: string input is normalized to a LanguageModelTextPart[]
+// so consumers that iterate `message.content` as parts behave correctly.
+const toMessageContent = (content: unknown): unknown =>
+    typeof content === 'string' ? [new LanguageModelTextPart(content)] : content;
+
 const LanguageModelChatMessage = {
-    User: (content: unknown) => ({ role: LanguageModelChatMessageRole.User, content }),
-    Assistant: (content: unknown) => ({ role: LanguageModelChatMessageRole.Assistant, content }),
+    User: (content: unknown) => ({ role: LanguageModelChatMessageRole.User, content: toMessageContent(content) }),
+    Assistant: (content: unknown) => ({
+        role: LanguageModelChatMessageRole.Assistant,
+        content: toMessageContent(content),
+    }),
 };
 
 class CancellationTokenSource {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -19,4 +19,54 @@ vsCodeMock.l10n = {
     t: vi.fn((msg) => msg),
 };
 
+// ─── Language Model API shims ────────────────────────────────────────────────
+// jest-mock-vscode does not provide the `vscode.lm` namespace or the
+// LanguageModel* value classes. Centralize them here so unit tests (and the
+// shared `createMockLanguageModel` helper) get working `instanceof` checks and
+// message/part constructors without each test re-shimming them.
+class LanguageModelTextPart {
+    constructor(value) {
+        this.value = value;
+    }
+}
+
+class LanguageModelToolCallPart {
+    constructor(callId, name, input) {
+        this.callId = callId;
+        this.name = name;
+        this.input = input;
+    }
+}
+
+class LanguageModelToolResultPart {
+    constructor(callId, content) {
+        this.callId = callId;
+        this.content = content;
+    }
+}
+
+const LanguageModelChatMessageRole = { User: 1, Assistant: 2 };
+
+const LanguageModelChatMessage = {
+    User: (content) => ({ role: LanguageModelChatMessageRole.User, content }),
+    Assistant: (content) => ({ role: LanguageModelChatMessageRole.Assistant, content }),
+};
+
+class CancellationTokenSource {
+    constructor() {
+        this.token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+        this.cancel = vi.fn();
+        this.dispose = vi.fn();
+    }
+}
+
+// Only fill gaps — never clobber anything jest-mock-vscode already provides.
+vsCodeMock.LanguageModelTextPart ??= LanguageModelTextPart;
+vsCodeMock.LanguageModelToolCallPart ??= LanguageModelToolCallPart;
+vsCodeMock.LanguageModelToolResultPart ??= LanguageModelToolResultPart;
+vsCodeMock.LanguageModelChatMessageRole ??= LanguageModelChatMessageRole;
+vsCodeMock.LanguageModelChatMessage ??= LanguageModelChatMessage;
+vsCodeMock.CancellationTokenSource ??= CancellationTokenSource;
+vsCodeMock.lm ??= { tools: [] };
+
 module.exports = vsCodeMock;

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -51,9 +51,33 @@ const LanguageModelChatMessage = {
 };
 
 class CancellationTokenSource {
-    token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
-    cancel = vi.fn();
-    dispose = vi.fn();
+    private listeners: Array<(e: unknown) => void> = [];
+    token = {
+        isCancellationRequested: false,
+        onCancellationRequested: (listener: (e: unknown) => void): { dispose: () => void } => {
+            this.listeners.push(listener);
+            return {
+                dispose: () => {
+                    const index = this.listeners.indexOf(listener);
+                    if (index >= 0) {
+                        this.listeners.splice(index, 1);
+                    }
+                },
+            };
+        },
+    };
+    cancel = (): void => {
+        if (this.token.isCancellationRequested) {
+            return;
+        }
+        this.token.isCancellationRequested = true;
+        for (const listener of [...this.listeners]) {
+            listener(undefined);
+        }
+    };
+    dispose = (): void => {
+        this.listeners.length = 0;
+    };
 }
 
 // Only fill gaps — never clobber anything jest-mock-vscode already provides.

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -25,39 +25,35 @@ vsCodeMock.l10n = {
 // shared `createMockLanguageModel` helper) get working `instanceof` checks and
 // message/part constructors without each test re-shimming them.
 class LanguageModelTextPart {
-    constructor(value) {
-        this.value = value;
-    }
+    constructor(public value: string) {}
 }
 
 class LanguageModelToolCallPart {
-    constructor(callId, name, input) {
-        this.callId = callId;
-        this.name = name;
-        this.input = input;
-    }
+    constructor(
+        public callId: string,
+        public name: string,
+        public input: unknown,
+    ) {}
 }
 
 class LanguageModelToolResultPart {
-    constructor(callId, content) {
-        this.callId = callId;
-        this.content = content;
-    }
+    constructor(
+        public callId: string,
+        public content: unknown,
+    ) {}
 }
 
 const LanguageModelChatMessageRole = { User: 1, Assistant: 2 };
 
 const LanguageModelChatMessage = {
-    User: (content) => ({ role: LanguageModelChatMessageRole.User, content }),
-    Assistant: (content) => ({ role: LanguageModelChatMessageRole.Assistant, content }),
+    User: (content: unknown) => ({ role: LanguageModelChatMessageRole.User, content }),
+    Assistant: (content: unknown) => ({ role: LanguageModelChatMessageRole.Assistant, content }),
 };
 
 class CancellationTokenSource {
-    constructor() {
-        this.token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
-        this.cancel = vi.fn();
-        this.dispose = vi.fn();
-    }
+    token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+    cancel = vi.fn();
+    dispose = vi.fn();
 }
 
 // Only fill gaps — never clobber anything jest-mock-vscode already provides.

--- a/src/chat/CosmosDbOperationsService.test.ts
+++ b/src/chat/CosmosDbOperationsService.test.ts
@@ -118,36 +118,10 @@ describe('CosmosDbOperationsService', () => {
         (CosmosDbOperationsService as any).instance = undefined;
         service = CosmosDbOperationsService.getInstance();
 
-        // Ensure vscode.lm exists for tests that need it
-        if (!vscode.lm) {
-            (vscode as any).lm = { tools: [] };
-        } else {
-            (vscode.lm as any).tools = [];
-        }
-
-        // Ensure vscode.LanguageModelChatMessage is available
-        if (!vscode.LanguageModelChatMessage) {
-            (vscode as any).LanguageModelChatMessage = {
-                User: (content: string) => ({ role: 1, content }),
-                Assistant: (content: string | unknown[]) => ({ role: 2, content }),
-            };
-        }
-
-        // Ensure vscode.LanguageModelTextPart is available
-        if (!vscode.LanguageModelTextPart) {
-            (vscode as any).LanguageModelTextPart = class LanguageModelTextPart {
-                constructor(public value: string) {}
-            };
-        }
-
-        // Ensure vscode.CancellationTokenSource is available
-        if (!vscode.CancellationTokenSource) {
-            (vscode as any).CancellationTokenSource = class CancellationTokenSource {
-                token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
-                cancel = vi.fn();
-                dispose = vi.fn();
-            };
-        }
+        // The vscode.lm namespace and LanguageModel* classes are provided
+        // centrally by src/__mocks__/vscode.ts. Reset the registered tools so
+        // tool state doesn't leak between tests.
+        (vscode.lm as any).tools = [];
     });
 
     describe('getInstance', () => {

--- a/src/panels/migration/helpers/aiHelpers.test.ts
+++ b/src/panels/migration/helpers/aiHelpers.test.ts
@@ -171,7 +171,9 @@ describe('runAgenticLoop (tool calling via mock language model)', () => {
                     : 'SELECT * FROM c',
         });
 
-        const executeToolCall = vi.fn(async (_toolCall: vscode.LanguageModelToolCallPart) => '{"schema":{"id":"string"}}');
+        const executeToolCall = vi.fn(
+            async (_toolCall: vscode.LanguageModelToolCallPart) => '{"schema":{"id":"string"}}',
+        );
 
         const result = await runAgenticLoop(
             model,

--- a/src/panels/migration/helpers/aiHelpers.test.ts
+++ b/src/panels/migration/helpers/aiHelpers.test.ts
@@ -3,7 +3,43 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from 'vscode';
+import { createMockLanguageModel } from '../../../utils/languageModelMockUtils';
+import { runAgenticLoop } from './aiHelpers';
 import { stripMarkdownPreamble } from './markdownUtils';
+
+vi.mock('../../../extensionVariables', () => ({
+    ext: {
+        outputChannel: {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            appendLog: vi.fn(),
+            show: vi.fn(),
+        },
+    },
+}));
+
+// Run the wrapped callback with a minimal mutable telemetry context.
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+    callWithTelemetryAndErrorHandling: vi.fn(async (_eventName: string, callback: (context: unknown) => unknown) =>
+        callback({
+            telemetry: { properties: {}, measurements: {} },
+            errorHandling: { issueProperties: {} },
+        }),
+    ),
+}));
+
+vi.mock('@vscode/prompt-tsx', () => ({ renderPrompt: vi.fn() }));
+
+vi.mock('../../../utils/aiUtils', () => ({
+    extractJsonObject: vi.fn(),
+    getSelectedModel: vi.fn(),
+    logLlmTokenUsage: vi.fn(),
+}));
+
+vi.mock('../../../utils/modelUtils', () => ({ MIGRATION_SELECTED_MODEL_KEY: 'migration.selectedModel' }));
 
 describe('stripMarkdownPreamble', () => {
     it('removes preamble text before the first heading', () => {
@@ -109,5 +145,73 @@ Content.`);
         const input = `\n\n# Report\n\nContent.`;
         const result = stripMarkdownPreamble(input);
         expect(result).toBe(`# Report\n\nContent.`);
+    });
+});
+
+describe('runAgenticLoop (tool calling via mock language model)', () => {
+    const SAMPLE_TOOL = 'cosmosdb_sampleContainerSchema';
+    const tools: vscode.LanguageModelChatTool[] = [
+        { name: SAMPLE_TOOL, description: 'Samples container schema', inputSchema: {} },
+    ];
+
+    function makeToken(): vscode.CancellationToken {
+        return new vscode.CancellationTokenSource().token;
+    }
+
+    it('runs a tool-call round, executes the tool, then returns the final answer', async () => {
+        let round = 0;
+        // The resolver is invoked once per round: round 0 emits a tool call,
+        // round 1 (after the tool result is fed back) emits the final query.
+        const model = createMockLanguageModel({
+            id: 'mock-model',
+            name: 'Mock Model',
+            resolveResponse: () =>
+                round++ === 0
+                    ? [{ type: 'toolCall', name: SAMPLE_TOOL, input: { containerId: 'orders' } }]
+                    : 'SELECT * FROM c',
+        });
+
+        const executeToolCall = vi.fn(async () => '{"schema":{"id":"string"}}');
+
+        const result = await runAgenticLoop(
+            model,
+            [vscode.LanguageModelChatMessage.User('generate a query for orders')],
+            tools,
+            executeToolCall,
+            5,
+            makeToken(),
+            'Test Loop',
+        );
+
+        expect(executeToolCall).toHaveBeenCalledTimes(1);
+        const toolCallArg = executeToolCall.mock.calls[0][0] as vscode.LanguageModelToolCallPart;
+        expect(toolCallArg.name).toBe(SAMPLE_TOOL);
+        expect(toolCallArg.input).toEqual({ containerId: 'orders' });
+        expect(result.text).toBe('SELECT * FROM c');
+        expect(result.roundsExhausted).toBe(false);
+        expect(round).toBe(2);
+    });
+
+    it('finishes in a single round when the model requests no tools', async () => {
+        const model = createMockLanguageModel({
+            id: 'mock-model',
+            name: 'Mock Model',
+            resolveResponse: () => 'SELECT VALUE COUNT(1) FROM c',
+        });
+        const executeToolCall = vi.fn(async () => '');
+
+        const result = await runAgenticLoop(
+            model,
+            [vscode.LanguageModelChatMessage.User('count documents')],
+            tools,
+            executeToolCall,
+            5,
+            makeToken(),
+            'Test Loop',
+        );
+
+        expect(executeToolCall).not.toHaveBeenCalled();
+        expect(result.text).toBe('SELECT VALUE COUNT(1) FROM c');
+        expect(result.roundsExhausted).toBe(false);
     });
 });

--- a/src/panels/migration/helpers/aiHelpers.test.ts
+++ b/src/panels/migration/helpers/aiHelpers.test.ts
@@ -171,7 +171,7 @@ describe('runAgenticLoop (tool calling via mock language model)', () => {
                     : 'SELECT * FROM c',
         });
 
-        const executeToolCall = vi.fn(async () => '{"schema":{"id":"string"}}');
+        const executeToolCall = vi.fn(async (_toolCall: vscode.LanguageModelToolCallPart) => '{"schema":{"id":"string"}}');
 
         const result = await runAgenticLoop(
             model,
@@ -184,7 +184,7 @@ describe('runAgenticLoop (tool calling via mock language model)', () => {
         );
 
         expect(executeToolCall).toHaveBeenCalledTimes(1);
-        const toolCallArg = executeToolCall.mock.calls[0][0] as vscode.LanguageModelToolCallPart;
+        const toolCallArg = executeToolCall.mock.calls[0][0];
         expect(toolCallArg.name).toBe(SAMPLE_TOOL);
         expect(toolCallArg.input).toEqual({ containerId: 'orders' });
         expect(result.text).toBe('SELECT * FROM c');

--- a/src/utils/languageModelMockUtils.test.ts
+++ b/src/utils/languageModelMockUtils.test.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { createMockLanguageModel, languageModelMessagesToText, setMockRoute } from './languageModelMockUtils';
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+    const out: T[] = [];
+    for await (const item of iterable) {
+        out.push(item);
+    }
+    return out;
+}
+
+const userMessages = () => [vscode.LanguageModelChatMessage.User('hi')];
+
+describe('createMockLanguageModel', () => {
+    it('streams a string response as one text chunk and a single text part', async () => {
+        const model = createMockLanguageModel({ id: 'm', name: 'M', resolveResponse: () => 'hello world' });
+
+        const response = await model.sendRequest(userMessages(), {});
+
+        expect(await collect(response.text)).toEqual(['hello world']);
+        const stream = await collect(response.stream);
+        expect(stream).toHaveLength(1);
+        expect(stream[0]).toBeInstanceOf(vscode.LanguageModelTextPart);
+        expect((stream[0] as vscode.LanguageModelTextPart).value).toBe('hello world');
+    });
+
+    it('emits tool-call parts and synthesizes a callId when omitted', async () => {
+        const model = createMockLanguageModel({
+            id: 'm',
+            name: 'M',
+            resolveResponse: () => [{ type: 'toolCall', name: 'myTool', input: { a: 1 } }],
+        });
+
+        const response = await model.sendRequest(userMessages(), {});
+        const stream = await collect(response.stream);
+
+        expect(await collect(response.text)).toEqual([]);
+        expect(stream).toHaveLength(1);
+        expect(stream[0]).toBeInstanceOf(vscode.LanguageModelToolCallPart);
+        const call = stream[0] as vscode.LanguageModelToolCallPart;
+        expect(call.name).toBe('myTool');
+        expect(call.input).toEqual({ a: 1 });
+        expect(call.callId).toMatch(/^mock-call-\d+$/);
+    });
+
+    it('preserves a provided tool-call id and orders mixed parts', async () => {
+        const model = createMockLanguageModel({
+            id: 'm',
+            name: 'M',
+            resolveResponse: () => [
+                { type: 'text', value: 'a' },
+                { type: 'toolCall', name: 't', callId: 'fixed-id' },
+                { type: 'text', value: 'b' },
+            ],
+        });
+
+        const response = await model.sendRequest(userMessages(), {});
+        const stream = await collect(response.stream);
+
+        expect(await collect(response.text)).toEqual(['a', 'b']);
+        expect(stream.map((p) => p.constructor.name)).toEqual([
+            'LanguageModelTextPart',
+            'LanguageModelToolCallPart',
+            'LanguageModelTextPart',
+        ]);
+        expect((stream[1] as vscode.LanguageModelToolCallPart).callId).toBe('fixed-id');
+    });
+
+    it('estimates token counts from string length', async () => {
+        const model = createMockLanguageModel({ id: 'm', name: 'M', resolveResponse: () => '' });
+        expect(await model.countTokens('12345678')).toBe(2); // ceil(8 / 4)
+    });
+});
+
+describe('setMockRoute', () => {
+    it('is sticky: the route persists across requests until changed or cleared', async () => {
+        const seen: (string | undefined)[] = [];
+        const model = createMockLanguageModel({
+            id: 'm',
+            name: 'M',
+            resolveResponse: ({ route }) => {
+                seen.push(route);
+                return 'x';
+            },
+        });
+
+        await model.sendRequest(userMessages(), {}); // no route set yet
+        setMockRoute(model, 'r1');
+        await model.sendRequest(userMessages(), {});
+        await model.sendRequest(userMessages(), {}); // sticky
+        setMockRoute(model, 'r2');
+        await model.sendRequest(userMessages(), {});
+        setMockRoute(model, undefined); // cleared
+        await model.sendRequest(userMessages(), {});
+
+        expect(seen).toEqual([undefined, 'r1', 'r1', 'r2', undefined]);
+    });
+
+    it('is a no-op on objects without the mock setter (real models)', () => {
+        expect(() => setMockRoute({} as unknown as vscode.LanguageModelChat, 'x')).not.toThrow();
+    });
+});
+
+describe('languageModelMessagesToText', () => {
+    it('returns plain string content', () => {
+        expect(languageModelMessagesToText([{ content: 'plain' } as unknown as vscode.LanguageModelChatMessage])).toBe(
+            'plain',
+        );
+    });
+
+    it('joins the values of text parts', () => {
+        const message = {
+            content: [new vscode.LanguageModelTextPart('a'), new vscode.LanguageModelTextPart('b')],
+        } as unknown as vscode.LanguageModelChatMessage;
+        expect(languageModelMessagesToText([message])).toBe('a\nb');
+    });
+
+    it('recurses into nested tool-result content', () => {
+        const toolResult = new vscode.LanguageModelToolResultPart('call-1', [
+            new vscode.LanguageModelTextPart('nested'),
+        ]);
+        const message = { content: [toolResult] } as unknown as vscode.LanguageModelChatMessage;
+        expect(languageModelMessagesToText([message])).toBe('nested');
+    });
+});

--- a/src/utils/languageModelMockUtils.test.ts
+++ b/src/utils/languageModelMockUtils.test.ts
@@ -63,7 +63,7 @@ describe('createMockLanguageModel', () => {
         const stream = await collect(response.stream);
 
         expect(await collect(response.text)).toEqual(['a', 'b']);
-        expect(stream.map((p) => p.constructor.name)).toEqual([
+        expect(stream.map((p) => (p as object).constructor.name)).toEqual([
             'LanguageModelTextPart',
             'LanguageModelToolCallPart',
             'LanguageModelTextPart',

--- a/src/utils/languageModelMockUtils.ts
+++ b/src/utils/languageModelMockUtils.ts
@@ -39,7 +39,7 @@ export function setMockRoute(model: vscode.LanguageModelChat, route: string | un
  */
 export type MockResponsePart =
     | { type: 'text'; value: string }
-    | { type: 'toolCall'; name: string; callId?: string; input?: object };
+    | { type: 'toolCall'; name: string; callId?: string; input?: unknown };
 
 /**
  * What a resolver may return for a single request: a plain string (sugar for a
@@ -168,7 +168,7 @@ export function createMockLanguageModel(options: CreateMockLanguageModelOptions)
                         yield new vscode.LanguageModelToolCallPart(
                             part.callId ?? `mock-call-${++mockToolCallSeq}`,
                             part.name,
-                            part.input ?? {},
+                            (part.input ?? {}) as object,
                         );
                     }
                 }

--- a/src/utils/languageModelMockUtils.ts
+++ b/src/utils/languageModelMockUtils.ts
@@ -17,8 +17,11 @@ type MockRouteSetter = (route: string | undefined) => void;
 
 /**
  * Sets the active route id on a mock model produced by
- * {@link createMockLanguageModel}. No-op on real `LanguageModelChat`
- * instances, so callers can invoke it unconditionally before `sendRequest`.
+ * {@link createMockLanguageModel}. The route is **sticky**: it persists across
+ * subsequent `sendRequest` calls until changed (like `vi.fn().mockReturnValue`),
+ * so multi-round flows such as an agentic loop can set it once. Pass `undefined`
+ * to clear it. No-op on real `LanguageModelChat` instances, so callers can
+ * invoke it unconditionally before `sendRequest`.
  */
 export function setMockRoute(model: vscode.LanguageModelChat, route: string | undefined): void {
     const setter = (model as unknown as Record<symbol, unknown>)[MOCK_ROUTE_SETTER];
@@ -63,31 +66,49 @@ export interface CreateMockLanguageModelOptions {
         requestOptions?: vscode.LanguageModelChatRequestOptions;
         token?: vscode.CancellationToken;
         promptText: string;
-        /** Route id set via {@link setMockRoute} just before this request. */
+        /** Most recent route id set via {@link setMockRoute} (sticky until changed). */
         route?: string;
     }) => MockResponse | Promise<MockResponse>;
 }
 
 /**
  * Flattens a `LanguageModelChatMessage[]` into a single searchable string.
- * Handles both string and structured-part content shapes across API versions.
+ * Handles string content, structured parts with a string `value` (e.g.
+ * `LanguageModelTextPart`), and parts whose own `content` is a nested array of
+ * parts (e.g. `LanguageModelToolResultPart`), recursing into them so tool
+ * results contribute to the flattened text.
  */
 export function languageModelMessagesToText(messages: readonly vscode.LanguageModelChatMessage[]): string {
     const parts: string[] = [];
+    const collect = (node: unknown): void => {
+        if (typeof node === 'string') {
+            parts.push(node);
+            return;
+        }
+        if (!node || typeof node !== 'object') {
+            return;
+        }
+        const value = (node as { value?: unknown }).value;
+        if (typeof value === 'string') {
+            parts.push(value);
+        }
+        const nested = (node as { content?: unknown }).content;
+        if (Array.isArray(nested)) {
+            for (const inner of nested) {
+                collect(inner);
+            }
+        } else if (typeof nested === 'string') {
+            parts.push(nested);
+        }
+    };
+
     for (const message of messages) {
         const content: unknown = (message as { content?: unknown }).content;
         if (typeof content === 'string') {
             parts.push(content);
         } else if (Array.isArray(content)) {
             for (const part of content) {
-                if (typeof part === 'string') {
-                    parts.push(part);
-                } else if (part && typeof part === 'object' && 'value' in part) {
-                    const value = (part as { value?: unknown }).value;
-                    if (typeof value === 'string') {
-                        parts.push(value);
-                    }
-                }
+                collect(part);
             }
         }
     }

--- a/src/utils/languageModelMockUtils.ts
+++ b/src/utils/languageModelMockUtils.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * Symbol-keyed setter installed on every mock model instance. Carrying the
+ * route out-of-band (instead of through `LanguageModelChatRequestOptions`)
+ * keeps the production VS Code API surface untouched while still letting tests
+ * deterministically select a canned response per request.
+ */
+const MOCK_ROUTE_SETTER = Symbol('cosmosDbMockRouteSetter');
+
+type MockRouteSetter = (route: string | undefined) => void;
+
+/**
+ * Sets the active route id on a mock model produced by
+ * {@link createMockLanguageModel}. No-op on real `LanguageModelChat`
+ * instances, so callers can invoke it unconditionally before `sendRequest`.
+ */
+export function setMockRoute(model: vscode.LanguageModelChat, route: string | undefined): void {
+    const setter = (model as unknown as Record<symbol, unknown>)[MOCK_ROUTE_SETTER];
+    if (typeof setter === 'function') {
+        (setter as MockRouteSetter)(route);
+    }
+}
+
+/**
+ * A single part of a scripted mock response.
+ *  - `text` becomes a `vscode.LanguageModelTextPart` in the stream.
+ *  - `toolCall` becomes a `vscode.LanguageModelToolCallPart`, which drives the
+ *    agentic tool-calling loop (`runAgenticLoop`) so its tool branch can be
+ *    exercised in unit tests.
+ */
+export type MockResponsePart =
+    | { type: 'text'; value: string }
+    | { type: 'toolCall'; name: string; callId?: string; input?: object };
+
+/**
+ * What a resolver may return for a single request: a plain string (sugar for a
+ * single text part) or an ordered list of parts (text and/or tool calls).
+ */
+export type MockResponse = string | readonly MockResponsePart[];
+
+export interface CreateMockLanguageModelOptions {
+    id: string;
+    name: string;
+    vendor?: string;
+    family?: string;
+    version?: string;
+    maxInputTokens?: number;
+    /**
+     * Returns what should be streamed back for a request. Return a string for a
+     * plain text answer, or an array of {@link MockResponsePart} to emit tool
+     * calls (and text) in order. The resolver is invoked once per request, so
+     * for a tool-call-then-finish flow branch on the round (e.g. a counter or
+     * the presence of a tool result in `messages`).
+     */
+    resolveResponse: (args: {
+        messages: readonly vscode.LanguageModelChatMessage[];
+        requestOptions?: vscode.LanguageModelChatRequestOptions;
+        token?: vscode.CancellationToken;
+        promptText: string;
+        /** Route id set via {@link setMockRoute} just before this request. */
+        route?: string;
+    }) => MockResponse | Promise<MockResponse>;
+}
+
+/**
+ * Flattens a `LanguageModelChatMessage[]` into a single searchable string.
+ * Handles both string and structured-part content shapes across API versions.
+ */
+export function languageModelMessagesToText(messages: readonly vscode.LanguageModelChatMessage[]): string {
+    const parts: string[] = [];
+    for (const message of messages) {
+        const content: unknown = (message as { content?: unknown }).content;
+        if (typeof content === 'string') {
+            parts.push(content);
+        } else if (Array.isArray(content)) {
+            for (const part of content) {
+                if (typeof part === 'string') {
+                    parts.push(part);
+                } else if (part && typeof part === 'object' && 'value' in part) {
+                    const value = (part as { value?: unknown }).value;
+                    if (typeof value === 'string') {
+                        parts.push(value);
+                    }
+                }
+            }
+        }
+    }
+
+    return parts.join('\n');
+}
+
+/** Monotonic counter for synthesizing tool-call ids when a part omits one. */
+let mockToolCallSeq = 0;
+
+/** Normalizes a {@link MockResponse} into an ordered list of parts. */
+function normalizeMockResponse(response: MockResponse): MockResponsePart[] {
+    return typeof response === 'string' ? [{ type: 'text', value: response }] : [...response];
+}
+
+/**
+ * Creates a deterministic `LanguageModelChat` mock that streams a
+ * resolver-provided payload for each request. The payload may contain text
+ * and/or tool calls (see {@link MockResponsePart}).
+ */
+export function createMockLanguageModel(options: CreateMockLanguageModelOptions): vscode.LanguageModelChat {
+    // Updated via the symbol-keyed setter (see {@link setMockRoute}) right
+    // before each `sendRequest`, then read back inside the resolver below.
+    let currentRoute: string | undefined;
+
+    const sendRequest = async (
+        messages: vscode.LanguageModelChatMessage[],
+        requestOptions?: vscode.LanguageModelChatRequestOptions,
+        token?: vscode.CancellationToken,
+    ): Promise<vscode.LanguageModelChatResponse> => {
+        const promptText = languageModelMessagesToText(messages);
+        const parts = normalizeMockResponse(
+            await options.resolveResponse({
+                messages,
+                requestOptions,
+                token,
+                promptText,
+                route: currentRoute,
+            }),
+        );
+
+        const textChunks = parts.filter((p) => p.type === 'text').map((p) => p.value);
+
+        const textIterable: AsyncIterable<string> = {
+            async *[Symbol.asyncIterator]() {
+                for (const chunk of textChunks) {
+                    yield chunk;
+                }
+            },
+        };
+        const streamIterable: AsyncIterable<vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart> = {
+            async *[Symbol.asyncIterator]() {
+                for (const part of parts) {
+                    if (part.type === 'text') {
+                        yield new vscode.LanguageModelTextPart(part.value);
+                    } else {
+                        yield new vscode.LanguageModelToolCallPart(
+                            part.callId ?? `mock-call-${++mockToolCallSeq}`,
+                            part.name,
+                            part.input ?? {},
+                        );
+                    }
+                }
+            },
+        };
+
+        return {
+            text: textIterable,
+            stream: streamIterable,
+        } as vscode.LanguageModelChatResponse;
+    };
+
+    const model: vscode.LanguageModelChat = {
+        id: options.id,
+        name: options.name,
+        vendor: options.vendor ?? 'copilot',
+        family: options.family ?? 'e2e-mock',
+        version: options.version ?? '1.0.0',
+        maxInputTokens: options.maxInputTokens ?? 128_000,
+        // A length-based estimate is enough for deterministic tests.
+        countTokens: (text: string | vscode.LanguageModelChatMessage): Thenable<number> => {
+            const input = typeof text === 'string' ? text : languageModelMessagesToText([text]);
+            return Promise.resolve(Math.ceil(input.length / 4));
+        },
+        sendRequest: (
+            messages: vscode.LanguageModelChatMessage[],
+            requestOptions?: vscode.LanguageModelChatRequestOptions,
+            token?: vscode.CancellationToken,
+        ): Thenable<vscode.LanguageModelChatResponse> => sendRequest(messages, requestOptions, token),
+    };
+
+    (model as unknown as Record<symbol, MockRouteSetter>)[MOCK_ROUTE_SETTER] = (route) => {
+        currentRoute = route;
+    };
+
+    return model;
+}


### PR DESCRIPTION
## Summary

Adds reusable infrastructure for mocking `vscode.LanguageModelChat` in tests, plus the supporting unit-test plumbing. This gives a single, ergonomic way to fake the VS Code Language Model API across **unit** tests (vitest, in-process) and **e2e** flows, replacing the per-test hand-rolled fake models that several suites currently duplicate.

Every AI flow in the extension funnels through one seam — `getSelectedModel()` → `model.sendRequest(...)` — so a single fake model can drive query generation, the chat participant, and the migration pipeline deterministically.

## What's included

| File | Change |
| --- | --- |
| `src/utils/languageModelMockUtils.ts` | **New.** Generic `createMockLanguageModel` factory, `setMockRoute` for route-based response selection, and structured (text + tool-call) responses. |
| `src/__mocks__/vscode.ts` | Centralized `LanguageModel*` class shims (`LanguageModelTextPart`, `LanguageModelToolCallPart`, `LanguageModelToolResultPart`, `LanguageModelChatMessage`, `LanguageModelChatMessageRole`, `CancellationTokenSource`, `lm`) so tests stop re-shimming them per file. Added with `??=` so they only fill gaps `jest-mock-vscode` leaves. |
| `src/chat/CosmosDbOperationsService.test.ts` | Removed the now-redundant per-test shim block. |
| `src/panels/migration/helpers/aiHelpers.test.ts` | Added `runAgenticLoop` tool-calling tests driven by the mock (living example of the tool-call path). |

## The mock API

```ts
import { createMockLanguageModel, setMockRoute } from '../utils/languageModelMockUtils';

const model = createMockLanguageModel({
    id: 'mock-model',
    name: 'Mock Model',
    resolveResponse: ({ messages, promptText, route }) => /* string | MockResponsePart[] */,
});
```

- The factory is a plain in-process object — no env gating, no extension side effects — so it's safe to import directly in vitest.
- `resolveResponse` may return a **string** (sugar for one text part) or an array of **parts**:
  - `{ type: 'text', value }` → streamed as a `LanguageModelTextPart`.
  - `{ type: 'toolCall', name, callId?, input? }` → streamed as a `LanguageModelToolCallPart` (drives `runAgenticLoop`'s tool branch).
- `setMockRoute(model, id)` sets a route id read back in `resolveResponse({ route })`. It's a **no-op on real models**, so callers can invoke it unconditionally before `sendRequest`.

## Usage examples

### 1. Simple text response (replaces hand-rolled fakes)

```ts
const model = createMockLanguageModel({
    id: 'test', name: 'Test',
    resolveResponse: () => 'SELECT * FROM c',
});
getSelectedModel.mockResolvedValue(model);
```

### 2. Dynamic / branching response

```ts
resolveResponse: ({ promptText }) =>
    promptText.includes('count') ? 'SELECT VALUE COUNT(1) FROM c' : 'SELECT * FROM c',
```

### 3. Deterministic route-based selection

Useful when one logical flow makes many distinct calls (e.g. the migration pipeline) — route on a stable step id instead of fuzzy prompt matching:

```ts
const fixtures = { 'step1-analysis': '...', 'step2-discovery': '...' };
const model = createMockLanguageModel({
    id, name,
    resolveResponse: ({ route }) => fixtures[route!],
});
setMockRoute(model, 'step1-analysis'); // before sendRequest; no-op on real models
```

### 4. Tool-calling loop (text + tool-call parts)

```ts
let round = 0;
const model = createMockLanguageModel({
    id, name,
    // round 0 asks for a tool; round 1 (after the tool result is fed back) finishes.
    resolveResponse: () =>
        round++ === 0
            ? [{ type: 'toolCall', name: 'cosmosdb_sampleContainerSchema', input: { containerId: 'orders' } }]
            : 'SELECT * FROM c',
});

const result = await runAgenticLoop(model, messages, tools, executeToolCall, 5, token, 'Test Loop');
expect(executeToolCall).toHaveBeenCalledTimes(1);
expect(result.text).toBe('SELECT * FROM c');
```

### 5. Error path

A throwing resolver rejects `sendRequest`, exercising the catch branch:

```ts
resolveResponse: () => { throw new Error('Model unavailable'); }
```

## Asserting what was sent

`sendRequest` is a real method (not a `vi.fn`), so either capture in the resolver or spy:

```ts
const spy = vi.spyOn(model, 'sendRequest');
// …run code under test…
expect(spy).toHaveBeenCalledOnce();
```

## Design notes

- **Single seam.** Inject the fake at `getSelectedModel()` (or `vscode.lm.selectChatModels`) and every downstream AI consumer sees it.
- **`instanceof` correctness.** The factory builds parts from the same centralized `vscode.LanguageModel*` classes the consumers check against, so `part instanceof vscode.LanguageModelTextPart` / `...ToolCallPart` works in `runAgenticLoop`.
- **No production impact.** `setMockRoute` no-ops on real models; the mock is only constructed by tests.
- **Kept `setMockRoute` generic.** It was first introduced for migration routing but is reusable by any test that wants deterministic, content-independent response selection — so it lives here in the shared util.

## Testing

- `src/panels/migration/helpers/aiHelpers.test.ts` and `src/chat/CosmosDbOperationsService.test.ts` pass.
- `npm run lint` clean.

## Notes

- A follow-up PR (migration deterministic e2e mock + determinism refactor) builds on this infrastructure via `setMockRoute`.
