### PR TITLE
feat(migration): default migration flag by release channel

### DIFF
--- a/src/commands/migration/migrationFeatureFlag.test.ts
+++ b/src/commands/migration/migrationFeatureFlag.test.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type Mock } from 'vitest';
+import * as vscode from 'vscode';
+import {
+    getMigrationFeatureDefaultEnabled,
+    isMigrationFeatureEnabled,
+    isPreReleaseBuild,
+    MIGRATION_ENABLED_SETTING_KEY,
+    MIGRATION_ENABLED_SETTING_SECTION,
+} from './migrationFeatureFlag';
+
+vi.mock('vscode', () => ({
+    extensions: {
+        getExtension: vi.fn(),
+    },
+    workspace: {
+        getConfiguration: vi.fn(),
+    },
+}));
+
+describe('migrationFeatureFlag', () => {
+    let mockGetExtension: Mock;
+    let mockGetSetting: Mock;
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+
+        mockGetExtension = vi.fn();
+        mockGetSetting = vi.fn();
+
+        vi.spyOn(vscode.extensions, 'getExtension').mockImplementation(mockGetExtension);
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+            get: mockGetSetting,
+        } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    describe('isPreReleaseBuild', () => {
+        it('returns true when extension package metadata marks preview=true', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: true } });
+
+            expect(isPreReleaseBuild()).toBe(true);
+        });
+
+        it('returns false when extension package metadata marks preview=false', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: false } });
+
+            expect(isPreReleaseBuild()).toBe(false);
+        });
+
+        it('returns false when extension metadata is unavailable', () => {
+            mockGetExtension.mockReturnValue(undefined);
+
+            expect(isPreReleaseBuild()).toBe(false);
+        });
+    });
+
+    describe('getMigrationFeatureDefaultEnabled', () => {
+        it('defaults to enabled for pre-release builds', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: true } });
+
+            expect(getMigrationFeatureDefaultEnabled()).toBe(true);
+        });
+
+        it('defaults to disabled for stable builds', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: false } });
+
+            expect(getMigrationFeatureDefaultEnabled()).toBe(false);
+        });
+    });
+
+    describe('isMigrationFeatureEnabled', () => {
+        it('passes pre-release default=true when reading the setting', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: true } });
+            mockGetSetting.mockReturnValue(true);
+
+            expect(isMigrationFeatureEnabled()).toBe(true);
+            expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith(MIGRATION_ENABLED_SETTING_SECTION);
+            expect(mockGetSetting).toHaveBeenCalledWith(MIGRATION_ENABLED_SETTING_KEY, true);
+        });
+
+        it('passes stable default=false when reading the setting', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: false } });
+            mockGetSetting.mockReturnValue(false);
+
+            expect(isMigrationFeatureEnabled()).toBe(false);
+            expect(mockGetSetting).toHaveBeenCalledWith(MIGRATION_ENABLED_SETTING_KEY, false);
+        });
+
+        it('honors explicit user override=true on stable builds', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: false } });
+            mockGetSetting.mockReturnValue(true);
+
+            expect(isMigrationFeatureEnabled()).toBe(true);
+        });
+
+        it('honors explicit user override=false on pre-release builds', () => {
+            mockGetExtension.mockReturnValue({ packageJSON: { preview: true } });
+            mockGetSetting.mockReturnValue(false);
+
+            expect(isMigrationFeatureEnabled()).toBe(false);
+        });
+
+        it('falls back to stable-safe default=false when metadata is unavailable and setting is unset', () => {
+            mockGetExtension.mockReturnValue(undefined);
+            mockGetSetting.mockReturnValue(undefined);
+
+            expect(isMigrationFeatureEnabled()).toBe(false);
+            expect(mockGetSetting).toHaveBeenCalledWith(MIGRATION_ENABLED_SETTING_KEY, false);
+        });
+    });
+});

--- a/src/commands/migration/migrationFeatureFlag.ts
+++ b/src/commands/migration/migrationFeatureFlag.ts
@@ -13,6 +13,8 @@ import * as vscode from 'vscode';
 export const MIGRATION_ENABLED_SETTING_SECTION = 'cosmosDB';
 export const MIGRATION_ENABLED_SETTING_KEY = 'experimental.migration.enabled';
 
+const EXTENSION_ID = 'ms-azuretools.vscode-cosmosdb';
+
 /**
  * Context key mirrored from {@link MIGRATION_ENABLED_SETTING_KEY}. Used by `when` clauses in
  * package.json to show/hide the migration commands and menu entries.
@@ -20,14 +22,45 @@ export const MIGRATION_ENABLED_SETTING_KEY = 'experimental.migration.enabled';
 export const MIGRATION_ENABLED_CONTEXT_KEY = 'cosmosDB.migration.enabled';
 
 /**
+ * Returns whether this extension is running as a pre-release build.
+ *
+ * Reads the `preview` marker from this extension's package metadata. If metadata
+ * is unavailable (for example in some test harnesses), defaults to `false` so
+ * migration remains opt-in.
+ */
+export function isPreReleaseBuild(): boolean {
+    const extension = vscode.extensions.getExtension(EXTENSION_ID);
+    if (!extension) {
+        return false;
+    }
+
+    const packageJson = extension.packageJSON as { preview?: unknown } | undefined;
+    return packageJson?.preview === true;
+}
+
+/**
+ * Default state for the migration feature when the user has not explicitly
+ * configured `cosmosDB.experimental.migration.enabled`.
+ *
+ * - Pre-release builds: enabled by default.
+ * - Stable builds: disabled by default.
+ */
+export function getMigrationFeatureDefaultEnabled(): boolean {
+    return isPreReleaseBuild();
+}
+
+/**
  * Returns whether the experimental Cosmos DB Migration (Preview) feature is enabled.
- * Defaults to `true` when the setting is unset.
+ * Defaults by release channel when the setting is unset:
+ * - pre-release builds default to `true`
+ * - stable builds default to `false`
  */
 export function isMigrationFeatureEnabled(): boolean {
+    const defaultEnabled = getMigrationFeatureDefaultEnabled();
     return (
         vscode.workspace
             .getConfiguration(MIGRATION_ENABLED_SETTING_SECTION)
-            .get<boolean>(MIGRATION_ENABLED_SETTING_KEY, true) ?? true
+            .get<boolean>(MIGRATION_ENABLED_SETTING_KEY, defaultEnabled) ?? defaultEnabled
     );
 }
 


### PR DESCRIPTION
## Summary
- make cosmosDB.experimental.migration.enabled default from extension release channel
- pre-release builds with package.json preview=true default to enabled
- stable builds default to disabled
- preserve explicit user setting overrides

## Implementation
- add isPreReleaseBuild() and getMigrationFeatureDefaultEnabled() in migration feature flag helper
- update isMigrationFeatureEnabled() to use release-aware default when setting is unset
- add unit tests for pre-release/stable defaults, explicit overrides, and metadata-unavailable fallback

## Validation
- npm run l10n
- npm run prettier-fix
- npm run lint
- targeted unit tests for migrationFeatureFlag
