### PR TITLE
chore: prepare 0.35.2 (Preview) release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Change Log
 
+## 0.35.2 (Preview)
+
+### Added
+
+- Added support for the official [Microsoft Fabric extension](https://marketplace.visualstudio.com/items?itemName=fabric.vscode-fabric), letting this extension act as its satellite. Cosmos DB in Fabric commands and experiences (via new tree node providers) now light up directly inside the Fabric workspace view. (#2921)
+- Added **schema generation from queries** in the NoSQL Query Editor, backed by a new `SchemaService` that provides schema simplification, cascade deletion, and telemetry. (#3074, #3079)
+- Added **Priority Level** support in the Query Editor, allowing requests to be issued with a low or high priority. (#3063)
+- Added a NoSQL diagnostic that detects and reports **`ORDER BY` used inside a subquery**, which is not supported. (#3148)
+
+### Fixed
+
+- Simplified the hotkey mechanism and fixed **Edit / View / Delete** actions on selected rows in the results grid. (#3168)
+- Improved error handling when generating a query with **NL2Query**. (#3078)
+- Guarded Fabric provider registration and dropped an abandoned activation call. (#3161)
+- Corrected several **Learn Microsoft** documentation URLs. (#3153, #3162)
+- Fixed the telemetry property name used for feedback direction in the Query Editor. (#3127)
+- Added explicit IDs to wizard steps to prevent mangled telemetry. (#3086)
+
+### Changed
+
+- The **Migration Assistant** is now gated behind a feature flag and clearly labeled as **Preview**. (#3176)
+- Refactored the **Azure Cosmos DB Shell** integration into split modules with centralized constants and added tests. (#3077)
+- Extracted the webview **tRPC** communication layer into dedicated packages. (#3121)
+- Removed the legacy LLM instructions deployment logic. (#3126)
+- Unified the `nosql-language-service` provider APIs and documented their options. (#3114)
+- Aligned the NoSQL query-generation prompt with the language service and removed legacy language-reference injection. (#3072)
+- Enhanced telemetry tracking and data privacy in the migration process, including correlating DDL extractor telemetry with the session and source database and stamping a baseline run index. (#3087, #3182, #3183)
+- Documented the `LOG`/`LOG10` zero-argument limitation in NoSQL. (#3149)
+- Expanded automated testing: migrated tests to **Vitest**, added **Playwright** end-to-end suites (Query Editor, webviews, relational-migration), enabled React component unit tests, and added a reusable Language Model mock and NL2Query quality test runner. (#3136, #3170, #3172, #3174, #3181, #3116, #3146, #3147, #3151)
+- Improved CI reliability by splitting the build and test workflows to run in parallel, tuning CodeQL configuration, and removing disabled workflows. (#3150, #3158, #3160)
+- Made Monaco workers load correctly in the dev server. (#3169)
+- Updated localization.
+- Updated several dependencies to address vulnerabilities.
+
 ## 0.35.0 (Preview)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cosmosdb",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cosmosdb",
-      "version": "0.35.1",
+      "version": "0.35.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-cosmosdb",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "preview": true,
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "publisher": "ms-azuretools",


### PR DESCRIPTION
## Summary

Prepares the **0.35.2 (Preview)** release:

- Bumps the extension version from `0.35.1` to `0.35.2` in `package.json` / `package-lock.json`.
- Adds a comprehensive `CHANGELOG.md` entry summarizing all changes since the `v0.35.1` tag.

## Changelog highlights

**Added**
- Support for the official [Microsoft Fabric extension](https://marketplace.visualstudio.com/items?itemName=fabric.vscode-fabric) — this extension now acts as its satellite, surfacing Cosmos DB in Fabric commands and experiences inside the Fabric workspace view. (#2921)
- Schema generation from queries in the Query Editor, backed by a new `SchemaService`. (#3074, #3079)
- Query Editor Priority Level support. (#3063)
- NoSQL diagnostic for `ORDER BY` used inside a subquery. (#3148)

**Fixed**
- Hotkey mechanism simplification and Edit/View/Delete on selected rows. (#3168)
- NL2Query generate-query error handling. (#3078)
- Fabric provider registration guard. (#3161)
- Learn Microsoft URLs and Query Editor feedback telemetry naming. (#3153, #3162, #3127, #3086)

**Changed**
- Migration Assistant gated behind a feature flag and labeled Preview. (#3176)
- Cosmos DB Shell and webview tRPC refactors. (#3077, #3121)
- Migration telemetry/privacy improvements. (#3087, #3182, #3183)
- Expanded Vitest/Playwright test coverage, CI workflow split, localization, and dependency updates.

## Notes

- `prettier-fix`/`lint` could not be run locally due to a sandboxed npm registry (Prettier not installed); the changelog Markdown follows existing formatting conventions.