### PR TITLE
test(migration): relational-migration e2e suite with offline AI mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -527,6 +527,16 @@
         "category": "Cosmos DB",
         "command": "cosmosDB.e2e.attachEmulator",
         "title": "[E2E Test] Attach Emulator to Workspace"
+      },
+      {
+        "category": "Cosmos DB",
+        "command": "cosmosDB.e2e.openMigration",
+        "title": "[E2E Test] Open Seeded Migration Assistant"
+      },
+      {
+        "category": "Cosmos DB",
+        "command": "cosmosDB.e2e.openMigrationFresh",
+        "title": "[E2E Test] Open Empty Migration Assistant"
       }
     ],
     "submenus": [
@@ -822,6 +832,14 @@
         },
         {
           "command": "cosmosDB.e2e.attachEmulator",
+          "when": "cosmosDB.e2eTestMode"
+        },
+        {
+          "command": "cosmosDB.e2e.openMigration",
+          "when": "cosmosDB.e2eTestMode"
+        },
+        {
+          "command": "cosmosDB.e2e.openMigrationFresh",
           "when": "cosmosDB.e2eTestMode"
         }
       ]

--- a/src/commands/e2eTestCommands/registerE2eTestCommands.ts
+++ b/src/commands/e2eTestCommands/registerE2eTestCommands.ts
@@ -42,14 +42,17 @@
  */
 
 import { registerCommand, type IActionContext } from '@microsoft/vscode-azext-utils';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { API } from '../../AzureDBExperiences';
 import { AuthenticationMethod } from '../../cosmosdb/AuthenticationMethod';
 import { type CosmosDBCredential } from '../../cosmosdb/CosmosDBCredential';
 import { type NoSqlQueryConnection } from '../../cosmosdb/NoSqlQueryConnection';
 import { DocumentTab } from '../../panels/DocumentTab';
+import { MigrationAssistantTab } from '../../panels/MigrationAssistantTab';
 import { QueryEditorTab } from '../../panels/QueryEditorTab';
-import { type StorageItem, StorageNames, StorageService } from '../../services/StorageService';
+import { MIGRATION_FOLDER } from '../../services/MigrationProjectService';
+import { StorageNames, StorageService, type StorageItem } from '../../services/StorageService';
 import { WorkspaceResourceType } from '../../tree/workspace-api/SharedWorkspaceResourceProvider';
 import { getEmulatorItemUniqueId } from '../../utils/emulatorUtils';
 
@@ -64,6 +67,11 @@ const ENV_EMULATOR_ENDPOINT = 'COSMOSDB_E2E_EMULATOR_ENDPOINT';
 const ENV_EMULATOR_KEY = 'COSMOSDB_E2E_EMULATOR_KEY';
 const ENV_DATABASE_ID = 'COSMOSDB_E2E_DATABASE_ID';
 const ENV_CONTAINER_ID = 'COSMOSDB_E2E_CONTAINER_ID';
+
+// Absolute path of a fixture directory copied into `<workspace>/.cosmosdb-migration`
+// by `cosmosDB.e2e.openMigration`. Set by the Playwright fixture so the command
+// stays palette-invokable without arguments.
+const ENV_MIGRATION_SEED_DIR = 'COSMOSDB_E2E_MIGRATION_SEED_DIR';
 
 export function isE2eTestModeEnabled(): boolean {
     return process.env[E2E_TEST_ENV_KEY] === '1';
@@ -133,6 +141,68 @@ async function attachEmulatorAccount(env: EmulatorEnv): Promise<void> {
 }
 
 /**
+ * Recursively copies a seed project directory into `<workspace>/.cosmosdb-migration`,
+ * overwriting any existing content so the command is idempotent.
+ */
+async function resetMigrationFolder(workspacePath: string): Promise<void> {
+    const target = vscode.Uri.file(path.join(workspacePath, MIGRATION_FOLDER));
+    try {
+        await vscode.workspace.fs.delete(target, { recursive: true, useTrash: false });
+    } catch {
+        // Target may not exist yet — ignore.
+    }
+}
+
+/**
+ * Copies a seed project directory into `<workspace>/.cosmosdb-migration` so
+ * specs can drive deterministic "loaded project" and full phase-flow scenarios
+ * without the native file-picker dialogs the production flow uses. The seed
+ * source is read from `COSMOSDB_E2E_MIGRATION_SEED_DIR` (set by the Playwright
+ * fixture) so the command stays palette-invokable (no args required).
+ */
+async function seedMigrationProject(workspacePath: string): Promise<boolean> {
+    const seedFrom = process.env[ENV_MIGRATION_SEED_DIR];
+    if (!seedFrom) return false;
+    const target = vscode.Uri.file(path.join(workspacePath, MIGRATION_FOLDER));
+    await vscode.workspace.fs.copy(vscode.Uri.file(seedFrom), target, { overwrite: true });
+    return true;
+}
+
+function resolveWorkspacePath(): string {
+    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspacePath) {
+        throw new Error('cosmosDB.e2e.openMigration requires an open workspace folder.');
+    }
+    return workspacePath;
+}
+
+/**
+ * Stubs the workspace's version-control state for migration specs: when
+ * `present`, creates an empty `.git/` dir (enough for the file-based
+ * `hasGitRepository()` check) so the "exclude from version control" control
+ * renders; when absent, removes it so the missing-VCS warning renders. Always
+ * resets `.gitignore` so the exclude checkbox starts unchecked.
+ */
+async function setGitPresent(workspacePath: string, present: boolean): Promise<void> {
+    const gitDir = vscode.Uri.file(path.join(workspacePath, '.git'));
+    const gitignore = vscode.Uri.file(path.join(workspacePath, '.gitignore'));
+    try {
+        await vscode.workspace.fs.delete(gitignore, { useTrash: false });
+    } catch {
+        // No .gitignore yet — fine.
+    }
+    if (present) {
+        await vscode.workspace.fs.createDirectory(gitDir);
+    } else {
+        try {
+            await vscode.workspace.fs.delete(gitDir, { recursive: true, useTrash: false });
+        } catch {
+            // No .git yet — fine.
+        }
+    }
+}
+
+/**
  * Registers the e2e-test commands and sets the `cosmosDB.e2eTestMode` context
  * key. Safe to call unconditionally — exits early if the env flag is unset.
  *
@@ -144,6 +214,34 @@ export function registerE2eTestCommands(): void {
 
     // The `when` clauses in package.json menus look for this context key.
     void vscode.commands.executeCommand('setContext', E2E_TEST_CONTEXT_KEY, true);
+
+    // Opens the Migration Assistant against a deterministic, pre-seeded project
+    // (consent granted + application analysis populated + schema files present)
+    // so phase-flow specs can drive Discovery → Assessment → Conversion without
+    // the native file pickers. Always resets `.cosmosdb-migration` first so the
+    // command is hermetic regardless of prior-test state.
+    registerCommand('cosmosDB.e2e.openMigration', async (context: IActionContext): Promise<void> => {
+        context.telemetry.properties.isE2eTest = 'true';
+        const workspacePath = resolveWorkspacePath();
+        await resetMigrationFolder(workspacePath);
+        // Version control present is the default scenario: seed a `.git` dir so
+        // the "exclude from version control" control renders, with a clean
+        // .gitignore so the exclude checkbox starts unchecked.
+        await setGitPresent(workspacePath, true);
+        context.telemetry.properties.seeded = String(await seedMigrationProject(workspacePath));
+        MigrationAssistantTab.render(workspacePath);
+    });
+
+    // Opens the Migration Assistant against a fresh, empty project (no consent,
+    // no analysis) so specs can assert the initial disabled-control state.
+    registerCommand('cosmosDB.e2e.openMigrationFresh', async (context: IActionContext): Promise<void> => {
+        context.telemetry.properties.isE2eTest = 'true';
+        const workspacePath = resolveWorkspacePath();
+        await resetMigrationFolder(workspacePath);
+        // No version control: drop `.git` so the missing-VCS warning renders.
+        await setGitPresent(workspacePath, false);
+        MigrationAssistantTab.render(workspacePath);
+    });
 
     registerCommand('cosmosDB.e2e.openQueryEditor', (context: IActionContext, args?: Partial<EmulatorEnv>): void => {
         context.telemetry.properties.isE2eTest = 'true';

--- a/src/commands/e2eTestCommands/registerE2eTestCommands.ts
+++ b/src/commands/e2eTestCommands/registerE2eTestCommands.ts
@@ -141,8 +141,10 @@ async function attachEmulatorAccount(env: EmulatorEnv): Promise<void> {
 }
 
 /**
- * Recursively copies a seed project directory into `<workspace>/.cosmosdb-migration`,
- * overwriting any existing content so the command is idempotent.
+ * Deletes `<workspace>/.cosmosdb-migration` so each migration spec starts from a
+ * clean slate. The seed copy (when a fresh project is needed) is performed
+ * separately by {@link seedMigrationProject}. Best-effort: a missing folder is
+ * ignored, which keeps the command idempotent.
  */
 async function resetMigrationFolder(workspacePath: string): Promise<void> {
     const target = vscode.Uri.file(path.join(workspacePath, MIGRATION_FOLDER));

--- a/src/panels/MigrationAssistantTab.ts
+++ b/src/panels/MigrationAssistantTab.ts
@@ -582,6 +582,13 @@ export class MigrationAssistantTab extends BaseTab {
 
             // (Re-)create file watchers using the resolved paths (supports custom folder overrides)
             this.setupFileWatchers();
+
+            // Push git status after projectLoaded: the webview registers its
+            // channel listeners as part of mounting, which can race the early
+            // `checkGitRepository` request and drop the response. Re-emitting
+            // here (once the project has loaded) guarantees the warning /
+            // exclude controls hydrate deterministically.
+            void this.checkGitRepository();
         });
     }
 
@@ -1789,7 +1796,12 @@ export class MigrationAssistantTab extends BaseTab {
             if (gitExtension) {
                 const git = gitExtension.isActive ? gitExtension.exports : await gitExtension.activate();
                 const api = git.getAPI(1);
-                return api.repositories.length > 0;
+                if (api.repositories.length > 0) {
+                    return true;
+                }
+                // Fall through to the filesystem check: the git extension may not
+                // have indexed this folder yet (e.g. a just-initialized repo), but
+                // a `.git` directory still means the workspace is under version control.
             }
         } catch {
             // Fall back to filesystem check

--- a/src/panels/migration/helpers/aiHelpers.ts
+++ b/src/panels/migration/helpers/aiHelpers.ts
@@ -15,6 +15,7 @@ import {
     getSelectedModel as getSelectedModelShared,
     logLlmTokenUsage,
 } from '../../../utils/aiUtils';
+import { setMockRoute } from '../../../utils/languageModelMockUtils';
 import { MIGRATION_SELECTED_MODEL_KEY } from '../../../utils/modelUtils';
 import {
     type DebugPromptConfig,
@@ -22,6 +23,7 @@ import {
     dumpDebugResponse,
     tryLoadPromptOverride,
 } from './debugPromptHelpers';
+import { createMockMigrationModel, isMigrationAiMockEnabled } from './e2eMigrationAiMock';
 
 export { createMkDebug, dumpDebugResponse } from './debugPromptHelpers';
 /** Re-exported from shared `aiUtils` to avoid churn for existing callers. */
@@ -43,6 +45,11 @@ export { extractJsonObject } from '../../../utils/aiUtils';
  * @returns The resolved language model for the Migration Assistant.
  */
 export function getSelectedModel(options?: GetSelectedModelOptions): Promise<vscode.LanguageModelChat> {
+    // In e2e mock mode, bypass Copilot entirely and return a deterministic
+    // fake model so the full migration pipeline can run offline.
+    if (isMigrationAiMockEnabled()) {
+        return Promise.resolve(createMockMigrationModel());
+    }
     return getSelectedModelShared({
         ...options,
         stateKey: options?.stateKey ?? MIGRATION_SELECTED_MODEL_KEY,
@@ -235,7 +242,7 @@ export async function renderWithDebug<P extends BasePromptElementProps>(
     // Handle debug dump / override BEFORE injecting the defense message so
     // that `{stepName}.prompt.md` stays bound to the phase prompt (index 0
     // of the rendered messages) and dumps don't include the defense rules.
-    if (isDebugPromptsEnabled() && debugConfig) {
+    if (debugConfig?.dumpEnabled) {
         const override = await tryLoadPromptOverride(debugConfig.debugDir, debugConfig.stepName);
         if (override && messages.length > 0) {
             messages[0] = override;
@@ -294,6 +301,7 @@ async function runPromptFromMessages(
     inputTokenCount: number,
     modelOptions?: Record<string, unknown>,
     logDetail?: string,
+    routeId?: string,
 ): Promise<string> {
     // `label` is the telemetry-safe constant (reported as `caller`); `logLabel`
     // adds optional per-iteration detail (e.g. a domain name) for
@@ -305,6 +313,9 @@ async function runPromptFromMessages(
     );
     const startTime = Date.now();
 
+    // Deterministically route the e2e mock to the right canned response.
+    // No-op on real models, so the production path is unaffected.
+    setMockRoute(model, routeId ?? label);
     const response = await model.sendRequest(
         messages,
         { modelOptions: { ...DEFAULT_MODEL_OPTIONS, ...modelOptions } },
@@ -370,9 +381,10 @@ export async function runPrompt<P extends BasePromptElementProps>(
         inputTokenCount,
         modelOptions,
         logDetail,
+        debugConfig?.stepName ?? label,
     );
 
-    if (isDebugPromptsEnabled() && debugConfig) {
+    if (debugConfig?.dumpEnabled) {
         await dumpDebugResponse(debugConfig.debugDir, debugConfig.stepName, fullText, 'md');
     }
 
@@ -418,6 +430,7 @@ export async function runPromptWithJsonResult<T>(
         inputTokenCount,
         { temperature: 0.1 },
         logDetail,
+        debugConfig?.stepName ?? label,
     );
 
     const jsonString = extractJsonObject(fullText);
@@ -436,7 +449,7 @@ export async function runPromptWithJsonResult<T>(
             `keys=[${Object.keys(parsed as Record<string, unknown>).join(', ')}]`,
     );
 
-    if (isDebugPromptsEnabled() && debugConfig) {
+    if (debugConfig?.dumpEnabled) {
         await dumpDebugResponse(debugConfig.debugDir, debugConfig.stepName, JSON.stringify(parsed, null, 2), 'json');
     }
 
@@ -514,7 +527,7 @@ export async function runAgenticLoopWithJsonResult<T>(
             `keys=[${Object.keys(parsed as Record<string, unknown>).join(', ')}]`,
     );
 
-    if (isDebugPromptsEnabled() && debugConfig) {
+    if (debugConfig?.dumpEnabled) {
         await dumpDebugResponse(debugConfig.debugDir, debugConfig.stepName, JSON.stringify(parsed, null, 2), 'json');
     }
 
@@ -647,6 +660,10 @@ export async function runAgenticLoop(
             let cumulativeInputTokens = 0;
             let cumulativeOutputTokens = 0;
             let lastRoundInputTokens = 0;
+
+            // Deterministically route the e2e mock to the right canned response.
+            // No-op on real models, so the production path is unaffected.
+            setMockRoute(model, debugConfig?.stepName ?? label);
 
             for (let round = 0; round < maxRounds; round++) {
                 if (token.isCancellationRequested) return { text: lastRoundText, roundsExhausted: false };
@@ -813,7 +830,7 @@ export async function runAgenticLoop(
             context.telemetry.measurements.totalRounds = totalRounds;
             context.telemetry.measurements.durationMs = loopElapsed;
 
-            if (isDebugPromptsEnabled() && debugConfig && lastRoundText) {
+            if (debugConfig?.dumpEnabled && lastRoundText) {
                 await dumpDebugResponse(debugConfig.debugDir, debugConfig.stepName, lastRoundText, 'md');
             }
 

--- a/src/panels/migration/helpers/debugPromptHelpers.ts
+++ b/src/panels/migration/helpers/debugPromptHelpers.ts
@@ -14,6 +14,12 @@ export interface DebugPromptConfig {
     debugDir: string;
     /** Kebab-case step name used as filename prefix (e.g. 'step1-analysis'). */
     stepName: string;
+    /**
+     * Whether prompt/response dumps should actually be written to disk.
+     * The config is always produced (so `stepName` is available at runtime for
+     * e.g. deterministic test routing), but dumps are gated on this flag.
+     */
+    dumpEnabled: boolean;
 }
 
 // ─── Serialization ──────────────────────────────────────────────────
@@ -141,7 +147,8 @@ export async function tryLoadPromptOverride(
 
 /**
  * Creates a `mkDebug` helper bound to a specific debug directory.
- * Returns `DebugPromptConfig` when debug prompts are enabled, `undefined` otherwise.
+ * Always returns a {@link DebugPromptConfig} so `stepName` is available at
+ * runtime; the `dumpEnabled` flag reflects whether dumps should be written.
  *
  * Usage:
  * ```ts
@@ -149,11 +156,8 @@ export async function tryLoadPromptOverride(
  * await runPrompt(..., mkDebug('step1-analysis'));
  * ```
  */
-export function createMkDebug(
-    debugEnabled: boolean,
-    debugDir: string,
-): (stepName: string) => DebugPromptConfig | undefined {
-    return (stepName: string) => (debugEnabled ? { debugDir, stepName } : undefined);
+export function createMkDebug(debugEnabled: boolean, debugDir: string): (stepName: string) => DebugPromptConfig {
+    return (stepName: string) => ({ debugDir, stepName, dumpEnabled: debugEnabled });
 }
 
 /**

--- a/src/panels/migration/helpers/e2eMigrationAiMock.ts
+++ b/src/panels/migration/helpers/e2eMigrationAiMock.ts
@@ -1,0 +1,383 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Deterministic mock of the migration AI layer for Playwright e2e tests.
+ *
+ * Why this exists
+ * ---------------
+ * The Migration Assistant drives every phase (discovery → assessment → schema
+ * conversion → provisioning) through Copilot language models. A real VS Code
+ * launched by Playwright has no Copilot signed in, so the phase buttons would
+ * stay disabled and no AI flow could be exercised end-to-end.
+ *
+ * This module supplies a fake `vscode.LanguageModelChat` whose `sendRequest`
+ * inspects the rendered prompt and returns a canned, schema-valid response for
+ * each distinct migration AI call. Because the migration helpers route ALL
+ * model access through {@link getSelectedModel} (extension side), swapping in
+ * this mock makes the full pipeline run offline and deterministically.
+ *
+ * Visibility / safety
+ * -------------------
+ *  - Active ONLY when both `COSMOSDB_E2E_TEST === '1'` and
+ *    `COSMOSDB_E2E_MIGRATION_AI_MOCK === '1'` (set by the Playwright fixture in
+ *    `test/e2e/fixtures/vscode.ts`).
+ *  - Production users never set these env vars, so the mock is never wired in.
+ *
+ * Routing
+ * -------
+ * The run helpers (`aiHelpers.ts`) call `setMockRoute(model, stepId)` on this
+ * mock immediately before every `model.sendRequest`, passing the stable
+ * kebab-case step id (e.g. `step1-analysis`). The mock routes purely on that
+ * id (see {@link routeMockResponse}) — no fuzzy prompt-text matching — so
+ * rewording a prompt never changes which fixture is returned. An unmapped id
+ * throws, surfacing prompt/test drift loudly instead of silently degrading.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import type * as vscode from 'vscode';
+import { createMockLanguageModel } from '../../../utils/languageModelMockUtils';
+
+const E2E_TEST_ENV_KEY = 'COSMOSDB_E2E_TEST';
+/** When set, every mock request appends `{route, promptText}` to capture.jsonl. */
+const CAPTURE_DIR_ENV_KEY = 'COSMOSDB_E2E_MIGRATION_CAPTURE_DIR';
+const MIGRATION_AI_MOCK_ENV_KEY = 'COSMOSDB_E2E_MIGRATION_AI_MOCK';
+
+/** Stable identity for the mock model, surfaced in the webview model dropdown. */
+const MOCK_MODEL_ID = 'e2e-mock-migration-model';
+const MOCK_MODEL_NAME = 'E2E Mock Model';
+
+/**
+ * `true` when the migration AI mock should be wired in. Requires the master
+ * e2e flag as well so the mock can never leak into a normal session.
+ */
+export function isMigrationAiMockEnabled(): boolean {
+    return process.env[E2E_TEST_ENV_KEY] === '1' && process.env[MIGRATION_AI_MOCK_ENV_KEY] === '1';
+}
+
+// ─── Canned fixtures ────────────────────────────────────────────────
+
+const MOCK_DOMAIN = 'SalesDomain';
+
+/** A small but structurally complete CosmosModel reused across Phase 3 calls. */
+const MOCK_COSMOS_MODEL = {
+    version: 1,
+    domain: MOCK_DOMAIN,
+    sourceType: 'SQL Server',
+    capacityMode: 'serverless',
+    containers: [
+        {
+            name: 'orders',
+            partitionKeys: [{ path: '/customerId' }],
+            entities: [
+                {
+                    name: 'Order',
+                    docType: 'order',
+                    sourceTable: 'Orders',
+                    idTemplate: 'order-{OrderID}',
+                    attributes: [
+                        {
+                            target: 'id',
+                            source: { table: 'Orders', column: 'OrderID', type: 'int' },
+                            type: 'string',
+                            isId: true,
+                        },
+                        {
+                            target: 'customerId',
+                            source: { table: 'Orders', column: 'CustomerID', type: 'int' },
+                            type: 'string',
+                            isPartitionKey: true,
+                        },
+                        {
+                            target: 'total',
+                            source: { table: 'Orders', column: 'Total', type: 'decimal' },
+                            type: 'number',
+                        },
+                    ],
+                    relationships: [],
+                },
+            ],
+            indexingPolicy: {
+                indexingMode: 'consistent',
+                automatic: true,
+                includedPaths: [{ path: '/*' }],
+                excludedPaths: [{ path: '/"_etag"/?' }],
+            },
+        },
+    ],
+};
+
+const COSMOS_MODEL_JSON = JSON.stringify(MOCK_COSMOS_MODEL, null, 2);
+
+/** A `{ analysis, updatedModel }` envelope for Phase 3 thorough sub-steps. */
+const SCHEMA_STEP_RESULT_JSON = JSON.stringify(
+    {
+        analysis: '## Analysis\n\nMock analysis for the e2e schema-conversion sub-step.',
+        updatedModel: MOCK_COSMOS_MODEL,
+    },
+    null,
+    2,
+);
+
+/** Fast-conversion / final-summary sentinel format: JSON then `===SUMMARY===` then markdown. */
+const FAST_CONVERSION_RESPONSE = `${COSMOS_MODEL_JSON}
+===SUMMARY===
+# Schema Conversion Summary
+
+## Container Summary
+- **orders** — partition key \`/customerId\`, single entity \`Order\`.
+
+## Example JSON Documents
+\`\`\`json
+{ "id": "order-1", "customerId": "c1", "total": 100, "docType": "order" }
+\`\`\`
+`;
+
+const APPLICATION_DETAILS_JSON = JSON.stringify({
+    projectName: 'Contoso Sales',
+    projectType: 'Web API',
+    language: 'C#',
+    frameworks: ['ASP.NET Core', 'Entity Framework'],
+    databaseType: 'SQL Server',
+    databaseAccess: 'Entity Framework',
+});
+
+const ACCESS_PATTERN_EXTRACTION_JSON = JSON.stringify({
+    accessPatterns: [
+        {
+            name: 'R001-GetOrdersByCustomer',
+            type: 'read',
+            tables: ['Orders'],
+            frequency: 'high',
+            codeReferences: ['OrderRepository.cs'],
+            filterFields: ['CustomerID'],
+            singleOrBatch: 'batch',
+        },
+    ],
+});
+
+const DOMAIN_IDENTIFICATION_JSON = JSON.stringify({
+    domains: [
+        {
+            name: MOCK_DOMAIN,
+            description: 'Customer orders and order line items.',
+            tables: ['Orders', 'OrderDetails'],
+            rationale: 'These tables form a cohesive order-management bounded context.',
+            aggregateRoot: 'Orders',
+        },
+    ],
+});
+
+const SPLIT_DOMAIN_JSON = JSON.stringify({
+    subDomains: [
+        {
+            name: MOCK_DOMAIN,
+            description: 'Customer orders.',
+            tables: ['Orders', 'OrderDetails'],
+            rationale: 'Single cohesive sub-domain.',
+            aggregateRoot: 'Orders',
+        },
+    ],
+});
+
+const CROSS_DOMAIN_JSON = JSON.stringify({
+    crossDomainDependencies: [],
+    domainRecommendations: {},
+    summary: 'No significant cross-domain dependencies detected in the e2e mock.',
+});
+
+const DOMAIN_MAPPING_RESPONSE =
+    'After investigating the workspace, the domain is referenced in application code. ' +
+    '{ "isMapped": true, "evidence": "OrderRepository.cs references the Orders table." }';
+
+const ASSESSMENT_SUMMARY_MARKDOWN = `# Domain Assessment Summary
+
+## Domains
+### ${MOCK_DOMAIN}
+- Tables: Orders, OrderDetails
+- Mapped in code: yes
+`;
+
+const DISCOVERY_REPORT_MARKDOWN = `# Discovery Report
+
+## Schema Overview
+| Schema | Tables |
+| ------ | ------ |
+| Sales  | Orders, OrderDetails |
+
+## Read Patterns
+### R001-GetOrdersByCustomer
+Retrieve all orders for a given customer.
+
+## Write Patterns
+### W001-InsertOrder
+Insert a new order row.
+`;
+
+const ACCESS_PATTERNS_MARKDOWN = `## Access Pattern Mapping
+
+### R001-GetOrdersByCustomer
+- Target container: \`orders\`
+- Operation: point-read by partition key \`/customerId\`
+`;
+
+const CROSS_PARTITION_MARKDOWN = `## Cross-Partition Queries
+
+No cross-partition queries are required for this domain in the e2e mock.
+`;
+
+const DOMAIN_SUMMARY_MARKDOWN = `## Container Summary
+- **orders** — partition key \`/customerId\`.
+
+## Example JSON Documents
+\`\`\`json
+{ "id": "order-1", "customerId": "c1", "total": 100, "docType": "order" }
+\`\`\`
+`;
+
+const SAMPLE_DATA_JSON = JSON.stringify({
+    sampleData: [
+        {
+            containerName: 'orders',
+            items: [
+                { id: 'order-1', customerId: 'c1', total: 100, docType: 'order' },
+                { id: 'order-2', customerId: 'c2', total: 250, docType: 'order' },
+            ],
+        },
+    ],
+});
+
+// ─── Routing ────────────────────────────────────────────────────────
+
+/**
+ * Exact `stepName` → canned response map. Keys are the stable kebab-case step
+ * ids produced by `createMkDebug`/`sanitizeStepName` and threaded to the mock
+ * via `setMockRoute` right before each request.
+ */
+const ROUTE_MAP: Record<string, string> = {
+    // Phase 1: Discovery
+    'step1-analysis': APPLICATION_DETAILS_JSON,
+    'step2-discovery': DISCOVERY_REPORT_MARKDOWN,
+    // Phase 2: Assessment
+    'step1-access-pattern-extraction': ACCESS_PATTERN_EXTRACTION_JSON,
+    'step2-domain-identification': DOMAIN_IDENTIFICATION_JSON,
+    'step5-cross-domain': CROSS_DOMAIN_JSON,
+    summary: ASSESSMENT_SUMMARY_MARKDOWN,
+    // Phase 3: Schema Conversion
+    'step1-container-design': COSMOS_MODEL_JSON,
+    'step2-partition-key': SCHEMA_STEP_RESULT_JSON,
+    'step3-embedding': SCHEMA_STEP_RESULT_JSON,
+    'step4-access-patterns': ACCESS_PATTERNS_MARKDOWN,
+    'step5-cross-partition': CROSS_PARTITION_MARKDOWN,
+    'step6-indexing': SCHEMA_STEP_RESULT_JSON,
+    'step7-summary': DOMAIN_SUMMARY_MARKDOWN,
+    'fast-conversion': FAST_CONVERSION_RESPONSE,
+    'step8-final-summary': FAST_CONVERSION_RESPONSE,
+    // Phase 4: Provisioning
+    'sample-data-generation': SAMPLE_DATA_JSON,
+};
+
+/**
+ * Prefix-matched routes for steps whose id embeds a dynamic domain name
+ * (e.g. `step4-split-domain-salesdomain`, `step6-domain-mapping-salesdomain`).
+ */
+const ROUTE_PREFIXES: readonly { readonly prefix: string; readonly response: string }[] = [
+    { prefix: 'step4-split-domain-', response: SPLIT_DOMAIN_JSON },
+    { prefix: 'step6-domain-mapping-', response: DOMAIN_MAPPING_RESPONSE },
+];
+
+/**
+ * Maps a stable step id to its deterministic canned response. Throws on an
+ * unknown id so prompt/test drift surfaces loudly instead of silently falling
+ * back to an empty object.
+ */
+function routeMockResponse(route: string | undefined): string {
+    if (route !== undefined) {
+        const exact = ROUTE_MAP[route];
+        if (exact !== undefined) {
+            return exact;
+        }
+        for (const { prefix, response } of ROUTE_PREFIXES) {
+            if (route.startsWith(prefix)) {
+                return response;
+            }
+        }
+    }
+
+    throw new Error(`[e2eMigrationAiMock] No canned response mapped for route id "${route ?? '<undefined>'}".`);
+}
+
+/**
+ * Builds a fake {@link vscode.LanguageModelChat} that returns deterministic
+ * canned responses for every migration AI call. Tool calls are never emitted,
+ * so every agentic loop completes naturally in its first round.
+ */
+export function createMockMigrationModel(): vscode.LanguageModelChat {
+    return createMockLanguageModel({
+        id: MOCK_MODEL_ID,
+        name: MOCK_MODEL_NAME,
+        resolveResponse: async ({ route, promptText, token }): Promise<string> => {
+            capturePrompt(route, promptText);
+            const control = readControl();
+            if (route && control.failRoutes?.includes(route)) {
+                throw new Error(`[e2eMigrationAiMock] Injected failure for route "${route}".`);
+            }
+            if (control.delayMs && control.delayMs > 0) {
+                await delay(control.delayMs, token);
+            }
+            return routeMockResponse(route);
+        },
+    });
+}
+
+/** Test-tunable behavior, read fresh per request from `control.json`. */
+interface MockControl {
+    delayMs?: number;
+    failRoutes?: string[];
+}
+
+function readControl(): MockControl {
+    const dir = process.env[CAPTURE_DIR_ENV_KEY];
+    if (!dir) {
+        return {};
+    }
+    try {
+        return JSON.parse(readFileSync(path.join(dir, 'control.json'), 'utf-8')) as MockControl;
+    } catch {
+        return {};
+    }
+}
+
+/** Cancellable sleep so a phase's Cancel button can abort mid-request. */
+function delay(ms: number, token?: vscode.CancellationToken): Promise<void> {
+    return new Promise((resolve) => {
+        const timer = setTimeout(resolve, ms);
+        token?.onCancellationRequested(() => {
+            clearTimeout(timer);
+            resolve();
+        });
+    });
+}
+
+/**
+ * Best-effort, test-only sink: appends each request's route + flattened prompt
+ * text to `capture.jsonl` in {@link CAPTURE_DIR_ENV_KEY}. Lets e2e tests assert
+ * that user-entered phase instructions actually reach the model prompt.
+ */
+function capturePrompt(route: string | undefined, promptText: string): void {
+    const dir = process.env[CAPTURE_DIR_ENV_KEY];
+    if (!dir) {
+        return;
+    }
+    try {
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+        appendFileSync(path.join(dir, 'capture.jsonl'), JSON.stringify({ route: route ?? null, promptText }) + '\n');
+    } catch {
+        // Capture is diagnostic-only; never let it break the mock.
+    }
+}

--- a/src/panels/migration/steps/phase3SchemaConversion.ts
+++ b/src/panels/migration/steps/phase3SchemaConversion.ts
@@ -401,7 +401,7 @@ async function runFastConversion(
         );
     }
 
-    if (isDebugPromptsEnabled() && debugConfig) {
+    if (debugConfig?.dumpEnabled) {
         await dumpDebugResponse(
             debugConfig.debugDir,
             debugConfig.stepName,
@@ -636,7 +636,7 @@ async function runFinalSummary(
         throw new Error(l10n.t('Could not parse final summary response.'));
     }
 
-    if (isDebugPromptsEnabled() && debugConfig) {
+    if (debugConfig?.dumpEnabled) {
         await dumpDebugResponse(
             debugConfig.debugDir,
             debugConfig.stepName,

--- a/src/panels/migration/steps/phase4Provisioning.ts
+++ b/src/panels/migration/steps/phase4Provisioning.ts
@@ -321,14 +321,8 @@ export async function runProvisioning(ctx: Phase4Context): Promise<void> {
                 const aiModel = await getSelectedModel();
                 const sourceType = model.sourceType ?? 'relational';
 
-                let debugConfig: DebugPromptConfig | undefined;
-                if (isDebugPromptsEnabled()) {
-                    const mkDebug = createMkDebug(
-                        isDebugPromptsEnabled(),
-                        path.join(provisioningPath, 'debug-prompts'),
-                    );
-                    debugConfig = mkDebug('sample-data-generation');
-                }
+                const mkDebug = createMkDebug(isDebugPromptsEnabled(), path.join(provisioningPath, 'debug-prompts'));
+                const debugConfig: DebugPromptConfig = mkDebug('sample-data-generation');
 
                 const { value: generated, roundsExhausted: sampleDataRoundsExhausted } =
                     await runAgenticLoopWithJsonResult<SampleDataResult>(

--- a/src/utils/aiUtils.ts
+++ b/src/utils/aiUtils.ts
@@ -91,6 +91,16 @@ export interface AvailableModelDescriptor {
 export async function getAvailableModelsInfo(
     stateKey: string = SELECTED_MODEL_KEY,
 ): Promise<{ models: AvailableModelDescriptor[]; savedModelId: string | null }> {
+    // In e2e migration AI mock mode, advertise a single deterministic fake
+    // model so the webview model dropdown is populated. Gated on the master
+    // e2e flag so it can never affect a normal session.
+    if (process.env.COSMOSDB_E2E_TEST === '1' && process.env.COSMOSDB_E2E_MIGRATION_AI_MOCK === '1') {
+        const id = 'e2e-mock-migration-model';
+        return {
+            models: [{ id, name: 'E2E Mock Model', family: 'e2e-mock', vendor: 'copilot', maxInputTokens: 128_000 }],
+            savedModelId: id,
+        };
+    }
     try {
         const allModels = await vscode.lm.selectChatModels(modelSelector);
         const savedModelId = ext.context.globalState.get<string>(stateKey) ?? null;

--- a/src/utils/copilotUtils.ts
+++ b/src/utils/copilotUtils.ts
@@ -38,6 +38,14 @@ export function isCopilotChatExtensionInstalled(): boolean {
  * @returns Promise<boolean> true if Copilot models are available, false otherwise
  */
 export async function areCopilotModelsAvailable(): Promise<boolean> {
+    // In e2e migration AI mock mode there is no real Copilot, but the
+    // migration helpers substitute a deterministic fake model. Report
+    // availability as true so `ext.isAIFeaturesEnabled` is set and the
+    // migration phase buttons enable. Gated on the master e2e flag so it can
+    // never affect a normal session.
+    if (process.env.COSMOSDB_E2E_TEST === '1' && process.env.COSMOSDB_E2E_MIGRATION_AI_MOCK === '1') {
+        return true;
+    }
     try {
         const models = await vscode.lm.selectChatModels({ vendor: 'copilot' });
         return models.length > 0;

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -56,7 +56,7 @@ import {
     WarningRegular,
 } from '@fluentui/react-icons';
 import * as l10n from '@vscode/l10n';
-import { useCallback, useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react';
 import { type MigrationAppRouter } from '../../../panels/trpc/appRouter';
 import { sanitizeCosmosDBAccountName, validateCosmosDBAccountName } from '../../../utils/cosmosDBAccountName';
 import { formatTokenCount, partitionModelsByCapability } from '../../../utils/modelUtils';
@@ -896,6 +896,19 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
         },
         [dispatch, sendCommand],
     );
+
+    // Once a code migration plan has been generated on disk, the primary action
+    // shifts from "Plan Migration" to "Start Migration". Fire only on the
+    // false→true transition so the user can still re-select "Plan Migration"
+    // from the SplitButton menu afterwards (e.g. to regenerate the plan).
+    const prevHasCodeMigrationPlan = useRef(state.hasCodeMigrationPlan);
+    useEffect(() => {
+        if (state.hasCodeMigrationPlan && !prevHasCodeMigrationPlan.current && state.migrationMode === 'plan') {
+            handleSetMigrationMode('start');
+        }
+        prevHasCodeMigrationPlan.current = state.hasCodeMigrationPlan;
+    }, [state.hasCodeMigrationPlan, state.migrationMode, handleSetMigrationMode]);
+
     const handleMigrationInstructionsChange = useCallback(
         (_e: unknown, data: { value: string }) => {
             dispatch({ type: 'SET_MIGRATION_INSTRUCTIONS', payload: data.value });
@@ -1018,6 +1031,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
 
                 {state.hasGitRepo === true && state.isInGitignore !== null && (
                     <Checkbox
+                        data-testid="migration-gitignore-exclude"
                         checked={state.isInGitignore === true}
                         onChange={(_e, data) => {
                             if (data.checked === true) {
@@ -1044,6 +1058,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                 {state.availableModels.length > 0 && (
                     <Field label={l10n.t('AI Model')}>
                         <Dropdown
+                            data-testid="migration-model-dropdown"
                             onOptionSelect={handleModelChange}
                             value={selectedModel?.name ?? ''}
                             selectedOptions={state.selectedModelId ? [state.selectedModelId] : []}
@@ -1074,6 +1089,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                 )}
 
                 <Checkbox
+                    data-testid="migration-consent-checkbox"
                     checked={state.consentGiven}
                     onChange={handleConsentChange}
                     label={
@@ -1087,7 +1103,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                 />
 
                 {!state.isAIFeaturesEnabled && (
-                    <Text className={styles.warningText}>
+                    <Text data-testid="migration-ai-disabled-warning" className={styles.warningText}>
                         {l10n.t('AI features are currently unavailable. Please ensure GitHub Copilot is active.')}
                     </Text>
                 )}
@@ -1101,7 +1117,12 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                             'This workspace is not under version control. It is strongly recommended to initialize a Git repository before starting the migration.',
                         )}
                     </Text>
-                    <Button appearance="secondary" size="small" onClick={handleInitGit}>
+                    <Button
+                        data-testid="migration-git-init"
+                        appearance="secondary"
+                        size="small"
+                        onClick={handleInitGit}
+                    >
                         {l10n.t('Initialize Git Repository')}
                     </Button>
                 </div>
@@ -1340,6 +1361,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 validationState={!state.analysisResult?.projectName?.trim() ? 'error' : 'none'}
                             >
                                 <Input
+                                    data-testid="migration-project-name"
                                     size="small"
                                     value={state.analysisResult?.projectName ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('projectName', data.value)}
@@ -1364,6 +1386,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 validationState={!state.analysisResult?.projectType?.trim() ? 'error' : 'none'}
                             >
                                 <Input
+                                    data-testid="migration-project-type"
                                     size="small"
                                     value={state.analysisResult?.projectType ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('projectType', data.value)}
@@ -1388,6 +1411,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 validationState={!state.analysisResult?.language?.trim() ? 'error' : 'none'}
                             >
                                 <Input
+                                    data-testid="migration-language"
                                     size="small"
                                     value={state.analysisResult?.language ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('language', data.value)}
@@ -1413,6 +1437,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 validationState={!state.analysisResult?.frameworks?.length ? 'error' : 'none'}
                             >
                                 <Input
+                                    data-testid="migration-frameworks"
                                     size="small"
                                     value={state.analysisResult?.frameworks?.join(', ') ?? ''}
                                     onChange={(_e, data) => handleFrameworksChange(data.value)}
@@ -1437,6 +1462,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 validationState={!state.analysisResult?.databaseType?.trim() ? 'error' : 'none'}
                             >
                                 <Input
+                                    data-testid="migration-database"
                                     size="small"
                                     value={state.analysisResult?.databaseType ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('databaseType', data.value)}
@@ -1462,6 +1488,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 validationState={!state.analysisResult?.databaseAccess?.trim() ? 'error' : 'none'}
                             >
                                 <Input
+                                    data-testid="migration-access"
                                     size="small"
                                     value={state.analysisResult?.databaseAccess ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('databaseAccess', data.value)}
@@ -1497,6 +1524,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                           : '';
                                     const button = (
                                         <Button
+                                            data-testid="migration-auto-detect"
                                             appearance="primary"
                                             size="small"
                                             icon={<SparkleRegular />}
@@ -1536,7 +1564,12 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         <AccordionHeader icon={getPhaseIcon(phase1State)}>
                             <Text weight="semibold">{l10n.t('Phase 1: Discovery Report')}</Text>
                             {phase1State === 'complete' && (
-                                <Badge appearance="filled" color="success" style={{ marginLeft: '8px' }}>
+                                <Badge
+                                    data-testid="migration-phase1-status-complete"
+                                    appearance="filled"
+                                    color="success"
+                                    style={{ marginLeft: '8px' }}
+                                >
                                     {l10n.t('Complete')}
                                 </Badge>
                             )}
@@ -1564,6 +1597,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                     }
                                 >
                                     <Textarea
+                                        data-testid="migration-discovery-instructions"
                                         value={state.discoveryInstructions ?? ''}
                                         onChange={handleDiscoveryInstructionsChange}
                                         placeholder={l10n.t(
@@ -1587,6 +1621,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                     (state.showTokenEstimate ? (
                                         <div className={styles.buttonRow}>
                                             <Button
+                                                data-testid="migration-run-discovery"
                                                 appearance="primary"
                                                 size="small"
                                                 icon={<SparkleRegular />}
@@ -1604,6 +1639,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                         </div>
                                     ) : (
                                         <Button
+                                            data-testid="migration-run-discovery"
                                             appearance="primary"
                                             size="small"
                                             icon={<SparkleRegular />}
@@ -1624,6 +1660,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
 
                                 {phase1State === 'complete' && (
                                     <Button
+                                        data-testid="migration-view-discovery"
                                         appearance="secondary"
                                         size="small"
                                         icon={<DocumentRegular />}
@@ -1651,7 +1688,12 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         >
                             <Text weight="semibold">{l10n.t('Phase 2: Domain Assessment')}</Text>
                             {phase2State === 'complete' && (
-                                <Badge appearance="filled" color="success" style={{ marginLeft: '8px' }}>
+                                <Badge
+                                    data-testid="migration-phase2-status-complete"
+                                    appearance="filled"
+                                    color="success"
+                                    style={{ marginLeft: '8px' }}
+                                >
                                     {l10n.t('Complete')}
                                 </Badge>
                             )}
@@ -1711,6 +1753,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                                 }
                                             >
                                                 <Textarea
+                                                    data-testid="migration-assessment-instructions"
                                                     value={state.assessmentInstructions ?? ''}
                                                     onChange={handleAssessmentInstructionsChange}
                                                     placeholder={l10n.t(
@@ -1722,6 +1765,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                             </Field>
 
                                             <Button
+                                                data-testid="migration-run-assessment"
                                                 appearance="primary"
                                                 size="small"
                                                 icon={<SparkleRegular />}
@@ -1754,6 +1798,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                             })}
                                         </Text>
                                         <table
+                                            data-testid="migration-phase2-domains"
                                             style={{
                                                 width: '100%',
                                                 borderCollapse: 'collapse',
@@ -1789,6 +1834,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                                     >
                                                         <td style={{ padding: '4px 6px' }}>
                                                             <Link
+                                                                data-testid="migration-phase2-domain-link"
                                                                 className={styles.fileLink}
                                                                 onClick={() => handlePreviewMarkdown(domain.filePath)}
                                                             >
@@ -1841,6 +1887,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                             </tbody>
                                         </table>
                                         <Button
+                                            data-testid="migration-phase2-summary"
                                             appearance="secondary"
                                             size="small"
                                             icon={<DocumentRegular />}
@@ -1867,7 +1914,12 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         >
                             <Text weight="semibold">{l10n.t('Phase 3: Schema Conversion')}</Text>
                             {phase3State === 'complete' && (
-                                <Badge appearance="filled" color="success" style={{ marginLeft: '8px' }}>
+                                <Badge
+                                    data-testid="migration-phase3-status-complete"
+                                    appearance="filled"
+                                    color="success"
+                                    style={{ marginLeft: '8px' }}
+                                >
                                     {l10n.t('Complete')}
                                 </Badge>
                             )}
@@ -1932,6 +1984,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                             }
                                         >
                                             <Textarea
+                                                data-testid="migration-conversion-instructions"
                                                 value={state.schemaConversionInstructions ?? ''}
                                                 onChange={handleSchemaConversionInstructionsChange}
                                                 placeholder={l10n.t(
@@ -1970,6 +2023,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
 
                                     {state.schemaConversionState !== 'in-progress' && (
                                         <Button
+                                            data-testid="migration-run-conversion"
                                             appearance="primary"
                                             size="small"
                                             icon={<SparkleRegular />}
@@ -1999,6 +2053,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                             })}
                                         </Text>
                                         <table
+                                            data-testid="migration-phase3-domains"
                                             style={{
                                                 width: '100%',
                                                 borderCollapse: 'collapse',
@@ -2034,6 +2089,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                                     >
                                                         <td style={{ padding: '4px 6px' }}>
                                                             <Link
+                                                                data-testid="migration-phase3-domain-link"
                                                                 className={styles.fileLink}
                                                                 onClick={() =>
                                                                     handlePreviewMarkdown(domain.summaryFilePath)
@@ -2067,6 +2123,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                                             }}
                                                         >
                                                             <Link
+                                                                data-testid="migration-phase3-model-link"
                                                                 className={styles.fileLink}
                                                                 style={{
                                                                     display: 'inline',
@@ -2089,6 +2146,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                             }}
                                         >
                                             <Button
+                                                data-testid="migration-phase3-summary"
                                                 appearance="secondary"
                                                 size="small"
                                                 icon={<DocumentRegular />}
@@ -2099,6 +2157,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                                 {l10n.t('View Schema Conversion Summary')}
                                             </Button>
                                             <Button
+                                                data-testid="migration-phase3-model"
                                                 appearance="secondary"
                                                 size="small"
                                                 icon={<DocumentRegular />}
@@ -2126,7 +2185,12 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         >
                             <Text weight="semibold">{l10n.t('Phase 4: Target Cosmos DB Environment')}</Text>
                             {phase4State === 'complete' && (
-                                <Badge appearance="filled" color="success" style={{ marginLeft: '8px' }}>
+                                <Badge
+                                    data-testid="migration-phase4-status-complete"
+                                    appearance="filled"
+                                    color="success"
+                                    style={{ marginLeft: '8px' }}
+                                >
                                     {l10n.t('Complete')}
                                 </Badge>
                             )}
@@ -2153,7 +2217,11 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                             onChange={handleTargetTypeChange}
                                             disabled={isPhase4Disabled}
                                         >
-                                            <Radio value="emulator" label={l10n.t('Local Cosmos DB Emulator')} />
+                                            <Radio
+                                                data-testid="migration-target-emulator"
+                                                value="emulator"
+                                                label={l10n.t('Local Cosmos DB Emulator')}
+                                            />
                                             <Radio value="azure" label={l10n.t('Azure Cosmos DB Account')} />
                                             <Radio
                                                 value="provision"
@@ -2362,6 +2430,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                                     <ProgressBar />
                                                 ) : state.targetType === 'provision' ? null : (
                                                     <Button
+                                                        data-testid="migration-test-connection"
                                                         appearance="primary"
                                                         size="small"
                                                         icon={<PlugConnectedRegular />}
@@ -2380,7 +2449,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 </div>
 
                                 {state.connectionVerified && (
-                                    <Text>
+                                    <Text data-testid="migration-connection-verified">
                                         <CheckmarkCircleFilled style={{ color: 'var(--vscode-testing-iconPassed)' }} />{' '}
                                         {l10n.t('Connection verified successfully.')}
                                     </Text>
@@ -2441,6 +2510,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
 
                                         {state.provisioningState !== 'in-progress' && (
                                             <Button
+                                                data-testid="migration-populate-sample-data"
                                                 appearance="primary"
                                                 size="small"
                                                 icon={<DatabaseRegular />}
@@ -2464,7 +2534,10 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                         )}
 
                                         {state.provisioningResult && (
-                                            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                            <div
+                                                data-testid="migration-provisioning-summary"
+                                                style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}
+                                            >
                                                 <Text>
                                                     <CheckmarkCircleFilled
                                                         style={{ color: 'var(--vscode-testing-iconPassed)' }}
@@ -2560,7 +2633,10 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                 </Button>
                 <div className={styles.footerRight}>
                     {state.hasCodeMigrationPlan && (
-                        <Link onClick={() => handlePreviewMarkdown(state.codeMigrationPlanPath)}>
+                        <Link
+                            data-testid="migration-view-plan"
+                            onClick={() => handlePreviewMarkdown(state.codeMigrationPlanPath)}
+                        >
                             <DocumentRegular style={{ marginRight: 4, verticalAlign: 'middle' }} />
                             {l10n.t('View Plan')}
                         </Link>
@@ -2577,7 +2653,10 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                         ...triggerProps,
                                         'aria-label': l10n.t('Select migration action'),
                                     }}
-                                    primaryActionButton={{ onClick: handleStartMigration }}
+                                    primaryActionButton={{
+                                        onClick: handleStartMigration,
+                                        'data-testid': 'migration-action-button',
+                                    }}
                                 >
                                     {state.migrationMode === 'plan'
                                         ? l10n.t('Plan Migration')

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -34,6 +34,7 @@ import {
     Tooltip,
     type MenuButtonProps,
     type OptionOnSelectData,
+    type SplitButtonProps,
 } from '@fluentui/react-components';
 import {
     AddRegular,
@@ -2653,10 +2654,12 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                         ...triggerProps,
                                         'aria-label': l10n.t('Select migration action'),
                                     }}
-                                    primaryActionButton={{
-                                        onClick: handleStartMigration,
-                                        'data-testid': 'migration-action-button',
-                                    }}
+                                    primaryActionButton={
+                                        {
+                                            onClick: handleStartMigration,
+                                            'data-testid': 'migration-action-button',
+                                        } as SplitButtonProps['primaryActionButton']
+                                    }
                                 >
                                     {state.migrationMode === 'plan'
                                         ? l10n.t('Plan Migration')

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -54,10 +54,6 @@ Use `closeAllEditorTabs(vscodeWindow)` from `fixtures/webviewHelpers.ts`.
 # seeds the test DB, runs Playwright, then tears the emulator down)
 npm run e2e
 
-# Coverage-enabled runs (collect Playwright JS coverage from the VS Code webview)
-npm run e2e:coverage
-npm run e2e:coverage:query-editor
-
 # Author / debug
 npm run e2e:ui         # Playwright's UI mode — step through tests, time-travel
 npm run e2e:debug      # Playwright Inspector — pause + step + REPL at each action
@@ -111,110 +107,12 @@ test/e2e/
 │   │                             pushes emulator env vars into the launched
 │   │                             VS Code process
 │   ├── webviewHelpers.ts      — runCommand, getWebviewByPredicate,
-│   │                             closeAllEditorTabs, maximize/resizeWindow,
-│   │                             native-dialog stubs (stubMessageBoxButton /
-│   │                             resetNativeDialogStubs), screenshot capture
-│   ├── webviews.ts            — per-panel openers (Query Editor / Document /
-│   │                             Migration) + attachEmulator
-│   ├── queryEditor.ts         — Query Editor page-object (open / run / view
-│   │                             modes / result toolbar / paging / Stats /
-│   │                             selection / drill-in / run history / CRUD)
-│   ├── documentPanel.ts       — Document webview page-object (mode banner,
-│   │                             clipboard-paste content, Save) used by the
-│   │                             CRUD spec
-│   ├── consoleHealth.ts       — webview console-error monitor +
-│   │                             CONSOLE_ERROR_ALLOWLIST (kept empty)
+│   │                             closeAllEditorTabs
 │   └── workspace/             — source-of-truth workspace opened by every
 │                                worker (.nosql samples, .vscode/settings.json)
 └── specs/
-    ├── smoke.spec.ts              — opens Migration Assistant, asserts React mount
-    ├── emulator-connected.spec.ts — Query Editor connects + runs the seed query
-    └── queryEditor-*.spec.ts      — Query Editor coverage (tag `@queryEditor`):
-                                      open, query toolbar, toolbar overflow,
-                                      result view modes, result toolbar + Stats,
-                                      paging + page-size, table selection +
-                                      drill-in, query history, the production
-                                      tree-open path, the document CRUD
-                                      round-trip, run-selected-fragment, the
-                                      empty-result / invalid-query error paths,
-                                      the Duplicate-tab control, the
-                                      column-resize dialog, the Cancel control,
-                                      and the keyboard hotkeys (global tab /
-                                      duplicate shortcuts plus each toolbar,
-                                      paging and item shortcut verified in the
-                                      same case as its button action)
+    └── smoke.spec.ts          — opens Migration Assistant, asserts React mount
 ```
-
-## Query Editor coverage (`@queryEditor`)
-
-The bulk of the suite drives the Query Editor webview. Every Query Editor spec
-shares two fixtures, and coverage is now enabled automatically for runs started
-with `npm run e2e:coverage`:
-
-- **`fixtures/queryEditor.ts`** — the `QueryEditorPage` page-object. It wraps the
-  webview `Frame` with intention-revealing actions (`run`, `setViewMode`,
-  `setPageSize`, `goToNextPage`, `selectRow`, `openRunHistoryMenu`, …) so specs
-  read as user stories. `QueryEditorPage.open(window)` mounts the editor via the
-  `cosmosDB.e2e.openQueryEditor` test command; `QueryEditorPage.fromOpenTab(window)`
-  attaches to an editor opened by some other affordance (used by the tree-open
-  spec).
-- **`fixtures/consoleHealth.ts`** — attaches a console listener to the webview
-  frame at mount. Every spec ends with `qe.consoleHealth.assertNoConsoleErrors()`,
-  failing on any non-allowlisted `console.error` from the panel.
-  `CONSOLE_ERROR_ALLOWLIST` is intentionally **empty** — add an entry only for a
-  real, unavoidable error and document why inline.
-- **`fixtures/coverage.ts`** — auto fixture for coverage-enabled runs
-  (`COSMOSDB_E2E_COVERAGE=1`). It collects Playwright's built-in **V8** coverage
-  for the VS Code window (no `nyc`/`istanbul`/`c8` dependency), then projects the
-  executed byte ranges back onto component **source lines** through the webview
-  bundle's source maps. Per test it writes
-  `test/e2e/.results/<run-id>/<test-name>/coverage.json` (per-component
-  `mapped`/`covered` line numbers); `globalTeardown` aggregates every artifact
-  into `test/e2e/.reports/<run-id>/coverage-summary.{json,md}` — a per-component
-  covered/uncovered-line report. Two things make this work and are wired up
-  automatically for coverage runs: `globalSetup` rebuilds `dist/` **unminified +
-  with source maps** (`vite.config.views.mjs` keys off the same env var), and the
-  VS Code window is launched with site isolation disabled so the webview iframe
-  runs in the page renderer where `page.coverage` can see it.
-
-Run just this slice while iterating:
-
-```bash
-npx playwright test --grep "@queryEditor"      # all Query Editor specs
-npx playwright test queryEditor-paging         # one file by name substring
-```
-
-Conventions every Query Editor spec follows:
-
-- tag the describe block `{ tag: '@queryEditor' }` and `test.skip` when
-  `COSMOSDB_E2E_SKIP_EMULATOR=1`;
-- `beforeEach`: `maximizeWindow` → `attachEmulator` → `QueryEditorPage.open` →
-  `waitForConnected`;
-- `afterEach`: `captureNamedScreenshot(vscodeWindow, 'final')` → `dispose()` →
-  `closeAllEditorTabs` (plus `resetNativeDialogStubs` / close any Document tab a
-  test opened);
-- the **page-size confirmation** is a _native_ Electron dialog, so drive it with
-  `stubMessageBoxButton(vscodeApp, 'Continue' | 'Close')` and restore with
-  `resetNativeDialogStubs` — never expect a `.monaco-dialog-box`;
-- **`queryEditor-tree-open.spec.ts`** is the only tree-driven spec: it expands the
-  attached emulator in the Cosmos DB Workspaces tree and invokes the production
-  "Open Query Editor" container action. Keep tree navigation out of the other
-  specs (it is slower and more brittle than the command shortcut).
-- **`queryEditor-crud.spec.ts`** is **self-contained**: it creates its OWN
-  document with a unique id, queries for exactly that document, then deletes it —
-  so it never mutates the shared seed data. Document content is set via the OS
-  clipboard (`DocumentPanel.setContent` → Electron `clipboard.writeText` + paste)
-  because Monaco's auto-closing brackets/indent corrupt typed JSON. The delete
-  confirmation is a native modal — stub it with `stubMessageBoxButton(app, 'Yes')`.
-- **keyboard hotkeys** are verified alongside the button actions they mirror, in
-  the same spec/case: editor-scoped shortcuts (Ctrl+O / Ctrl+S) via
-  `pressEditorHotkey`, result-panel-scoped ones (paging, Refresh, Copy/Export,
-  item View/Edit/New/Delete) via `pressResultHotkey` / `focusResultPanel` + key.
-  A hotkey only fires when focus is inside its bound scope, so always focus the
-  editor or result panel first; item shortcuts (Alt+V/E/D) additionally need a
-  selected row, and focusing the result panel before Alt+V/E avoids the host
-  menu-bar mnemonics swallowing them. Global shortcuts (Alt+1/2, Alt+Shift+D)
-  live in `queryEditor-hotkeys.spec.ts`.
 
 ## Cosmos DB emulator
 
@@ -294,12 +192,50 @@ pipeline).
    React app mounted" check.
 6. Drive the webview with standard Playwright APIs on the returned `Frame`.
 
+## Controlling window chrome (side bars / panel)
+
+VS Code is reused per worker and the activation handshake opens the Azure side
+bar; on a fresh profile the GitHub Copilot Chat secondary side bar can also
+auto-pop. Both steal horizontal space and clutter the window screenshots we
+attach for webview tests.
+
+Every test gets a **`layout`** option (see `helpers/windowLayout.ts`) that the
+auto `windowLayout` fixture enforces before the test body runs. The default
+hides the Copilot Chat secondary side bar and the bottom panel; the primary
+side bar is left untouched.
+
+```ts
+// Default per test (no opt-in needed):
+//   { secondarySideBar: false, panel: false }
+
+// Override per file / describe / test. Your object is merged over the
+// defaults, so you only restate the parts you want to change — a key you
+// pass wins, a key you omit keeps its default (and parts absent from both
+// are left untouched):
+test.use({ layout: { primarySideBar: false } });           // also hide the tree
+test.use({ layout: { secondarySideBar: true } });          // show Copilot Chat
+test.use({ layout: { primarySideBar: false, panel: false } });
+```
+
+You can also apply a layout inline from within a test (e.g. mid-test):
+
+```ts
+import { applyWindowLayout } from '../helpers/windowLayout';
+
+await applyWindowLayout(vscodeWindow, { panel: true });
+```
+
+The helper diffs against the live workbench DOM and issues a visibility-toggle
+command only when a part isn't already in the desired state, so re-applying the
+same layout is a no-op.
+
 ## Patterns adopted from `vs-code-postgresql`
 
 | Pattern                                                      | Where                                                          | Why                                                                                                                                         |
 | ------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | Worker-scoped fixture                                        | `fixtures/vscode.ts`                                           | One VS Code launch per worker → 5–10× faster as the suite grows                                                                             |
 | `settings.json` pre-seeding                                  | `seedUserSettings()` in `fixtures/vscode.ts`                   | Disables sticky tree headers, preview tabs, secondary sidebar — kills several classes of flake before they happen                           |
+| Per-test window layout (`layout` option)                     | `helpers/windowLayout.ts` + `windowLayout` auto fixture        | Hides Copilot Chat / panel by default for clean screenshots; per-test override of which side bars + panel are visible                       |
 | Native dialog auto-dismiss                                   | `disableNativeDialogs()` via `app.evaluate(({ dialog }) => …)` | Save / message dialogs would otherwise block the test forever                                                                               |
 | Multi-step workbench-ready wait                              | `helpers/workbenchReady.ts`                                    | Force-shows all Electron windows, dumps diagnostics + screenshot on failure                                                                 |
 | `getWebviewByPredicate`                                      | `fixtures/webviewHelpers.ts`                                   | Outer webview iframe has no aria-label/title in current VS Code — iterating frames + predicate matching is more robust than selector chains |

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -54,6 +54,10 @@ Use `closeAllEditorTabs(vscodeWindow)` from `fixtures/webviewHelpers.ts`.
 # seeds the test DB, runs Playwright, then tears the emulator down)
 npm run e2e
 
+# Coverage-enabled runs (collect Playwright JS coverage from the VS Code webview)
+npm run e2e:coverage
+npm run e2e:coverage:query-editor
+
 # Author / debug
 npm run e2e:ui         # Playwright's UI mode — step through tests, time-travel
 npm run e2e:debug      # Playwright Inspector — pause + step + REPL at each action
@@ -99,6 +103,8 @@ test/e2e/
 │                                fixtures/vscode.ts.
 ├── helpers/
 │   ├── e2eIsolation.ts        — runId + run-scoped temp/results/reports dirs
+│   ├── windowLayout.ts        — per-test side-bar / panel visibility control
+│   │                             (the `layout` option + `windowLayout` fixture)
 │   └── workbenchReady.ts      — hardened workbench-readiness wait
 ├── fixtures/
 │   ├── vscode.ts              — worker-scoped vscodeApp + vscodeWindow,
@@ -107,12 +113,118 @@ test/e2e/
 │   │                             pushes emulator env vars into the launched
 │   │                             VS Code process
 │   ├── webviewHelpers.ts      — runCommand, getWebviewByPredicate,
-│   │                             closeAllEditorTabs
+│   │                             closeAllEditorTabs, maximize/resizeWindow,
+│   │                             native-dialog stubs (stubMessageBoxButton /
+│   │                             resetNativeDialogStubs), screenshot capture
+│   ├── webviews.ts            — per-panel openers (Query Editor / Document /
+│   │                             Migration) + attachEmulator
+│   ├── queryEditor.ts         — Query Editor page-object (open / run / view
+│   │                             modes / result toolbar / paging / Stats /
+│   │                             selection / drill-in / run history / CRUD)
+│   ├── documentPanel.ts       — Document webview page-object (mode banner,
+│   │                             clipboard-paste content, Save) used by the
+│   │                             CRUD spec
+│   ├── consoleHealth.ts       — webview console-error monitor +
+│   │                             CONSOLE_ERROR_ALLOWLIST (kept empty)
+│   ├── migration.ts           — Migration Assistant page-object + on-disk /
+│   │                             emulator artifact assertion helpers
+│   ├── migration-seed/        — seeded migration project (consent + analysis +
+│   │                             schema DDL) copied into the workspace for the
+│   │                             deterministic phase flow
 │   └── workspace/             — source-of-truth workspace opened by every
 │                                worker (.nosql samples, .vscode/settings.json)
 └── specs/
-    └── smoke.spec.ts          — opens Migration Assistant, asserts React mount
+    ├── smoke.spec.ts              — opens Migration Assistant, asserts React mount
+    ├── migration.spec.ts          — full Migration Assistant flow (phases 1–4
+    │                                 driven against the offline AI mock, plus
+    │                                 on-disk artifact + emulator assertions)
+    ├── emulator-connected.spec.ts — Query Editor connects + runs the seed query
+    └── queryEditor-*.spec.ts      — Query Editor coverage (tag `@queryEditor`):
+                                      open, query toolbar, toolbar overflow,
+                                      result view modes, result toolbar + Stats,
+                                      paging + page-size, table selection +
+                                      drill-in, query history, the production
+                                      tree-open path, the document CRUD
+                                      round-trip, run-selected-fragment, the
+                                      empty-result / invalid-query error paths,
+                                      the Duplicate-tab control, the
+                                      column-resize dialog, the Cancel control,
+                                      and the keyboard hotkeys (global tab /
+                                      duplicate shortcuts plus each toolbar,
+                                      paging and item shortcut verified in the
+                                      same case as its button action)
 ```
+
+## Query Editor coverage (`@queryEditor`)
+
+The bulk of the suite drives the Query Editor webview. Every Query Editor spec
+shares two fixtures, and coverage is now enabled automatically for runs started
+with `npm run e2e:coverage`:
+
+- **`fixtures/queryEditor.ts`** — the `QueryEditorPage` page-object. It wraps the
+  webview `Frame` with intention-revealing actions (`run`, `setViewMode`,
+  `setPageSize`, `goToNextPage`, `selectRow`, `openRunHistoryMenu`, …) so specs
+  read as user stories. `QueryEditorPage.open(window)` mounts the editor via the
+  `cosmosDB.e2e.openQueryEditor` test command; `QueryEditorPage.fromOpenTab(window)`
+  attaches to an editor opened by some other affordance (used by the tree-open
+  spec).
+- **`fixtures/consoleHealth.ts`** — attaches a console listener to the webview
+  frame at mount. Every spec ends with `qe.consoleHealth.assertNoConsoleErrors()`,
+  failing on any non-allowlisted `console.error` from the panel.
+  `CONSOLE_ERROR_ALLOWLIST` is intentionally **empty** — add an entry only for a
+  real, unavoidable error and document why inline.
+- **`fixtures/coverage.ts`** — auto fixture for coverage-enabled runs
+  (`COSMOSDB_E2E_COVERAGE=1`). It collects Playwright's built-in **V8** coverage
+  for the VS Code window (no `nyc`/`istanbul`/`c8` dependency), then projects the
+  executed byte ranges back onto component **source lines** through the webview
+  bundle's source maps. Per test it writes
+  `test/e2e/.results/<run-id>/<test-name>/coverage.json` (per-component
+  `mapped`/`covered` line numbers); `globalTeardown` aggregates every artifact
+  into `test/e2e/.reports/<run-id>/coverage-summary.{json,md}` — a per-component
+  covered/uncovered-line report. Two things make this work and are wired up
+  automatically for coverage runs: `globalSetup` rebuilds `dist/` **unminified +
+  with source maps** (`vite.config.views.mjs` keys off the same env var), and the
+  VS Code window is launched with site isolation disabled so the webview iframe
+  runs in the page renderer where `page.coverage` can see it.
+
+Run just this slice while iterating:
+
+```bash
+npx playwright test --grep "@queryEditor"      # all Query Editor specs
+npx playwright test queryEditor-paging         # one file by name substring
+```
+
+Conventions every Query Editor spec follows:
+
+- tag the describe block `{ tag: '@queryEditor' }` and `test.skip` when
+  `COSMOSDB_E2E_SKIP_EMULATOR=1`;
+- `beforeEach`: `maximizeWindow` → `attachEmulator` → `QueryEditorPage.open` →
+  `waitForConnected`;
+- `afterEach`: `captureNamedScreenshot(vscodeWindow, 'final')` → `dispose()` →
+  `closeAllEditorTabs` (plus `resetNativeDialogStubs` / close any Document tab a
+  test opened);
+- the **page-size confirmation** is a _native_ Electron dialog, so drive it with
+  `stubMessageBoxButton(vscodeApp, 'Continue' | 'Close')` and restore with
+  `resetNativeDialogStubs` — never expect a `.monaco-dialog-box`;
+- **`queryEditor-tree-open.spec.ts`** is the only tree-driven spec: it expands the
+  attached emulator in the Cosmos DB Workspaces tree and invokes the production
+  "Open Query Editor" container action. Keep tree navigation out of the other
+  specs (it is slower and more brittle than the command shortcut).
+- **`queryEditor-crud.spec.ts`** is **self-contained**: it creates its OWN
+  document with a unique id, queries for exactly that document, then deletes it —
+  so it never mutates the shared seed data. Document content is set via the OS
+  clipboard (`DocumentPanel.setContent` → Electron `clipboard.writeText` + paste)
+  because Monaco's auto-closing brackets/indent corrupt typed JSON. The delete
+  confirmation is a native modal — stub it with `stubMessageBoxButton(app, 'Yes')`.
+- **keyboard hotkeys** are verified alongside the button actions they mirror, in
+  the same spec/case: editor-scoped shortcuts (Ctrl+O / Ctrl+S) via
+  `pressEditorHotkey`, result-panel-scoped ones (paging, Refresh, Copy/Export,
+  item View/Edit/New/Delete) via `pressResultHotkey` / `focusResultPanel` + key.
+  A hotkey only fires when focus is inside its bound scope, so always focus the
+  editor or result panel first; item shortcuts (Alt+V/E/D) additionally need a
+  selected row, and focusing the result panel before Alt+V/E avoids the host
+  menu-bar mnemonics swallowing them. Global shortcuts (Alt+1/2, Alt+Shift+D)
+  live in `queryEditor-hotkeys.spec.ts`.
 
 ## Cosmos DB emulator
 

--- a/test/e2e/fixtures/migration-seed/phases/1-discovery/schema-ddl/schema.sql
+++ b/test/e2e/fixtures/migration-seed/phases/1-discovery/schema-ddl/schema.sql
@@ -1,0 +1,18 @@
+-- E2E seed schema for the Migration Assistant phase-flow tests.
+-- Deterministic, minimal DDL so the (mocked) AI pipeline has schema input.
+
+CREATE TABLE Orders (
+    OrderID    INT          NOT NULL PRIMARY KEY,
+    CustomerID INT          NOT NULL,
+    OrderDate  DATETIME     NOT NULL,
+    Total      DECIMAL(18,2) NOT NULL
+);
+
+CREATE TABLE OrderDetails (
+    OrderDetailID INT          NOT NULL PRIMARY KEY,
+    OrderID       INT          NOT NULL,
+    ProductID     INT          NOT NULL,
+    Quantity      INT          NOT NULL,
+    UnitPrice     DECIMAL(18,2) NOT NULL,
+    CONSTRAINT FK_OrderDetails_Orders FOREIGN KEY (OrderID) REFERENCES Orders (OrderID)
+);

--- a/test/e2e/fixtures/migration-seed/project.json
+++ b/test/e2e/fixtures/migration-seed/project.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "name": "E2E Migration",
+  "sourceCode": "parent",
+  "sessionId": "e2e-fixed-session",
+  "consentGiven": true,
+  "migrationMode": "plan",
+  "phases": {
+    "discovery": {
+      "status": "not-started",
+      "applicationAnalysis": {
+        "projectName": "Contoso Sales",
+        "projectType": "Web API",
+        "language": "C#",
+        "frameworks": ["ASP.NET Core", "Entity Framework"],
+        "databaseType": "SQL Server",
+        "databaseAccess": "Entity Framework"
+      }
+    }
+  }
+}

--- a/test/e2e/fixtures/migration.ts
+++ b/test/e2e/fixtures/migration.ts
@@ -1,0 +1,365 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Page-object helpers for driving the Migration Assistant webview from e2e
+ * specs. Selectors prefer the stable `data-testid` attributes added to the
+ * React component (see `src/webviews/cosmosdb/Migration/MigrationAssistant.tsx`)
+ * and fall back to visible phase-header text for the collapsible accordion.
+ */
+
+import { CosmosClient } from '@azure/cosmos';
+import { expect, type Frame, type Locator } from '@playwright/test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import * as https from 'node:https';
+import * as path from 'node:path';
+import { E2E_EMULATOR_ENDPOINT, E2E_EMULATOR_KEY } from '../setup/emulator';
+
+/** Tunes the migration AI mock (delay/failure) for the current test. */
+export function setMockControl(control: { delayMs?: number; failRoutes?: string[] }): void {
+    const dir = process.env.COSMOSDB_E2E_MIGRATION_CAPTURE_DIR;
+    if (!dir) return;
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'control.json'), JSON.stringify(control));
+}
+
+/** Clears any mock control so the next test runs at full speed. */
+export function clearMockControl(): void {
+    const dir = process.env.COSMOSDB_E2E_MIGRATION_CAPTURE_DIR;
+    if (!dir) return;
+    try {
+        rmSync(path.join(dir, 'control.json'), { force: true });
+    } catch {
+        /* ignore */
+    }
+}
+
+/** Reads the workspace `.gitignore` (empty string when absent). */
+export function readGitignore(): string {
+    const ws = process.env.COSMOSDB_E2E_WORKSPACE_DIR;
+    if (!ws) return '';
+    try {
+        return readFileSync(path.join(ws, '.gitignore'), 'utf-8');
+    } catch {
+        return '';
+    }
+}
+
+/** True when the worker workspace currently has a seeded `.git` directory. */
+export function gitDirExists(): boolean {
+    const ws = process.env.COSMOSDB_E2E_WORKSPACE_DIR;
+    return !!ws && existsSync(path.join(ws, '.git'));
+}
+
+/** Absolute path to a Phase 4 provisioning artifact in the worker workspace. */
+function provisioningArtifact(name: 'sample-data.json' | 'seed-data.csh'): string | undefined {
+    const ws = process.env.COSMOSDB_E2E_WORKSPACE_DIR;
+    if (!ws) return undefined;
+    return path.join(ws, '.cosmosdb-migration', 'phases', '4-provisioning', name);
+}
+
+/** True when a given Phase 4 provisioning artifact exists on disk. */
+export function provisioningArtifactExists(name: 'sample-data.json' | 'seed-data.csh'): boolean {
+    const p = provisioningArtifact(name);
+    return !!p && existsSync(p);
+}
+
+/**
+ * Reads a migration artifact relative to the worker workspace's
+ * `.cosmosdb-migration` root (e.g. `phases/1-discovery/discovery-report.md`).
+ * Returns `undefined` when the env or file is absent.
+ */
+export function readMigrationArtifact(relativePath: string): string | undefined {
+    const ws = process.env.COSMOSDB_E2E_WORKSPACE_DIR;
+    if (!ws) return undefined;
+    try {
+        return readFileSync(path.join(ws, '.cosmosdb-migration', relativePath), 'utf-8');
+    } catch {
+        return undefined;
+    }
+}
+
+/** Reads + JSON-parses a migration artifact (undefined when absent/invalid). */
+export function readMigrationJson<T = unknown>(relativePath: string): T | undefined {
+    const raw = readMigrationArtifact(relativePath);
+    if (raw === undefined) return undefined;
+    try {
+        return JSON.parse(raw) as T;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Simulates Copilot Chat producing the code migration plan by writing
+ * `code-migration-plan.md` into the worker workspace's `.cosmosdb-migration`
+ * root. The extension's file watcher picks it up and flips `hasCodeMigrationPlan`.
+ */
+export function writeCodeMigrationPlan(content = '# Code Migration Plan\n'): void {
+    const ws = process.env.COSMOSDB_E2E_WORKSPACE_DIR;
+    if (!ws) throw new Error('COSMOSDB_E2E_WORKSPACE_DIR is not set');
+    const dir = path.join(ws, '.cosmosdb-migration');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'code-migration-plan.md'), content, 'utf-8');
+}
+
+/** Reads + parses the generated `sample-data.json` (undefined when absent). */
+export function readSampleData(): { sampleData: { containerName: string; items: unknown[] }[] } | undefined {
+    const p = provisioningArtifact('sample-data.json');
+    if (!p || !existsSync(p)) return undefined;
+    try {
+        return JSON.parse(readFileSync(p, 'utf-8')) as { sampleData: { containerName: string; items: unknown[] }[] };
+    } catch {
+        return undefined;
+    }
+}
+
+/** Reads every document from an emulator container (id-sorted, no system fields). */
+export async function readEmulatorItems(databaseId: string, containerId: string): Promise<Record<string, unknown>[]> {
+    // Scoped self-signed-cert trust, mirroring `test/e2e/setup/emulator.ts`. The
+    // agent is local to this client so the relaxation never leaks process-wide.
+    const client = new CosmosClient({
+        endpoint: E2E_EMULATOR_ENDPOINT,
+        key: E2E_EMULATOR_KEY,
+        connectionPolicy: { enableEndpointDiscovery: false },
+        agent: new https.Agent({ rejectUnauthorized: false }),
+    });
+    const container = client.database(databaseId).container(containerId);
+    const { resources } = await container.items.readAll<Record<string, unknown>>().fetchAll();
+    return resources
+        .map((doc) => {
+            const stripped: Record<string, unknown> = {};
+            for (const [k, v] of Object.entries(doc)) {
+                if (!k.startsWith('_')) stripped[k] = v;
+            }
+            return stripped;
+        })
+        .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+}
+
+/** Reads the migration AI-mock prompt capture log written during the run. */
+export function readCapturedPrompts(): { route: string | null; promptText: string }[] {
+    const dir = process.env.COSMOSDB_E2E_MIGRATION_CAPTURE_DIR;
+    if (!dir) return [];
+    try {
+        return readFileSync(path.join(dir, 'capture.jsonl'), 'utf-8')
+            .split('\n')
+            .filter((l) => l.trim().length > 0)
+            .map((l) => JSON.parse(l) as { route: string | null; promptText: string });
+    } catch {
+        return [];
+    }
+}
+
+/** Visible (English-default) phase header labels. */
+export const PHASE_HEADERS = {
+    phase1: 'Phase 1: Discovery Report',
+    phase2: 'Phase 2: Domain Assessment',
+    phase3: 'Phase 3: Schema Conversion',
+    phase4: 'Phase 4: Target Cosmos DB Environment',
+} as const;
+
+export class MigrationPage {
+    constructor(private readonly frame: Frame) {}
+
+    get root(): Locator {
+        return this.frame.locator('#root');
+    }
+
+    get consentCheckbox(): Locator {
+        // Fluent UI's Checkbox renders the real <input type="checkbox"> with the
+        // accessible name taken from its label. Target it by role rather than by
+        // data-testid (which Fluent places on the root wrapper, not the input).
+        return this.frame.getByRole('checkbox', { name: /acknowledge that this feature uses AI/i });
+    }
+
+    get modelDropdown(): Locator {
+        return this.frame.getByTestId('migration-model-dropdown');
+    }
+
+    runDiscoveryButton(): Locator {
+        return this.frame.getByTestId('migration-run-discovery');
+    }
+
+    runAssessmentButton(): Locator {
+        return this.frame.getByTestId('migration-run-assessment');
+    }
+
+    runConversionButton(): Locator {
+        return this.frame.getByTestId('migration-run-conversion');
+    }
+
+    // ── Configuration / Phase 1 controls ─────────────────────────────
+    get autoDetectButton(): Locator {
+        return this.frame.getByTestId('migration-auto-detect');
+    }
+
+    get projectNameInput(): Locator {
+        return this.frame.getByTestId('migration-project-name');
+    }
+
+    /** An Application Details input by field key. */
+    analysisField(field: 'project-name' | 'project-type' | 'language' | 'frameworks' | 'database' | 'access'): Locator {
+        return this.frame.getByTestId(`migration-${field}`);
+    }
+
+    get viewDiscoveryButton(): Locator {
+        return this.frame.getByTestId('migration-view-discovery');
+    }
+
+    get gitignoreExclude(): Locator {
+        return this.frame.getByRole('checkbox', { name: /Exclude migration configuration from version control/i });
+    }
+
+    get gitInitButton(): Locator {
+        return this.frame.getByTestId('migration-git-init');
+    }
+
+    get aiDisabledWarning(): Locator {
+        return this.frame.getByTestId('migration-ai-disabled-warning');
+    }
+
+    instructions(phase: 'discovery' | 'assessment' | 'conversion'): Locator {
+        return this.frame.getByTestId(`migration-${phase}-instructions`);
+    }
+
+    // ── Progress / cancel / error states ─────────────────────────────
+    get progressBar(): Locator {
+        return this.frame.getByRole('progressbar');
+    }
+
+    get cancelButton(): Locator {
+        return this.frame.getByRole('button', { name: 'Cancel', exact: true });
+    }
+
+    get errorAlert(): Locator {
+        return this.frame.getByRole('alert');
+    }
+
+    phaseHeader(label: string): Locator {
+        return this.frame.getByText(label, { exact: true });
+    }
+
+    phaseCompleteBadge(phase: 'phase1' | 'phase2' | 'phase3' | 'phase4'): Locator {
+        return this.frame.getByTestId(`migration-${phase}-status-complete`);
+    }
+
+    // ── Phase 2 artifacts ────────────────────────────────────────────
+    get phase2DomainTable(): Locator {
+        return this.frame.getByTestId('migration-phase2-domains');
+    }
+
+    /** Per-domain summary links rendered in the Phase 2 table. */
+    phase2DomainLinks(): Locator {
+        return this.frame.getByTestId('migration-phase2-domain-link');
+    }
+
+    get phase2SummaryButton(): Locator {
+        return this.frame.getByTestId('migration-phase2-summary');
+    }
+
+    // ── Phase 3 artifacts ────────────────────────────────────────────
+    get phase3DomainTable(): Locator {
+        return this.frame.getByTestId('migration-phase3-domains');
+    }
+
+    /** Per-domain summary links rendered in the Phase 3 table. */
+    phase3DomainLinks(): Locator {
+        return this.frame.getByTestId('migration-phase3-domain-link');
+    }
+
+    /** Per-domain JSON model links rendered in the Phase 3 table. */
+    phase3ModelLinks(): Locator {
+        return this.frame.getByTestId('migration-phase3-model-link');
+    }
+
+    get phase3SummaryButton(): Locator {
+        return this.frame.getByTestId('migration-phase3-summary');
+    }
+
+    get phase3ModelButton(): Locator {
+        return this.frame.getByTestId('migration-phase3-model');
+    }
+
+    // ── Phase 4: Target environment / provisioning ───────────────────
+    get emulatorRadio(): Locator {
+        return this.frame.getByRole('radio', { name: /Local Cosmos DB Emulator/i });
+    }
+
+    get testConnectionButton(): Locator {
+        return this.frame.getByTestId('migration-test-connection');
+    }
+
+    get connectionVerified(): Locator {
+        return this.frame.getByTestId('migration-connection-verified');
+    }
+
+    get populateSampleDataButton(): Locator {
+        return this.frame.getByTestId('migration-populate-sample-data');
+    }
+
+    get provisioningSummary(): Locator {
+        return this.frame.getByTestId('migration-provisioning-summary');
+    }
+
+    // ── Final step: Plan / Start Migration ───────────────────────────
+    /** Primary action of the footer SplitButton ("Plan Migration" / "Start Migration"). */
+    get migrationActionButton(): Locator {
+        return this.frame.getByTestId('migration-action-button');
+    }
+
+    /** "View Plan" link, rendered only once a code migration plan exists. */
+    get viewPlanLink(): Locator {
+        return this.frame.getByTestId('migration-view-plan');
+    }
+
+    /**
+     * A VS Code editor/preview tab by accessible name. Tabs live in the
+     * workbench (outside the webview iframe), reachable via `frame.page()`.
+     */
+    openedTab(name: string | RegExp): Locator {
+        return this.frame.page().getByRole('tab', { name });
+    }
+
+    /**
+     * Re-activates the Migration Assistant editor tab. Opening an artifact tab
+     * makes the webview the inactive tab, so the panel must be refocused before
+     * interacting with its controls again.
+     */
+    async focus(): Promise<void> {
+        await this.openedTab(/Cosmos DB Migration Assistant/).click();
+        await expect(this.modelDropdown).toBeVisible();
+    }
+
+    /**
+     * Expands a collapsed accordion phase by clicking its header. The Phase 1
+     * panel is open by default; Phases 2–4 must be expanded before their
+     * controls become interactable.
+     */
+    async expandPhase(label: string): Promise<void> {
+        await this.phaseHeader(label).click();
+    }
+
+    /** Runs a phase end-to-end and waits for its completion badge. */
+    async runDiscovery(timeoutMs = 60_000): Promise<void> {
+        await expect(this.runDiscoveryButton()).toBeEnabled();
+        await this.runDiscoveryButton().click();
+        await expect(this.phaseCompleteBadge('phase1')).toBeVisible({ timeout: timeoutMs });
+    }
+
+    async runAssessment(timeoutMs = 60_000): Promise<void> {
+        await this.expandPhase(PHASE_HEADERS.phase2);
+        await expect(this.runAssessmentButton()).toBeEnabled();
+        await this.runAssessmentButton().click();
+        await expect(this.phaseCompleteBadge('phase2')).toBeVisible({ timeout: timeoutMs });
+    }
+
+    async runConversion(timeoutMs = 90_000): Promise<void> {
+        await this.expandPhase(PHASE_HEADERS.phase3);
+        await expect(this.runConversionButton()).toBeEnabled();
+        await this.runConversionButton().click();
+        await expect(this.phaseCompleteBadge('phase3')).toBeVisible({ timeout: timeoutMs });
+    }
+}

--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -45,10 +45,10 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
 import { ensureE2eIsolationContext } from '../helpers/e2eIsolation';
+import { applyWindowLayout, DEFAULT_LAYOUT, type WindowLayout } from '../helpers/windowLayout';
 import { waitForWorkbenchReady } from '../helpers/workbenchReady';
 import { waitForExtensionsActivated } from '../setup/activation';
-import { isCoverageEnabled, startCoverage, stopAndPersistCoverage } from './coverage';
-import { closeAuxiliaryBar } from './webviewHelpers';
+import { E2E_EMULATOR_PORT } from '../setup/emulator';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..', '..', '..');
@@ -98,15 +98,8 @@ function seedUserSettings(userDataDir: string): void {
         // worker should start with an empty workbench.
         'files.hotExit': 'onExitAndWindowClose',
         // Chat / secondary sidebar can autopopup on fresh installs and steal
-        // 30 % of horizontal space, hiding webview content. The setting below
-        // is best-effort (auxiliary-bar visibility is mostly persisted UI
-        // state, not a real setting), so we also explicitly close the
-        // auxiliary bar once the workbench is ready — see `closeAuxiliaryBar`
-        // in the `vscodeWindow` fixture.
+        // 30 % of horizontal space, hiding webview content.
         'workbench.secondarySideBar.visible': false,
-        // Drop the Chat entry from the title-bar command center so a fresh
-        // profile doesn't surface the chat affordance at all.
-        'chat.commandCenter.enabled': false,
         // Silence "do you trust this folder" — we already pass --disable-workspace-trust.
         'security.workspace.trust.enabled': false,
         // Cosmos DB emulator (linux/vnext-preview) advertises its writable
@@ -116,7 +109,9 @@ function seedUserSettings(userDataDir: string): void {
         // unreachable port. Force the client to stay on whichever endpoint
         // the connection points at. Harmless for production single-region
         // accounts; required for any e2e-vs-emulator scenario.
-        'cosmosDB.enableEndpointDiscovery': false,
+        'cosmosDB.enableEndpointDiscovery': false, // The dedicated e2e emulator binds to 8082 (not the default 8081);
+        // the migration provisioning step reads this to target the right port.
+        'cosmosDB.emulator.port': E2E_EMULATOR_PORT,
     };
     const settingsPath = path.join(userDataDir, 'User', 'settings.json');
     mkdirSync(path.dirname(settingsPath), { recursive: true });
@@ -125,15 +120,14 @@ function seedUserSettings(userDataDir: string): void {
 
 /**
  * Monkey-patch Electron's main-process `dialog` module so native
- * save / open / message dialogs never block the test. Untitled SQL editors,
- * unsaved changes on tab close, the Query Editor's "Open query" file picker,
- * etc. would otherwise pop an OS dialog that Playwright cannot interact with.
+ * save / message dialogs never block the test. Untitled SQL editors,
+ * unsaved changes on tab close, etc. would otherwise pop an OS dialog
+ * that Playwright cannot interact with.
  */
 async function disableNativeDialogs(app: ElectronApplication): Promise<void> {
     await app
         .evaluate(({ dialog }) => {
             dialog.showSaveDialog = () => Promise.resolve({ canceled: true, filePath: '' });
-            dialog.showOpenDialog = () => Promise.resolve({ canceled: true, filePaths: [] });
             dialog.showMessageBoxSync = () => 1; // Typically "Don't Save"
             dialog.showMessageBox = () => Promise.resolve({ response: 1, checkboxChecked: false });
         })
@@ -158,16 +152,33 @@ interface VsCodeFixtures {
 
 interface VsCodeTestFixtures {
     /**
+     * Test-scoped **option** controlling which VS Code chrome parts (primary
+     * side bar, secondary side bar / Copilot Chat, bottom panel) are visible
+     * for the test. Merged over {@link DEFAULT_LAYOUT} by the auto
+     * `windowLayout` fixture (Copilot Chat + bottom panel hidden by default for
+     * clean webview screenshots).
+     *
+     * Override per file / describe / test with `test.use()`:
+     *
+     *     test.use({ layout: { primarySideBar: false } });
+     *
+     * Keys are tri-state — a key you omit keeps its default; the defaults you
+     * don't override stay in effect (the fixture merges them in). Applied
+     * before each test body and re-enforced before each window screenshot.
+     */
+    layout: WindowLayout;
+    /**
+     * Auto fixture (no value) that enforces the {@link VsCodeTestFixtures.layout}
+     * option on the shared VS Code window before each test runs. See the
+     * fixture body.
+     */
+    windowLayout: void;
+    /**
      * Auto fixture (no value) that records a self-managed Playwright trace of
      * the VS Code window for the duration of each test when
      * `COSMOSDB_E2E_SCREENSHOT` selects a `trace` mode. See the fixture body.
      */
     windowTrace: void;
-    /**
-     * Auto fixture that captures JS coverage for the VS Code webview window
-     * when `COSMOSDB_E2E_COVERAGE=1` is set.
-     */
-    coverage: void;
 }
 
 export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
@@ -202,6 +213,22 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
                 mkdirSync(workspaceDir, { recursive: true });
             }
 
+            // Per-worker scratch dir the migration AI mock reads (control.json)
+            // and writes (capture.jsonl). Created up front so both the worker
+            // (setMockControl) and the extension can see the same location.
+            const migrationCaptureDir = path.join(workerDir, 'migration-capture');
+            mkdirSync(migrationCaptureDir, { recursive: true });
+
+            // Expose the per-worker workspace + capture dirs to this worker's
+            // process.env. The migration fixtures (readGitignore, gitDirExists,
+            // provisioningArtifact*, setMockControl) read these from the worker,
+            // and the `...process.env` spread below forwards COSMOSDB_E2E_*
+            // straight into the launched extension host (the AI mock reads the
+            // capture dir there). Workers are isolated processes, so this never
+            // leaks across workers.
+            process.env.COSMOSDB_E2E_WORKSPACE_DIR = workspaceDir;
+            process.env.COSMOSDB_E2E_MIGRATION_CAPTURE_DIR = migrationCaptureDir;
+
             seedUserSettings(userDataDir);
 
             const launchPromise = electron.launch({
@@ -219,14 +246,6 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
                     // Headless/CI envs without a real GPU surface — avoid GPU init crashes.
                     '--disable-gpu',
                     '--disable-gpu-sandbox',
-                    // Coverage runs only: keep the webview iframe in the page's
-                    // renderer process so Playwright's page-level V8 coverage
-                    // (`page.coverage`) can see its scripts. With site isolation
-                    // on, the webview is an out-of-process iframe and its
-                    // coverage is never reported. No effect on normal runs.
-                    ...(isCoverageEnabled()
-                        ? ['--disable-site-isolation-trials', '--disable-features=IsolateOrigins,site-per-process']
-                        : []),
                     // Force a new window so the launcher doesn't try to attach to a
                     // running instance (which would fail Playwright's CDP attach).
                     '--new-window',
@@ -244,6 +263,15 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
                     // Without this flag those commands are not registered at all,
                     // so production users running the extension never see them.
                     COSMOSDB_E2E_TEST: '1',
+                    // Replaces the migration assistant's Copilot calls with a
+                    // deterministic offline mock (see
+                    // `src/panels/migration/helpers/e2eMigrationAiMock.ts`) so the
+                    // full migration pipeline can run end-to-end without Copilot.
+                    COSMOSDB_E2E_MIGRATION_AI_MOCK: '1',
+                    // Source directory copied into `<workspace>/.cosmosdb-migration`
+                    // by the `cosmosDB.e2e.openMigration` command so phase-flow
+                    // specs start from a deterministic, pre-seeded project.
+                    COSMOSDB_E2E_MIGRATION_SEED_DIR: path.resolve(here, 'migration-seed'),
                     // Emulator coordinates — read by the `cosmosDB.e2e.*` commands
                     // when building a `NoSqlQueryConnection` so QueryEditor /
                     // Document tabs open against the seeded e2e database. Absent
@@ -340,15 +368,33 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
             // the full rationale.
             await waitForExtensionsActivated(page);
 
-            // A fresh VS Code profile can auto-open the Chat view in the
-            // auxiliary (secondary) side bar, which eats ~30 % of horizontal
-            // space and squeezes the webview under test. Close it once here so
-            // every spec starts with the editor area at full width.
-            await closeAuxiliaryBar(page);
-
             await use(page);
         },
         { scope: 'worker' },
+    ],
+
+    // Test-scoped option: per-test window-layout overrides, merged over
+    // DEFAULT_LAYOUT by the `windowLayout` fixture. `test.use({ layout })`
+    // *replaces* this value (it doesn't deep-merge), so it defaults to `{}`
+    // and the defaults are applied in the fixture — that keeps a partial
+    // override like `{ primarySideBar: false }` additive over the defaults.
+    layout: [{}, { option: true }],
+
+    windowLayout: [
+        async ({ vscodeWindow, layout }, use) => {
+            // Enforce the requested layout on the shared (worker-scoped) window
+            // before the test body runs, so prior tests can't leak chrome state
+            // (an opened side bar / panel) into this one. Merge over the
+            // defaults so a partial override only changes the parts it names.
+            // Best-effort — the helper never throws on a layout tweak.
+            if (!vscodeWindow.isClosed()) {
+                await applyWindowLayout(vscodeWindow, { ...DEFAULT_LAYOUT, ...layout });
+            }
+            await use();
+        },
+        // `auto` so every test gets the layout without opting in; declared
+        // before `windowTrace` so the window has settled before tracing starts.
+        { auto: true },
     ],
 
     windowTrace: [
@@ -410,17 +456,6 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
             } catch {
                 // Best-effort — never fail a test on trace capture/teardown.
             }
-        },
-        { auto: true },
-    ],
-
-    coverage: [
-        async ({ vscodeWindow }, use, testInfo) => {
-            await startCoverage(vscodeWindow);
-
-            await use();
-
-            await stopAndPersistCoverage(vscodeWindow, testInfo);
         },
         { auto: true },
     ],

--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -109,7 +109,8 @@ function seedUserSettings(userDataDir: string): void {
         // unreachable port. Force the client to stay on whichever endpoint
         // the connection points at. Harmless for production single-region
         // accounts; required for any e2e-vs-emulator scenario.
-        'cosmosDB.enableEndpointDiscovery': false, // The dedicated e2e emulator binds to 8082 (not the default 8081);
+        'cosmosDB.enableEndpointDiscovery': false,
+        // The dedicated e2e emulator binds to 8082 (not the default 8081);
         // the migration provisioning step reads this to target the right port.
         'cosmosDB.emulator.port': E2E_EMULATOR_PORT,
     };
@@ -120,14 +121,16 @@ function seedUserSettings(userDataDir: string): void {
 
 /**
  * Monkey-patch Electron's main-process `dialog` module so native
- * save / message dialogs never block the test. Untitled SQL editors,
- * unsaved changes on tab close, etc. would otherwise pop an OS dialog
- * that Playwright cannot interact with.
+ * save / open / message dialogs never block the test. Untitled SQL editors,
+ * unsaved changes on tab close, file pickers (e.g. the Query Editor Open
+ * action), etc. would otherwise pop an OS dialog that Playwright cannot
+ * interact with.
  */
 async function disableNativeDialogs(app: ElectronApplication): Promise<void> {
     await app
         .evaluate(({ dialog }) => {
             dialog.showSaveDialog = () => Promise.resolve({ canceled: true, filePath: '' });
+            dialog.showOpenDialog = () => Promise.resolve({ canceled: true, filePaths: [] });
             dialog.showMessageBoxSync = () => 1; // Typically "Don't Save"
             dialog.showMessageBox = () => Promise.resolve({ response: 1, checkboxChecked: false });
         })
@@ -164,7 +167,7 @@ interface VsCodeTestFixtures {
      *
      * Keys are tri-state — a key you omit keeps its default; the defaults you
      * don't override stay in effect (the fixture merges them in). Applied
-     * before each test body and re-enforced before each window screenshot.
+     * before each test body.
      */
     layout: WindowLayout;
     /**

--- a/test/e2e/fixtures/vscode.ts
+++ b/test/e2e/fixtures/vscode.ts
@@ -49,6 +49,7 @@ import { applyWindowLayout, DEFAULT_LAYOUT, type WindowLayout } from '../helpers
 import { waitForWorkbenchReady } from '../helpers/workbenchReady';
 import { waitForExtensionsActivated } from '../setup/activation';
 import { E2E_EMULATOR_PORT } from '../setup/emulator';
+import { isCoverageEnabled, startCoverage, stopAndPersistCoverage } from './coverage';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..', '..', '..');
@@ -100,6 +101,9 @@ function seedUserSettings(userDataDir: string): void {
         // Chat / secondary sidebar can autopopup on fresh installs and steal
         // 30 % of horizontal space, hiding webview content.
         'workbench.secondarySideBar.visible': false,
+        // Drop the Chat entry from the title-bar command center so a fresh
+        // profile doesn't surface the chat affordance at all.
+        'chat.commandCenter.enabled': false,
         // Silence "do you trust this folder" — we already pass --disable-workspace-trust.
         'security.workspace.trust.enabled': false,
         // Cosmos DB emulator (linux/vnext-preview) advertises its writable
@@ -182,6 +186,11 @@ interface VsCodeTestFixtures {
      * `COSMOSDB_E2E_SCREENSHOT` selects a `trace` mode. See the fixture body.
      */
     windowTrace: void;
+    /**
+     * Auto fixture that captures JS coverage for the VS Code webview window
+     * when `COSMOSDB_E2E_COVERAGE=1` is set.
+     */
+    coverage: void;
 }
 
 export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
@@ -249,6 +258,14 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
                     // Headless/CI envs without a real GPU surface — avoid GPU init crashes.
                     '--disable-gpu',
                     '--disable-gpu-sandbox',
+                    // Coverage runs only: keep the webview iframe in the page's
+                    // renderer process so Playwright's page-level V8 coverage
+                    // (`page.coverage`) can see its scripts. With site isolation
+                    // on, the webview is an out-of-process iframe and its
+                    // coverage is never reported. No effect on normal runs.
+                    ...(isCoverageEnabled()
+                        ? ['--disable-site-isolation-trials', '--disable-features=IsolateOrigins,site-per-process']
+                        : []),
                     // Force a new window so the launcher doesn't try to attach to a
                     // running instance (which would fail Playwright's CDP attach).
                     '--new-window',
@@ -459,6 +476,17 @@ export const test = base.extend<VsCodeTestFixtures, VsCodeFixtures>({
             } catch {
                 // Best-effort — never fail a test on trace capture/teardown.
             }
+        },
+        { auto: true },
+    ],
+
+    coverage: [
+        async ({ vscodeWindow }, use, testInfo) => {
+            await startCoverage(vscodeWindow);
+
+            await use();
+
+            await stopAndPersistCoverage(vscodeWindow, testInfo);
         },
         { auto: true },
     ],

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -23,15 +23,123 @@
  * the webview to be fully populated (React mounted, expected UI present).
  */
 
-import { test, type Frame, type Page } from '@playwright/test';
+import { test, type ElectronApplication, type Frame, type Page } from '@playwright/test';
 import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
-import { reapplyWindowLayout } from '../helpers/windowLayout';
 
 const COMMAND_PALETTE_SHORTCUT = process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P';
 const QUICK_INPUT_SELECTOR = '.quick-input-widget input';
 const TAB_SELECTOR = 'div[role="tab"]';
 const WEBVIEW_FRAME_TIMEOUT_MS = 30_000;
 const WEBVIEW_POLL_INTERVAL_MS = 250;
+
+/**
+ * Maximizes (and enlarges) the VS Code window so webview toolbars render all of
+ * their controls inline instead of collapsing into a Fluent UI "More items"
+ * overflow menu. Several Query Editor specs assert on toolbar buttons directly;
+ * a wide, deterministic window removes overflow-driven flakiness. Best-effort —
+ * never throws.
+ */
+export async function maximizeWindow(app: ElectronApplication): Promise<void> {
+    await app
+        .evaluate(({ BrowserWindow }) => {
+            const [win] = BrowserWindow.getAllWindows();
+            if (!win) {
+                return;
+            }
+            win.setBounds({ x: 0, y: 0, width: 1920, height: 1200 });
+            win.maximize();
+        })
+        .catch(() => {
+            /* No window yet / context torn down — callers tolerate this. */
+        });
+}
+
+/**
+ * Resizes the VS Code window to an explicit width/height (un-maximizing first
+ * if needed). Use this to make the editor area — and therefore a webview's
+ * toolbar — narrow enough to force Fluent UI's `Overflow` to collapse controls
+ * into the "More items" menu. Best-effort — never throws.
+ */
+export async function resizeWindow(app: ElectronApplication, width: number, height: number): Promise<void> {
+    await app
+        .evaluate(
+            ({ BrowserWindow }, bounds) => {
+                const [win] = BrowserWindow.getAllWindows();
+                if (!win) {
+                    return;
+                }
+                if (win.isMaximized()) {
+                    win.unmaximize();
+                }
+                win.setBounds({ x: 0, y: 0, width: bounds.width, height: bounds.height });
+            },
+            { width, height },
+        )
+        .catch(() => {
+            /* No window yet / context torn down — callers tolerate this. */
+        });
+}
+
+/**
+ * Overrides the native Electron message-box (used by VS Code modal
+ * `showWarningMessage`/`showInformationMessage` prompts when the default
+ * `window.dialogStyle: 'native'` is in effect) so a test can deterministically
+ * "click" a specific button without a real, non-interactable OS dialog.
+ *
+ * `buttonLabelPattern` is a case-insensitive RegExp source matched against the
+ * dialog's button labels; the first matching button's index is returned as the
+ * response (falling back to 0 when nothing matches). Restore the fixture's
+ * default with {@link resetNativeDialogStubs} afterwards (the Electron app is
+ * worker-scoped, so the override otherwise leaks into later tests).
+ */
+export async function stubMessageBoxButton(app: ElectronApplication, buttonLabelPattern: string): Promise<void> {
+    await app.evaluate(({ dialog }, pattern) => {
+        const re = new RegExp(pattern, 'i');
+        // VS Code calls dialog.showMessageBox either as (window, options) or
+        // (options); pick whichever argument carries the `buttons` array.
+        dialog.showMessageBox = ((...args: unknown[]) => {
+            const opts = (args.length > 1 ? args[1] : args[0]) as { buttons?: string[] } | undefined;
+            const buttons = opts?.buttons ?? [];
+            const index = buttons.findIndex((label) => re.test(label));
+            return Promise.resolve({ response: index >= 0 ? index : 0, checkboxChecked: false });
+        }) as typeof dialog.showMessageBox;
+    }, buttonLabelPattern);
+}
+
+/**
+ * Restores the native dialog stubs to the fixture defaults (cancel/decline
+ * everything). Mirrors `disableNativeDialogs` in `vscode.ts`; call this in a
+ * test's cleanup after {@link stubMessageBoxButton}.
+ */
+export async function resetNativeDialogStubs(app: ElectronApplication): Promise<void> {
+    await app
+        .evaluate(({ dialog }) => {
+            dialog.showSaveDialog = () => Promise.resolve({ canceled: true, filePath: '' });
+            dialog.showOpenDialog = () => Promise.resolve({ canceled: true, filePaths: [] });
+            dialog.showMessageBoxSync = () => 1;
+            dialog.showMessageBox = () => Promise.resolve({ response: 1, checkboxChecked: false });
+        })
+        .catch(() => {
+            /* Context may be torn down during teardown — tolerate. */
+        });
+}
+
+/**
+ * Closes the auxiliary (secondary) side bar — where a fresh VS Code profile may
+ * auto-open the Chat view. Leaving it open steals horizontal space from the
+ * editor area and squeezes webviews under test. Best-effort — never throws.
+ */
+export async function closeAuxiliaryBar(page: Page): Promise<void> {
+    if (page.isClosed()) {
+        return;
+    }
+    try {
+        await runCommand(page, 'workbench.action.closeAuxiliaryBar');
+    } catch {
+        // The command may be unavailable (older builds) or the bar already
+        // closed — either way there's nothing to clean up.
+    }
+}
 
 /** Frames whose parent is non-null = nested = webview content frames. */
 function getWebviewFrames(page: Page): Frame[] {
@@ -140,11 +248,6 @@ export async function captureWindowScreenshot(page: Page, name = 'vscode-window'
     const failed = info.status !== info.expectedStatus;
     if (!shouldCapture(screenshot, failed)) return;
 
-    // Re-enforce the test's requested window layout. VS Code chrome (notably
-    // the Copilot Chat secondary side bar) can auto-pop *after* the pre-test
-    // layout pass, so without this the final screenshot would show it again.
-    await reapplyWindowLayout(page);
-
     try {
         // Wrap the capture in a named `test.step` so the underlying
         // `Page.screenshot` call surfaces as a labeled action in the trace's
@@ -155,6 +258,48 @@ export async function captureWindowScreenshot(page: Page, name = 'vscode-window'
             const file = info.outputPath(`${name}.png`);
             await page.screenshot({ path: file });
             await info.attach(`${name} (${info.title})`, { path: file, contentType: 'image/png' });
+        });
+    } catch {
+        // Best-effort — never fail a test on screenshot capture.
+    }
+}
+
+/**
+ * Captures a screenshot of the whole VS Code window to a file named after the
+ * current test (plus a `label` such as `loaded` / `final`), attaches it to the
+ * HTML report, and writes it under the per-test results directory.
+ *
+ * Unlike {@link captureWindowScreenshot} (which honours the only-on-failure
+ * default), this fires for *every* test so you can eyeball what each test
+ * actually rendered — useful while building out coverage. It is suppressed only
+ * when `COSMOSDB_E2E_SCREENSHOT=off`. Best-effort: never fails a test.
+ */
+export async function captureNamedScreenshot(page: Page, label: string): Promise<void> {
+    if (page.isClosed()) return;
+
+    let info: ReturnType<typeof test.info>;
+    try {
+        info = test.info();
+    } catch {
+        // Not running inside a test (e.g. called from a non-test context).
+        return;
+    }
+
+    if (resolveCapturePlan().screenshot === 'off') return;
+
+    const slug = (value: string, max: number): string =>
+        value
+            .trim()
+            .replace(/[^a-z0-9-_]+/gi, '-')
+            .replace(/(^-+|-+$)/g, '')
+            .toLowerCase()
+            .slice(0, max) || 'shot';
+
+    try {
+        await test.step(`📸 ${label}`, async () => {
+            const file = info.outputPath(`${slug(info.title, 60)}-${slug(label, 20)}.png`);
+            await page.screenshot({ path: file });
+            await info.attach(`${label} (${info.title})`, { path: file, contentType: 'image/png' });
         });
     } catch {
         // Best-effort — never fail a test on screenshot capture.
@@ -200,4 +345,49 @@ export async function closeAllEditorTabs(page: Page): Promise<void> {
     } catch {
         // Best-effort cleanup — never fail a test on cleanup.
     }
+}
+
+/**
+ * Closes only the *active* editor tab via
+ * `workbench.action.revertAndCloseActiveEditor`, reverting any unsaved changes
+ * so no save prompt blocks the test. Use this to dismiss a Document panel that a
+ * Query Editor drill-in (New / View / Edit item) opened while keeping the Query
+ * Editor tab itself open. Returns once the tab count has dropped (or after a
+ * best-effort timeout).
+ */
+export async function closeActiveEditorTab(page: Page): Promise<void> {
+    if (page.isClosed()) return;
+
+    const before = await page.locator(TAB_SELECTOR).count();
+    if (before === 0) return;
+
+    try {
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(150);
+
+        const input = page.locator(QUICK_INPUT_SELECTOR).first();
+        await page.keyboard.press(COMMAND_PALETTE_SHORTCUT);
+        await input.waitFor({ state: 'visible', timeout: 2_000 });
+        await input.fill('>workbench.action.revertAndCloseActiveEditor');
+        await page.waitForTimeout(150);
+        await page.keyboard.press('Enter');
+
+        // Wait for the tab count to actually drop so callers can rely on the
+        // previous editor regaining focus.
+        for (let attempt = 0; attempt < 20; attempt++) {
+            if ((await page.locator(TAB_SELECTOR).count()) < before) return;
+            await page.waitForTimeout(150);
+        }
+    } catch {
+        // Best-effort — never fail a test on cleanup.
+    }
+}
+
+/**
+ * Counts the open editor tabs in the workbench. Used to assert that an action
+ * (e.g. the Query Editor "Duplicate" control) actually spawned a new tab.
+ */
+export async function countEditorTabs(page: Page): Promise<number> {
+    if (page.isClosed()) return 0;
+    return page.locator(TAB_SELECTOR).count();
 }

--- a/test/e2e/fixtures/webviewHelpers.ts
+++ b/test/e2e/fixtures/webviewHelpers.ts
@@ -23,123 +23,15 @@
  * the webview to be fully populated (React mounted, expected UI present).
  */
 
-import { test, type ElectronApplication, type Frame, type Page } from '@playwright/test';
+import { test, type Frame, type Page } from '@playwright/test';
 import { resolveCapturePlan, shouldCapture } from '../helpers/captureMode';
+import { reapplyWindowLayout } from '../helpers/windowLayout';
 
 const COMMAND_PALETTE_SHORTCUT = process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P';
 const QUICK_INPUT_SELECTOR = '.quick-input-widget input';
 const TAB_SELECTOR = 'div[role="tab"]';
 const WEBVIEW_FRAME_TIMEOUT_MS = 30_000;
 const WEBVIEW_POLL_INTERVAL_MS = 250;
-
-/**
- * Maximizes (and enlarges) the VS Code window so webview toolbars render all of
- * their controls inline instead of collapsing into a Fluent UI "More items"
- * overflow menu. Several Query Editor specs assert on toolbar buttons directly;
- * a wide, deterministic window removes overflow-driven flakiness. Best-effort —
- * never throws.
- */
-export async function maximizeWindow(app: ElectronApplication): Promise<void> {
-    await app
-        .evaluate(({ BrowserWindow }) => {
-            const [win] = BrowserWindow.getAllWindows();
-            if (!win) {
-                return;
-            }
-            win.setBounds({ x: 0, y: 0, width: 1920, height: 1200 });
-            win.maximize();
-        })
-        .catch(() => {
-            /* No window yet / context torn down — callers tolerate this. */
-        });
-}
-
-/**
- * Resizes the VS Code window to an explicit width/height (un-maximizing first
- * if needed). Use this to make the editor area — and therefore a webview's
- * toolbar — narrow enough to force Fluent UI's `Overflow` to collapse controls
- * into the "More items" menu. Best-effort — never throws.
- */
-export async function resizeWindow(app: ElectronApplication, width: number, height: number): Promise<void> {
-    await app
-        .evaluate(
-            ({ BrowserWindow }, bounds) => {
-                const [win] = BrowserWindow.getAllWindows();
-                if (!win) {
-                    return;
-                }
-                if (win.isMaximized()) {
-                    win.unmaximize();
-                }
-                win.setBounds({ x: 0, y: 0, width: bounds.width, height: bounds.height });
-            },
-            { width, height },
-        )
-        .catch(() => {
-            /* No window yet / context torn down — callers tolerate this. */
-        });
-}
-
-/**
- * Overrides the native Electron message-box (used by VS Code modal
- * `showWarningMessage`/`showInformationMessage` prompts when the default
- * `window.dialogStyle: 'native'` is in effect) so a test can deterministically
- * "click" a specific button without a real, non-interactable OS dialog.
- *
- * `buttonLabelPattern` is a case-insensitive RegExp source matched against the
- * dialog's button labels; the first matching button's index is returned as the
- * response (falling back to 0 when nothing matches). Restore the fixture's
- * default with {@link resetNativeDialogStubs} afterwards (the Electron app is
- * worker-scoped, so the override otherwise leaks into later tests).
- */
-export async function stubMessageBoxButton(app: ElectronApplication, buttonLabelPattern: string): Promise<void> {
-    await app.evaluate(({ dialog }, pattern) => {
-        const re = new RegExp(pattern, 'i');
-        // VS Code calls dialog.showMessageBox either as (window, options) or
-        // (options); pick whichever argument carries the `buttons` array.
-        dialog.showMessageBox = ((...args: unknown[]) => {
-            const opts = (args.length > 1 ? args[1] : args[0]) as { buttons?: string[] } | undefined;
-            const buttons = opts?.buttons ?? [];
-            const index = buttons.findIndex((label) => re.test(label));
-            return Promise.resolve({ response: index >= 0 ? index : 0, checkboxChecked: false });
-        }) as typeof dialog.showMessageBox;
-    }, buttonLabelPattern);
-}
-
-/**
- * Restores the native dialog stubs to the fixture defaults (cancel/decline
- * everything). Mirrors `disableNativeDialogs` in `vscode.ts`; call this in a
- * test's cleanup after {@link stubMessageBoxButton}.
- */
-export async function resetNativeDialogStubs(app: ElectronApplication): Promise<void> {
-    await app
-        .evaluate(({ dialog }) => {
-            dialog.showSaveDialog = () => Promise.resolve({ canceled: true, filePath: '' });
-            dialog.showOpenDialog = () => Promise.resolve({ canceled: true, filePaths: [] });
-            dialog.showMessageBoxSync = () => 1;
-            dialog.showMessageBox = () => Promise.resolve({ response: 1, checkboxChecked: false });
-        })
-        .catch(() => {
-            /* Context may be torn down during teardown — tolerate. */
-        });
-}
-
-/**
- * Closes the auxiliary (secondary) side bar — where a fresh VS Code profile may
- * auto-open the Chat view. Leaving it open steals horizontal space from the
- * editor area and squeezes webviews under test. Best-effort — never throws.
- */
-export async function closeAuxiliaryBar(page: Page): Promise<void> {
-    if (page.isClosed()) {
-        return;
-    }
-    try {
-        await runCommand(page, 'workbench.action.closeAuxiliaryBar');
-    } catch {
-        // The command may be unavailable (older builds) or the bar already
-        // closed — either way there's nothing to clean up.
-    }
-}
 
 /** Frames whose parent is non-null = nested = webview content frames. */
 function getWebviewFrames(page: Page): Frame[] {
@@ -248,6 +140,11 @@ export async function captureWindowScreenshot(page: Page, name = 'vscode-window'
     const failed = info.status !== info.expectedStatus;
     if (!shouldCapture(screenshot, failed)) return;
 
+    // Re-enforce the test's requested window layout. VS Code chrome (notably
+    // the Copilot Chat secondary side bar) can auto-pop *after* the pre-test
+    // layout pass, so without this the final screenshot would show it again.
+    await reapplyWindowLayout(page);
+
     try {
         // Wrap the capture in a named `test.step` so the underlying
         // `Page.screenshot` call surfaces as a labeled action in the trace's
@@ -258,48 +155,6 @@ export async function captureWindowScreenshot(page: Page, name = 'vscode-window'
             const file = info.outputPath(`${name}.png`);
             await page.screenshot({ path: file });
             await info.attach(`${name} (${info.title})`, { path: file, contentType: 'image/png' });
-        });
-    } catch {
-        // Best-effort — never fail a test on screenshot capture.
-    }
-}
-
-/**
- * Captures a screenshot of the whole VS Code window to a file named after the
- * current test (plus a `label` such as `loaded` / `final`), attaches it to the
- * HTML report, and writes it under the per-test results directory.
- *
- * Unlike {@link captureWindowScreenshot} (which honours the only-on-failure
- * default), this fires for *every* test so you can eyeball what each test
- * actually rendered — useful while building out coverage. It is suppressed only
- * when `COSMOSDB_E2E_SCREENSHOT=off`. Best-effort: never fails a test.
- */
-export async function captureNamedScreenshot(page: Page, label: string): Promise<void> {
-    if (page.isClosed()) return;
-
-    let info: ReturnType<typeof test.info>;
-    try {
-        info = test.info();
-    } catch {
-        // Not running inside a test (e.g. called from a non-test context).
-        return;
-    }
-
-    if (resolveCapturePlan().screenshot === 'off') return;
-
-    const slug = (value: string, max: number): string =>
-        value
-            .trim()
-            .replace(/[^a-z0-9-_]+/gi, '-')
-            .replace(/(^-+|-+$)/g, '')
-            .toLowerCase()
-            .slice(0, max) || 'shot';
-
-    try {
-        await test.step(`📸 ${label}`, async () => {
-            const file = info.outputPath(`${slug(info.title, 60)}-${slug(label, 20)}.png`);
-            await page.screenshot({ path: file });
-            await info.attach(`${label} (${info.title})`, { path: file, contentType: 'image/png' });
         });
     } catch {
         // Best-effort — never fail a test on screenshot capture.
@@ -345,49 +200,4 @@ export async function closeAllEditorTabs(page: Page): Promise<void> {
     } catch {
         // Best-effort cleanup — never fail a test on cleanup.
     }
-}
-
-/**
- * Closes only the *active* editor tab via
- * `workbench.action.revertAndCloseActiveEditor`, reverting any unsaved changes
- * so no save prompt blocks the test. Use this to dismiss a Document panel that a
- * Query Editor drill-in (New / View / Edit item) opened while keeping the Query
- * Editor tab itself open. Returns once the tab count has dropped (or after a
- * best-effort timeout).
- */
-export async function closeActiveEditorTab(page: Page): Promise<void> {
-    if (page.isClosed()) return;
-
-    const before = await page.locator(TAB_SELECTOR).count();
-    if (before === 0) return;
-
-    try {
-        await page.keyboard.press('Escape');
-        await page.waitForTimeout(150);
-
-        const input = page.locator(QUICK_INPUT_SELECTOR).first();
-        await page.keyboard.press(COMMAND_PALETTE_SHORTCUT);
-        await input.waitFor({ state: 'visible', timeout: 2_000 });
-        await input.fill('>workbench.action.revertAndCloseActiveEditor');
-        await page.waitForTimeout(150);
-        await page.keyboard.press('Enter');
-
-        // Wait for the tab count to actually drop so callers can rely on the
-        // previous editor regaining focus.
-        for (let attempt = 0; attempt < 20; attempt++) {
-            if ((await page.locator(TAB_SELECTOR).count()) < before) return;
-            await page.waitForTimeout(150);
-        }
-    } catch {
-        // Best-effort — never fail a test on cleanup.
-    }
-}
-
-/**
- * Counts the open editor tabs in the workbench. Used to assert that an action
- * (e.g. the Query Editor "Duplicate" control) actually spawned a new tab.
- */
-export async function countEditorTabs(page: Page): Promise<number> {
-    if (page.isClosed()) return 0;
-    return page.locator(TAB_SELECTOR).count();
 }

--- a/test/e2e/fixtures/webviews.ts
+++ b/test/e2e/fixtures/webviews.ts
@@ -56,6 +56,30 @@ export async function openMigrationAssistant(page: Page): Promise<Frame> {
 }
 
 /**
+ * Opens the Migration Assistant against a deterministic, pre-seeded project
+ * via the `cosmosDB.e2e.openMigration` test-only command. The seed (consent
+ * granted, application analysis populated, schema files present) lets phase-flow
+ * specs drive Discovery → Assessment → Conversion without the native file
+ * pickers. The migration AI layer is mocked (see
+ * `src/panels/migration/helpers/e2eMigrationAiMock.ts`), so the phases run
+ * offline and deterministically.
+ */
+export async function openMigrationSeeded(page: Page): Promise<Frame> {
+    await runCommand(page, 'Cosmos DB: [E2E Test] Open Seeded Migration Assistant');
+    return getWebviewByPredicate(page, REACT_ROOT_RENDERED);
+}
+
+/**
+ * Opens the Migration Assistant against a fresh, empty project via the
+ * `cosmosDB.e2e.openMigrationFresh` test-only command. Use to assert the
+ * initial disabled-control state (no consent, no analysis).
+ */
+export async function openMigrationFresh(page: Page): Promise<Frame> {
+    await runCommand(page, 'Cosmos DB: [E2E Test] Open Empty Migration Assistant');
+    return getWebviewByPredicate(page, REACT_ROOT_RENDERED);
+}
+
+/**
  * Opens the Query Editor panel and returns its content frame. Uses the
  * `cosmosDB.e2e.openQueryEditor` test-only command, which calls
  * `QueryEditorTab.render(connection)` directly.

--- a/test/e2e/helpers/windowLayout.ts
+++ b/test/e2e/helpers/windowLayout.ts
@@ -165,15 +165,3 @@ export async function applyWindowLayout(page: Page, layout: WindowLayout): Promi
         await ensurePartVisibility(page, PARTS[key], desired);
     }
 }
-
-/**
- * Re-enforce the layout last applied to `page` via {@link applyWindowLayout}.
- * No-op when no layout has been recorded for the window. Used right before a
- * screenshot to undo any chrome (e.g. Copilot Chat) that auto-popped mid-test.
- */
-export async function reapplyWindowLayout(page: Page): Promise<void> {
-    const layout = appliedLayouts.get(page);
-    if (layout) {
-        await applyWindowLayout(page, layout);
-    }
-}

--- a/test/e2e/helpers/windowLayout.ts
+++ b/test/e2e/helpers/windowLayout.ts
@@ -99,14 +99,6 @@ const PARTS: Record<keyof WindowLayout, PartDescriptor> = {
 const VISIBILITY_SETTLE_TIMEOUT_MS = 2_000;
 
 /**
- * Remembers the layout last requested for a given window so it can be
- * re-enforced just before a screenshot — VS Code chrome (notably the Copilot
- * Chat secondary side bar) can auto-pop *after* the pre-test layout pass, and
- * the window screenshot is captured at the end of the test.
- */
-const appliedLayouts = new WeakMap<Page, WindowLayout>();
-
-/**
  * Ensure a single part matches `desired` visibility. No-op when it already
  * does. Best-effort: a missing command or selector never fails the test.
  */
@@ -123,7 +115,13 @@ async function ensurePartVisibility(page: Page, part: PartDescriptor, desired: b
 
     if (current === desired) return;
 
-    await runCommand(page, part.toggleCommandTitle);
+    try {
+        await runCommand(page, part.toggleCommandTitle);
+    } catch {
+        // The command palette / quick input can be transiently unavailable.
+        // A layout tweak must never fail the test (best-effort contract).
+        return;
+    }
 
     // Wait for the part to reach the desired state so callers (and the
     // subsequent screenshot) observe a settled layout. Best-effort: tolerate
@@ -154,8 +152,6 @@ async function ensurePartVisibility(page: Page, part: PartDescriptor, desired: b
  */
 export async function applyWindowLayout(page: Page, layout: WindowLayout): Promise<void> {
     if (page.isClosed()) return;
-
-    appliedLayouts.set(page, { ...appliedLayouts.get(page), ...layout });
 
     for (const key of Object.keys(PARTS) as (keyof WindowLayout)[]) {
         const desired = layout[key];

--- a/test/e2e/helpers/windowLayout.ts
+++ b/test/e2e/helpers/windowLayout.ts
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Declarative control over which VS Code "chrome" parts are visible during an
+ * e2e test — the primary side bar, the secondary side bar (where GitHub
+ * Copilot Chat lives), and the bottom panel.
+ *
+ * Why this exists
+ * ---------------
+ * VS Code is **worker-scoped** in this suite (one launch reused across every
+ * test — see `fixtures/vscode.ts`), and the worker activation handshake opens
+ * the Azure side bar. On a fresh install the Copilot Chat secondary side bar
+ * can also auto-pop. Both steal horizontal space and clutter the window
+ * screenshots we attach for webview tests.
+ *
+ * `seedUserSettings()` already sets `workbench.secondarySideBar.visible: false`
+ * as a first line of defense, but settings are applied once at launch and don't
+ * give a per-test override. This helper closes that gap: it enforces a desired
+ * layout at runtime, per test, and is exposed both as the auto-applied `layout`
+ * Playwright option (see `fixtures/vscode.ts`) and as a direct function a spec
+ * can call inline.
+ *
+ * How it works
+ * ------------
+ * For each part the caller cares about, we read the part's current visibility
+ * from the workbench DOM and only issue the corresponding "toggle" command
+ * (via the command palette) when the current state differs from the desired
+ * one. That keeps the operation idempotent despite the shared, reused window —
+ * re-applying the same layout across tests is a no-op.
+ */
+
+import { type Page } from '@playwright/test';
+import { runCommand } from '../fixtures/webviewHelpers';
+
+/**
+ * Desired visibility of the configurable VS Code chrome parts.
+ *
+ * Each key is **tri-state**:
+ *   - `undefined` — leave the part as-is (don't touch it)
+ *   - `true`      — ensure the part is visible
+ *   - `false`     — ensure the part is hidden
+ *
+ * This makes overrides additive: a test can flip a single part without having
+ * to restate the rest of {@link DEFAULT_LAYOUT}.
+ */
+export interface WindowLayout {
+    /** The primary (left) side bar — Explorer / Azure tree, etc. */
+    primarySideBar?: boolean;
+    /** The secondary (right) side bar — where GitHub Copilot Chat docks. */
+    secondarySideBar?: boolean;
+    /** The bottom panel — Terminal / Problems / Output, etc. */
+    panel?: boolean;
+}
+
+/**
+ * Default layout applied to every test that doesn't override it: hide the
+ * Copilot Chat secondary side bar and the bottom panel so webview screenshots
+ * are clean. The primary side bar is intentionally left untouched (the worker
+ * activation handshake opens it, and tree-dependent specs rely on it).
+ */
+export const DEFAULT_LAYOUT: WindowLayout = {
+    secondarySideBar: false,
+    panel: false,
+};
+
+interface PartDescriptor {
+    /** Workbench DOM selector for the part container. */
+    selector: string;
+    /** Command palette title of the visibility-toggle command (English UI). */
+    toggleCommandTitle: string;
+}
+
+/**
+ * The three configurable parts, keyed by {@link WindowLayout} field.
+ *
+ * Selectors target the stable `.part.*` workbench containers. Toggle command
+ * titles match the English command palette labels — consistent with the rest
+ * of the suite, which already drives the palette by English title (e.g.
+ * `View: Show Azure`).
+ */
+const PARTS: Record<keyof WindowLayout, PartDescriptor> = {
+    primarySideBar: {
+        selector: '.monaco-workbench .part.sidebar',
+        toggleCommandTitle: 'View: Toggle Primary Side Bar Visibility',
+    },
+    secondarySideBar: {
+        selector: '.monaco-workbench .part.auxiliarybar',
+        toggleCommandTitle: 'View: Toggle Secondary Side Bar Visibility',
+    },
+    panel: {
+        selector: '.monaco-workbench .part.panel',
+        toggleCommandTitle: 'View: Toggle Panel Visibility',
+    },
+};
+
+const VISIBILITY_SETTLE_TIMEOUT_MS = 2_000;
+
+/**
+ * Remembers the layout last requested for a given window so it can be
+ * re-enforced just before a screenshot — VS Code chrome (notably the Copilot
+ * Chat secondary side bar) can auto-pop *after* the pre-test layout pass, and
+ * the window screenshot is captured at the end of the test.
+ */
+const appliedLayouts = new WeakMap<Page, WindowLayout>();
+
+/**
+ * Ensure a single part matches `desired` visibility. No-op when it already
+ * does. Best-effort: a missing command or selector never fails the test.
+ */
+async function ensurePartVisibility(page: Page, part: PartDescriptor, desired: boolean): Promise<void> {
+    const locator = page.locator(part.selector).first();
+
+    let current: boolean;
+    try {
+        current = await locator.isVisible();
+    } catch {
+        // Selector lookup failed (workbench not ready / part absent) — skip.
+        return;
+    }
+
+    if (current === desired) return;
+
+    await runCommand(page, part.toggleCommandTitle);
+
+    // Wait for the part to reach the desired state so callers (and the
+    // subsequent screenshot) observe a settled layout. Best-effort: tolerate
+    // the wait timing out rather than failing the test on a layout tweak.
+    try {
+        await locator.waitFor({
+            state: desired ? 'visible' : 'hidden',
+            timeout: VISIBILITY_SETTLE_TIMEOUT_MS,
+        });
+    } catch {
+        /* The toggle was issued; don't fail a test on a layout settle wait. */
+    }
+}
+
+/**
+ * Apply a {@link WindowLayout} to the given VS Code window.
+ *
+ * Only keys present in `layout` are touched; `undefined` keys are left as-is.
+ * Parts are processed one at a time (the command palette is a shared, modal
+ * surface, so concurrent palette use would race).
+ *
+ * Safe to call repeatedly — it diffs against the live DOM and issues a toggle
+ * only when needed, so re-applying the same layout is a no-op.
+ *
+ * @example
+ *   // Inline, from within a test:
+ *   await applyWindowLayout(vscodeWindow, { primarySideBar: false });
+ */
+export async function applyWindowLayout(page: Page, layout: WindowLayout): Promise<void> {
+    if (page.isClosed()) return;
+
+    appliedLayouts.set(page, { ...appliedLayouts.get(page), ...layout });
+
+    for (const key of Object.keys(PARTS) as (keyof WindowLayout)[]) {
+        const desired = layout[key];
+        if (desired === undefined) continue;
+        // Sequential by design — see the doc comment.
+        // oxlint-disable-next-line no-await-in-loop
+        await ensurePartVisibility(page, PARTS[key], desired);
+    }
+}
+
+/**
+ * Re-enforce the layout last applied to `page` via {@link applyWindowLayout}.
+ * No-op when no layout has been recorded for the window. Used right before a
+ * screenshot to undo any chrome (e.g. Copilot Chat) that auto-popped mid-test.
+ */
+export async function reapplyWindowLayout(page: Page): Promise<void> {
+    const layout = appliedLayouts.get(page);
+    if (layout) {
+        await applyWindowLayout(page, layout);
+    }
+}

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -1,0 +1,401 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * E2E coverage for the Migration Assistant webview.
+ *
+ * Layers:
+ *   1. Structural / render — the panel mounts and all four phase sections and
+ *      the model dropdown render.
+ *   2. Non-AI interactions — toggling consent and the initial disabled-control
+ *      state on a fresh project (no AI involved).
+ *   3. Loaded-project state — a deterministic pre-seeded project hydrates with
+ *      consent granted, the model populated, and Discovery enabled.
+ *   4. Full AI phase flows — Discovery → Assessment → Conversion driven to
+ *      completion against the offline migration AI mock
+ *      (`src/panels/migration/helpers/e2eMigrationAiMock.ts`).
+ *
+ * The seeded/AI flows rely on the `cosmosDB.e2e.openMigration*` test-only
+ * commands and the `COSMOSDB_E2E_MIGRATION_AI_MOCK` env flag, both wired up by
+ * the Playwright fixture in `test/e2e/fixtures/vscode.ts`.
+ */
+
+import {
+    clearMockControl,
+    gitDirExists,
+    MigrationPage,
+    PHASE_HEADERS,
+    provisioningArtifactExists,
+    readCapturedPrompts,
+    readEmulatorItems,
+    readGitignore,
+    readMigrationArtifact,
+    readMigrationJson,
+    readSampleData,
+    setMockControl,
+    writeCodeMigrationPlan,
+} from '../fixtures/migration';
+import { expect, test } from '../fixtures/vscode';
+import { closeAllEditorTabs } from '../fixtures/webviewHelpers';
+import { openMigrationFresh, openMigrationSeeded } from '../fixtures/webviews';
+
+test.describe('Migration Assistant', () => {
+    // Worker-scoped VS Code is reused across tests; reset editor state so panels
+    // from one test don't leak into the next. The e2e open commands also reset
+    // the on-disk `.cosmosdb-migration` folder, keeping each test hermetic.
+    test.afterEach(async ({ vscodeWindow }) => {
+        clearMockControl();
+        await closeAllEditorTabs(vscodeWindow);
+    });
+
+    test('renders all phase sections and the model dropdown', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await expect(migration.root).toBeVisible();
+        for (const label of Object.values(PHASE_HEADERS)) {
+            await expect(migration.phaseHeader(label)).toBeVisible();
+        }
+        await expect(migration.modelDropdown).toBeVisible();
+    });
+
+    test('exclude-from-VCS checkbox toggles the .gitignore entry', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        // Seeded scenario is git-tracked (`.git` seeded), no warning, exclude renders.
+        expect(gitDirExists()).toBe(true);
+        await expect(migration.gitInitButton).toHaveCount(0);
+        await expect(migration.gitignoreExclude).toBeVisible({ timeout: 15_000 });
+        await expect(migration.gitignoreExclude).not.toBeChecked();
+        expect(readGitignore()).not.toContain('.cosmosdb-migration');
+
+        // Exclude → entry written; un-exclude → entry removed.
+        await migration.gitignoreExclude.click();
+        await expect(migration.gitignoreExclude).toBeChecked();
+        await expect.poll(() => readGitignore(), { timeout: 10_000 }).toContain('.cosmosdb-migration');
+        await migration.gitignoreExclude.click();
+        await expect(migration.gitignoreExclude).not.toBeChecked();
+        await expect.poll(() => readGitignore(), { timeout: 10_000 }).not.toContain('.cosmosdb-migration');
+    });
+
+    test('no version control hides the exclude control and shows the warning', async ({ vscodeWindow }) => {
+        const frame = await openMigrationFresh(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await expect(migration.gitInitButton).toBeVisible();
+        await expect(migration.gitignoreExclude).toHaveCount(0);
+    });
+
+    test('fresh project surfaces the Git-init warning', async ({ vscodeWindow }) => {
+        const frame = await openMigrationFresh(vscodeWindow);
+        const migration = new MigrationPage(frame);
+        await expect(migration.gitInitButton).toBeVisible();
+    });
+
+    test('seeded project hydrates with consent and Discovery enabled', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await expect(migration.consentCheckbox).toBeChecked();
+        await expect(migration.modelDropdown).toContainText('E2E Mock Model');
+        await expect(migration.runDiscoveryButton()).toBeEnabled();
+    });
+
+    test('fresh project starts with Discovery disabled and no consent', async ({ vscodeWindow }) => {
+        const frame = await openMigrationFresh(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await expect(migration.consentCheckbox).not.toBeChecked();
+        await expect(migration.runDiscoveryButton()).toBeDisabled();
+    });
+
+    test('toggling consent updates the checkbox state', async ({ vscodeWindow }) => {
+        const frame = await openMigrationFresh(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await expect(migration.consentCheckbox).not.toBeChecked();
+        await migration.consentCheckbox.click();
+        await expect(migration.consentCheckbox).toBeChecked();
+    });
+
+    test('AI-consent checkbox gates Auto-Detect and Discovery', async ({ vscodeWindow }) => {
+        const frame = await openMigrationFresh(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        // Without consent both AI entry points are locked.
+        await expect(migration.consentCheckbox).not.toBeChecked();
+        await expect(migration.autoDetectButton).toBeDisabled();
+        await expect(migration.runDiscoveryButton()).toBeDisabled();
+
+        // Consent unlocks Auto-Detect; re-uncheck re-locks it.
+        await migration.consentCheckbox.click();
+        await expect(migration.autoDetectButton).toBeEnabled();
+        await migration.consentCheckbox.click();
+        await expect(migration.autoDetectButton).toBeDisabled();
+    });
+
+    test('Auto-Detect populates application details (AI mocked)', async ({ vscodeWindow }) => {
+        const frame = await openMigrationFresh(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.consentCheckbox.click();
+        await migration.autoDetectButton.click();
+        // Mock returns the canned ApplicationDetails — assert every field is filled.
+        await expect(migration.analysisField('project-name')).toHaveValue('Contoso Sales', { timeout: 30_000 });
+        await expect(migration.analysisField('project-type')).toHaveValue('Web API');
+        await expect(migration.analysisField('language')).toHaveValue('C#');
+        await expect(migration.analysisField('frameworks')).toHaveValue('ASP.NET Core, Entity Framework');
+        await expect(migration.analysisField('database')).toHaveValue('SQL Server');
+        await expect(migration.analysisField('access')).toHaveValue('Entity Framework');
+    });
+
+    test('phase instructions reach the AI prompt', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        const marker = `e2e-marker-${Date.now()}`;
+        await migration.instructions('discovery').fill(`Focus on the ${marker} domain.`);
+        await migration.runDiscovery();
+
+        // The mock captures every prompt; the typed instruction must appear.
+        await expect
+            .poll(() => readCapturedPrompts().some((p) => p.promptText.includes(marker)), { timeout: 15_000 })
+            .toBe(true);
+    });
+
+    test('Discovery shows progress + cancel, then completes', async ({ vscodeWindow }) => {
+        setMockControl({ delayMs: 3000 });
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.runDiscoveryButton().click();
+        await expect(migration.progressBar).toBeVisible();
+        await expect(migration.cancelButton).toBeVisible();
+        await expect(migration.phaseCompleteBadge('phase1')).toBeVisible({ timeout: 30_000 });
+    });
+
+    test('Cancel aborts Discovery without completing', async ({ vscodeWindow }) => {
+        setMockControl({ delayMs: 20_000 });
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.runDiscoveryButton().click();
+        await expect(migration.cancelButton).toBeVisible();
+        await migration.cancelButton.click();
+        await expect(migration.cancelButton).toHaveCount(0);
+        await expect(migration.runDiscoveryButton()).toBeEnabled();
+    });
+
+    test('Discovery surfaces an error when the model fails', async ({ vscodeWindow }) => {
+        setMockControl({ failRoutes: ['step2-discovery'] });
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.runDiscoveryButton().click();
+        await expect(migration.errorAlert).toBeVisible({ timeout: 30_000 });
+        await expect(migration.phaseCompleteBadge('phase1')).toHaveCount(0);
+    });
+
+    test('View Discovery Report opens discovery-report.md', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.runDiscovery();
+        await expect(migration.viewDiscoveryButton).toBeVisible();
+        await migration.viewDiscoveryButton.click();
+        await expect(migration.openedTab(/discovery-report\.md/)).toBeVisible({ timeout: 15_000 });
+    });
+
+    test('Phase 2 domain and summary links open their markdown', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.runDiscovery();
+        await migration.runAssessment();
+        await migration.phase2DomainLinks().first().click();
+        await expect(migration.openedTab(/SalesDomain\.md/)).toBeVisible({ timeout: 15_000 });
+        await migration.focus();
+        await migration.phase2SummaryButton.click();
+        await expect(migration.openedTab(/summary\.md/)).toBeVisible({ timeout: 15_000 });
+    });
+
+    test('surfaces domain, summary, and schema-model artifacts with links', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        // Phase 2: domains listed in a table, each linking to its summary,
+        // plus a link to the full assessment summary.
+        await migration.runDiscovery();
+        await migration.runAssessment();
+        await expect(migration.phase2DomainTable).toBeVisible();
+        await expect(migration.phase2DomainLinks()).toHaveCount(1);
+        await expect(migration.phase2DomainLinks().first()).toHaveText('SalesDomain');
+        await expect(migration.phase2SummaryButton).toBeVisible();
+
+        // Phase 3: converted domains with per-domain summary + JSON model links,
+        // plus the merged summary/model artifact buttons.
+        await migration.runConversion();
+        await expect(migration.phase3DomainTable).toBeVisible();
+        await expect(migration.phase3DomainLinks()).toHaveCount(1);
+        await expect(migration.phase3DomainLinks().first()).toHaveText('SalesDomain');
+        await expect(migration.phase3ModelLinks().first()).toHaveText('JSON');
+        await expect(migration.phase3SummaryButton).toBeVisible();
+        await expect(migration.phase3ModelButton).toBeVisible();
+
+        // Links must open their exact artifacts: the per-domain JSON link opens
+        // that domain's cosmos-model.json, while the merged-model button opens the
+        // top-level model.json — distinct files, so the tab names must differ.
+        await migration.phase3ModelLinks().first().click();
+        await expect(migration.openedTab(/cosmos-model\.json/)).toBeVisible({ timeout: 15_000 });
+        await migration.focus();
+        await migration.phase3ModelButton.click();
+        await expect(migration.openedTab(/^model\.json$/)).toBeVisible({ timeout: 15_000 });
+    });
+
+    test('drives Discovery → Assessment → Conversion to completion (AI mocked)', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.runDiscovery();
+        await migration.runAssessment();
+        await migration.runConversion();
+
+        await expect(migration.phaseCompleteBadge('phase1')).toBeVisible();
+        await expect(migration.phaseCompleteBadge('phase2')).toBeVisible();
+        await expect(migration.phaseCompleteBadge('phase3')).toBeVisible();
+
+        // Beyond the completion badges, assert the on-disk artifacts each phase
+        // produced carry the deterministic content from the mocked AI. This
+        // guards against a phase "completing" while writing empty/garbled files.
+
+        // Phase 1 — discovery-report.md (mock markdown, preamble stripped).
+        const discoveryReport = readMigrationArtifact('phases/1-discovery/discovery-report.md');
+        expect(discoveryReport).toContain('# Discovery Report');
+        expect(discoveryReport).toContain('Orders, OrderDetails');
+        expect(discoveryReport).toContain('R001-GetOrdersByCustomer');
+
+        // Phase 2 — assessment-summary.md plus the per-domain markdown.
+        const assessmentSummary = readMigrationArtifact('phases/2-assessment/assessment-summary.md');
+        expect(assessmentSummary).toContain('SalesDomain');
+        expect(assessmentSummary).toContain('Orders, OrderDetails');
+
+        const domainMarkdown = readMigrationArtifact('phases/2-assessment/domains/SalesDomain.md');
+        expect(domainMarkdown).toContain('# Domain: SalesDomain');
+        expect(domainMarkdown).toContain('Aggregate Root: Orders');
+        expect(domainMarkdown).toContain('R001-GetOrdersByCustomer');
+
+        // Phase 3 — the merged model.json must describe the single `orders`
+        // container partitioned by `/customerId` with the `order` doc type.
+        const model = readMigrationJson<{
+            containers: { name: string; partitionKeys?: { path: string }[]; entities: { docType: string }[] }[];
+        }>('phases/3-schema-conversion/model.json');
+        expect(model?.containers).toHaveLength(1);
+        expect(model?.containers[0].name).toBe('orders');
+        expect(model?.containers[0].partitionKeys?.[0]?.path).toBe('/customerId');
+        expect(model?.containers[0].entities[0].docType).toBe('order');
+
+        // Phase 3 — summary.md narrates the same container/partition decision.
+        const conversionSummary = readMigrationArtifact('phases/3-schema-conversion/summary.md');
+        expect(conversionSummary).toContain('Schema Conversion Summary');
+        expect(conversionSummary).toContain('orders');
+        expect(conversionSummary).toContain('/customerId');
+    });
+
+    test('Phase 4 provisions the emulator with the exact sample data (AI mocked)', async ({ vscodeWindow }) => {
+        // Requires a live emulator (8082) — skip on pure-webview runs.
+        test.skip(process.env.COSMOSDB_E2E_SKIP_EMULATOR === '1', 'needs the e2e Cosmos DB emulator');
+
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        // Phase 4 provisioning consumes model.json, so drive 1→3 first.
+        await migration.runDiscovery();
+        await migration.runAssessment();
+        await migration.runConversion();
+
+        // Target the local emulator, verify the connection.
+        await migration.expandPhase(PHASE_HEADERS.phase4);
+        await migration.emulatorRadio.click();
+        await migration.testConnectionButton.click();
+        await expect(migration.connectionVerified).toBeVisible({ timeout: 30_000 });
+
+        // Populate sample data: creates DB + containers and inserts mock items.
+        await expect(migration.populateSampleDataButton).toBeEnabled();
+        await migration.populateSampleDataButton.click();
+        await expect(migration.provisioningSummary).toBeVisible({ timeout: 60_000 });
+        await expect(migration.phaseCompleteBadge('phase4')).toBeVisible();
+
+        // Summary reports the database + the single `orders` container.
+        await expect(migration.provisioningSummary).toContainText('E2E Migration');
+        await expect(migration.provisioningSummary).toContainText('orders');
+
+        // Artifacts written to phases/4-provisioning/.
+        await expect.poll(() => provisioningArtifactExists('sample-data.json'), { timeout: 10_000 }).toBe(true);
+        await expect.poll(() => provisioningArtifactExists('seed-data.csh'), { timeout: 10_000 }).toBe(true);
+
+        // sample-data.json holds exactly the mocked items.
+        const sample = readSampleData();
+        expect(sample?.sampleData).toEqual([
+            {
+                containerName: 'orders',
+                items: [
+                    { id: 'order-1', customerId: 'c1', total: 100, docType: 'order' },
+                    { id: 'order-2', customerId: 'c2', total: 250, docType: 'order' },
+                ],
+            },
+        ]);
+
+        // The emulator was actually provisioned with those exact two documents.
+        const items = await readEmulatorItems('E2E Migration', 'orders');
+        expect(items).toEqual([
+            { id: 'order-1', customerId: 'c1', total: 100, docType: 'order' },
+            { id: 'order-2', customerId: 'c2', total: 250, docType: 'order' },
+        ]);
+    });
+
+    test('Plan Migration is gated on phase completion, then flips to Start once the plan exists', async ({
+        vscodeWindow,
+    }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        // Phase 4 is not required (IS_PHASE4_REQUIRED === false), so the action
+        // gates on Discovery → Assessment → Conversion only. Until those run the
+        // primary action stays disabled and reads "Plan Migration".
+        await expect(migration.migrationActionButton).toContainText('Plan Migration');
+        await expect(migration.migrationActionButton).toBeDisabled();
+        await expect(migration.viewPlanLink).toHaveCount(0);
+
+        await migration.runDiscovery();
+        // Still gated while Assessment + Conversion remain incomplete.
+        await migration.focus();
+        await expect(migration.migrationActionButton).toBeDisabled();
+
+        await migration.runAssessment();
+        await migration.focus();
+        await expect(migration.migrationActionButton).toBeDisabled();
+
+        await migration.runConversion();
+        await migration.focus();
+
+        // All required phases complete → the action enables (still "Plan Migration").
+        await expect(migration.migrationActionButton).toBeEnabled();
+        await expect(migration.migrationActionButton).toContainText('Plan Migration');
+
+        // Click "Plan Migration" (opens Copilot Chat with the generated prompt —
+        // a no-op for plan creation in the mocked e2e run), then simulate Chat
+        // writing the plan to disk. The file watcher flips hasCodeMigrationPlan.
+        await migration.migrationActionButton.click();
+        await migration.focus();
+        writeCodeMigrationPlan();
+
+        // The plan now exists: "View Plan" appears and the primary action
+        // auto-switches from "Plan Migration" to "Start Migration".
+        await expect(migration.viewPlanLink).toBeVisible({ timeout: 15_000 });
+        await expect(migration.migrationActionButton).toContainText('Start Migration');
+        await expect(migration.migrationActionButton).toBeEnabled();
+    });
+});

--- a/test/e2e/specs/smoke.spec.ts
+++ b/test/e2e/specs/smoke.spec.ts
@@ -22,6 +22,12 @@ import { openDocument, openMigrationAssistant, openQueryEditor } from '../fixtur
  * round-trips) belongs in dedicated specs that build on these fixtures.
  */
 test.describe('webview smoke', () => {
+    // These tests only care about the webview iframe, so hide all the VS Code
+    // chrome that competes for space in the attached screenshots. The Copilot
+    // Chat secondary side bar and bottom panel are hidden by default; also drop
+    // the primary side bar (Azure tree) here since no test below touches it.
+    test.use({ layout: { primarySideBar: false } });
+
     // Worker-scoped vscodeApp/Window fixtures mean VS Code is reused across
     // tests. Each test must reset editor state itself or panels from one test
     // leak into the next.


### PR DESCRIPTION
## Summary

Adds end-to-end (Playwright) test coverage for the **Migration Assistant** (relational → Azure Cosmos DB NoSQL), driven entirely offline against a deterministic AI mock. The suite exercises the full top-to-bottom UI: configuration, version control, consent/model, Application Details / Auto-Detect, and migration phases 1–4, plus the final Plan → Start footer action.

All AI/Copilot calls are replaced by a canned, deterministic mock so the entire pipeline runs without Copilot and without network access. The mock is gated behind two env flags (`COSMOSDB_E2E_TEST=1` + `COSMOSDB_E2E_MIGRATION_AI_MOCK=1`) and is a **no-op in normal sessions**.

## What's covered

The suite (`test/e2e/specs/migration.spec.ts`, 19 tests) is ordered to mirror the UI from top to bottom:

- **Structure** — all phase sections + model dropdown render.
- **Version control** — `.gitignore` exclude toggle writes/removes the entry; no-VCS hides the control and shows the Git-init warning.
- **AI model / consent** — seeded project hydrates with consent + model; consent gates Auto-Detect and Discovery.
- **Application Details** — Auto-Detect populates every analysis field from the mock.
- **Phase 1 (Discovery)** — instructions reach the prompt; progress + cancel; cancel aborts; error surfacing; View Discovery Report opens the artifact.
- **Phase 2 (Assessment)** — domain table + summary links open their markdown.
- **Phase 3 (Schema Conversion)** — per-domain + merged model/summary links open the correct artifacts.
- **Phases 1–3 content validation** — beyond completion badges, the on-disk artifacts are read and asserted (discovery report, assessment summary + per-domain markdown, `model.json` structure, conversion summary) so a phase can't "complete" while writing empty/garbled files.
- **Phase 4 (Provisioning)** — provisions the live e2e emulator, asserts the **exact** generated `sample-data.json` and the **exact documents actually written to the emulator**, plus provisioning artifacts.
- **Footer** — `Plan Migration` is gated until required phases complete, then flips to `Start Migration` once a code migration plan exists.

## Test infrastructure

- `e2eMigrationAiMock.ts` — deterministic `LanguageModelChat` mock with a per-step route map covering every phase.
- Seed fixtures (`migration-seed/`) for a hermetic, pre-consented project.
- `windowLayout.ts` helper + fixture wiring (worker-scoped VS Code, per-worker workspace + capture dirs, emulator port).
- Test-only `cosmosDB.e2e.openMigration` / `cosmosDB.e2e.openMigrationFresh` commands (registered in `package.json`, visible only under `cosmosDB.e2eTestMode`) to open the assistant seeded/fresh. The dedicated e2e emulator (ports 8082/1235) and its scripts already exist on `main` and are reused as-is.

## Product changes (driven/discovered by the new tests)

1. **Plan → Start auto-switch (UX fix).** Previously the footer action stayed on `Plan Migration` even after a migration plan had been generated, so there was no clear affordance to proceed. The button now auto-advances to `Start Migration` on the false→true transition of "plan exists" (persisted, and still allowing re-planning from the dropdown). _(`MigrationAssistant.tsx`)_

2. **Deterministic git-status hydration + repo detection (UX fix).** The version-control controls (the exclude-from-VCS checkbox / Git-init warning) could fail to hydrate: the webview registers its channel listeners while mounting, which can race the early `checkGitRepository` response and drop it. Git status is now re-emitted once the project has loaded. Additionally, git-repo detection falls back to a filesystem `.git` check when the Git extension hasn't indexed a just-initialized repo yet. _(`MigrationAssistantTab.ts`)_

3. **Deterministic debug-config / step routing.** `createMkDebug` now always returns a `DebugPromptConfig` carrying `stepName`, with a separate `dumpEnabled` flag, instead of returning `undefined` when debug dumps are off. This makes the step id available at runtime (used to route the mock and, in production, keeps dump behavior identical). _(`debugPromptHelpers.ts`, `aiHelpers.ts`, `phase3SchemaConversion.ts`, `phase4Provisioning.ts`)_

4. **Test-only AI availability/model gating.** `getAvailableModelsInfo` and `areCopilotModelsAvailable` short-circuit to a single deterministic fake model when the e2e mock flags are set, so the model dropdown populates and `isAIFeaturesEnabled` is true under mock. Strictly gated; no effect on normal sessions. _(`aiUtils.ts`, `copilotUtils.ts`, `aiHelpers.ts`)_

5. **Stable test hooks.** Added `data-testid`s to the migration action button and View Plan link.

## Validation

- `tsc --noEmit` (main + vitest + test projects) and `tsc -p tsconfig.e2e.json` — clean.
- `oxlint` + `eslint` — clean.
- Full migration e2e suite: **19/19 passing** against the dockerized e2e emulator.

## Notes

- No new user-facing strings beyond reused existing labels (no `l10n` changes required).
- The production AI mock paths are unreachable unless both `COSMOSDB_E2E_TEST` and `COSMOSDB_E2E_MIGRATION_AI_MOCK` are set.
