### PR TITLE
fix(migration): correlate DDL extractor telemetry with session & source DB

### DIFF
--- a/src/panels/migration/helpers/migrationTelemetry.ts
+++ b/src/panels/migration/helpers/migrationTelemetry.ts
@@ -208,6 +208,13 @@ export function enrichErrorContext(context: IActionContext, error: unknown): voi
  * event) and accumulates phase-level rollups on the optional phase context for
  * dashboards/alerts that prefer one record per phase.
  *
+ * When a `phaseContext` is supplied, the shared migration dimensions it already
+ * carries (`sessionId`, `phase`, `sourceDbType`, `migrationMode`) are inherited
+ * onto the per-call event so extractor stats can be sliced by source database
+ * type / mode and correlated to a session. Those values are stamped upstream by
+ * {@link setMigrationTelemetryContext} and are all telemetry-safe (an in-memory
+ * session GUID and bounded enums).
+ *
  * No file contents, paths, or names are emitted — only structural counts.
  */
 export function reportDdlExtractorStats(
@@ -217,6 +224,18 @@ export function reportDdlExtractorStats(
     phaseContext?: IActionContext,
 ): void {
     callContext.telemetry.properties.encoding = encoding;
+
+    // Inherit the shared migration dimensions from the surrounding phase so this
+    // per-file event can be grouped by source DB type / mode and joined by session.
+    // Explicit allow-list only — never copy the whole property bag.
+    if (phaseContext) {
+        for (const key of ['sessionId', 'phase', 'sourceDbType', 'migrationMode'] as const) {
+            const value = phaseContext.telemetry.properties[key];
+            if (value !== undefined) {
+                callContext.telemetry.properties[key] = value;
+            }
+        }
+    }
 
     const m = callContext.telemetry.measurements;
     m.inputChars = stats.inputChars;


### PR DESCRIPTION
## What

The `cosmosDB.migration.ddlExtractor.extract` telemetry event currently emits only structural counts plus `encoding`. It carries **no** `sessionId`, `phase`, `sourceDbType`, or `migrationMode`, so extractor-quality dashboards cannot break the stats down by source database type / migration mode, nor join them back to a session.

This change makes `reportDdlExtractorStats` **inherit** those four dimensions from the surrounding phase context (passed in as `phaseContext`) onto the per-file event:

```ts
if (phaseContext) {
    for (const key of ['sessionId', 'phase', 'sourceDbType', 'migrationMode'] as const) {
        const value = phaseContext.telemetry.properties[key];
        if (value !== undefined) {
            callContext.telemetry.properties[key] = value;
        }
    }
}
```

## Why this approach

- **Zero churn / low risk.** Every `createToolExecutor` caller already passes the phase `IActionContext`, which is stamped with these fields by `setMigrationTelemetryContext` at phase start. No signature or caller changes are needed — the values already exist and are just propagated.
- **Telemetry-safe by construction.** Per the repo telemetry guidelines: `sessionId` is an in-memory GUID, and `sourceDbType` / `migrationMode` / `phase` are bounded enums. An **explicit allow-list** is used so no other (potentially OII/PII) property-bag entries are ever copied.

## Impact

Once released, the "DDL Extractor Quality" dashboard tile can group **exactly** by `sourceDbType` / `migrationMode` (today it can only approximate via a lossy `VSCodeSessionId` join), and extract events become session-joinable. Only affects telemetry emitted after the release.

## Testing

- `oxfmt`, `oxlint`, and `eslint` pass on the changed file.
- No user-facing strings changed (no l10n update needed).