### PR TITLE
Feat: add Preview to NL2Query

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -448,6 +448,7 @@
   "From TOP 50": "From TOP 50",
   "From TOP 500": "From TOP 500",
   "From Workspace Connections": "From Workspace Connections",
+  "Generate": "Generate",
   "Generate a comprehensive discovery report using AI analysis of your schema, access patterns, and application details.": "Generate a comprehensive discovery report using AI analysis of your schema, access patterns, and application details.",
   "Generate Discovery Report": "Generate Discovery Report",
   "Generate query": "Generate query",

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/AIButton.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/AIButton.tsx
@@ -65,10 +65,12 @@ export const AIButton = ({ ref, type }: ToolbarOverflowItemProps<HTMLButtonEleme
             <MenuTrigger disableButtonEnhancement>
                 {type === 'button' ? (
                     <MenuButton ref={ref} appearance="subtle" icon={aiIcon}>
-                        {l10n.t('AI')}
+                        {l10n.t('AI')} {l10n.t('(Preview)')}
                     </MenuButton>
                 ) : (
-                    <MenuItem icon={aiIcon}>{l10n.t('AI')}</MenuItem>
+                    <MenuItem icon={aiIcon}>
+                        {l10n.t('AI')} {l10n.t('(Preview)')}
+                    </MenuItem>
                 )}
             </MenuTrigger>
             <MenuPopover>

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
@@ -634,7 +634,7 @@ export const GenerateQueryInput = () => {
                         color="informative"
                         className={styles.previewBadge}
                         tabIndex={0}
-                        aria-label={l10n.t('Preview')}
+                        aria-label={l10n.t('Preview: features and behavior may change. Use with care.')}
                     >
                         <span aria-hidden="true">{l10n.t('Preview')}</span>
                     </Badge>

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
@@ -203,9 +203,14 @@ const useStyles = makeStyles({
             },
         },
     },
+    submitSection: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        flexShrink: 0,
+    },
     button: {
-        padding: '0px',
-        width: '24px',
+        padding: '0px 10px',
         height: '24px',
         flexShrink: 0,
         borderRadius: '6px',
@@ -794,16 +799,20 @@ export const GenerateQueryInput = () => {
                                 </div>
                             )}
                         </div>
-                        <Button
-                            className={styles.button}
-                            icon={isLoading ? <RecordStopFilled /> : <SendFilled />}
-                            onClick={isLoading ? handleCancel : () => void handleSend()}
-                            disabled={!isLoading && !input.trim()}
-                            title={isLoading ? l10n.t('Cancel generation') : l10n.t('Generate query')}
-                            aria-label={isLoading ? l10n.t('Cancel generation') : l10n.t('Generate query')}
-                            appearance={isLoading ? 'transparent' : 'primary'}
-                            size="small"
-                        />
+                        <div className={styles.submitSection}>
+                            <Button
+                                className={styles.button}
+                                icon={isLoading ? <RecordStopFilled /> : <SendFilled />}
+                                onClick={isLoading ? handleCancel : () => void handleSend()}
+                                disabled={!isLoading && !input.trim()}
+                                title={isLoading ? l10n.t('Cancel generation') : l10n.t('Generate query')}
+                                aria-label={isLoading ? l10n.t('Cancel generation') : l10n.t('Generate query')}
+                                appearance={isLoading ? 'transparent' : 'primary'}
+                                size="small"
+                            >
+                                {isLoading ? l10n.t('Cancel') : l10n.t('Generate')}
+                            </Button>
+                        </div>
                     </div>
                 )}
             </div>

--- a/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/QueryPanel/GenerateQueryInput.tsx
@@ -5,11 +5,13 @@
 
 import { useTrpcClient } from '@cosmosdb/webview-rpc/react';
 import {
+    Badge,
     Button,
     Combobox,
     MessageBar,
     MessageBarBody,
     Option,
+    Tooltip,
     createCustomFocusIndicatorStyle,
     makeStyles,
     mergeClasses,
@@ -261,6 +263,18 @@ const useStyles = makeStyles({
             },
             { customizeSelector: (s) => `${s}${s}` },
         ) as Record<string, unknown>),
+    },
+    previewBadge: {
+        // Sits just to the left of the close (X) button in the top-right corner.
+        position: 'absolute',
+        top: '4px',
+        right: '24px',
+        zIndex: 1,
+        cursor: 'default',
+        ':focus-visible': {
+            outline: '1px solid var(--vscode-focusBorder)',
+            outlineOffset: '1px',
+        },
     },
     confirmBanner: {
         display: 'flex',
@@ -606,6 +620,20 @@ export const GenerateQueryInput = () => {
         <div ref={containerRef} className={mergeClasses(styles.container, isFocused && styles.containerFocused)}>
             {isLoading && containerSize && <ProgressBorder width={containerSize.width} height={containerSize.height} />}
             <div className={styles.innerContent}>
+                <Tooltip
+                    content={l10n.t('Preview: features and behavior may change. Use with care.')}
+                    relationship="description"
+                >
+                    <Badge
+                        appearance="outline"
+                        color="informative"
+                        className={styles.previewBadge}
+                        tabIndex={0}
+                        aria-label={l10n.t('Preview')}
+                    >
+                        <span aria-hidden="true">{l10n.t('Preview')}</span>
+                    </Badge>
+                </Tooltip>
                 <Button
                     className={styles.closeButton}
                     icon={<Dismiss12Regular />}

--- a/test/e2e/specs/generate-query-input.spec.ts
+++ b/test/e2e/specs/generate-query-input.spec.ts
@@ -76,7 +76,7 @@ async function showGenerateQueryInput(webview: Frame): Promise<undefined> {
     const toolbar = webview.getByRole('toolbar').first();
     await toolbar.waitFor({ state: 'visible', timeout: 30_000 });
 
-    const aiButton = toolbar.getByRole('button', { name: 'AI', exact: true }).first();
+    const aiButton = toolbar.getByRole('button', { name: 'AI (Preview)', exact: true }).first();
     await expect.poll(() => aiButton.isVisible().catch(() => false), { timeout: 30_000 }).toBe(true);
     await aiButton.click();
 

--- a/test/e2e/specs/query-editor-toolbar.spec.ts
+++ b/test/e2e/specs/query-editor-toolbar.spec.ts
@@ -110,7 +110,7 @@ test.describe('query editor toolbar', () => {
         const webview = await openQueryEditor(vscodeWindow);
         await expect(webview.locator('#root')).toBeVisible();
 
-        await openToolbarMenu(webview, { toolbarName: 'AI', overflowText: 'AI' });
+        await openToolbarMenu(webview, { toolbarName: 'AI (Preview)', overflowText: 'AI (Preview)' });
 
         await expect(webview.getByRole('menuitem', { name: 'Generate query', exact: true })).toBeVisible();
         await expect(webview.getByRole('menuitem', { name: 'Explain query', exact: true })).toBeVisible();


### PR DESCRIPTION
Add "Preview" to "AI" dropdown button label and `GenerateQueryInput` component.
Add "Generate" label to the submit button of the `GenerateQueryInput` component to make it more prominent and discoverable.