### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     groups:
       github-actions:
-        patterns: ["*"]
+        patterns: ['*']
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     cooldown:
       default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,10 @@ jobs:
        !startsWith(github.head_ref, 'dev/'))
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 📦 Using Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -222,7 +222,7 @@ jobs:
       - name: 📤 Upload VSIX
         id: upload-vsix
         if: ${{ !cancelled() && steps.verify-vsix.outcome == 'success' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.verify-vsix.outputs.artifact_name }}
           path: ${{ steps.verify-vsix.outputs.vsix_file }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,10 +86,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 📦 Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -125,7 +125,7 @@ jobs:
 
       - name: 📤 Upload Playwright HTML report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-html-report-${{ github.run_attempt }}
           # Per-run report lives at test/e2e/.reports/<runId>/html/ (runId is random per
@@ -148,7 +148,7 @@ jobs:
         # log clean on fully green runs where Playwright wrote nothing here.
         # `include-hidden-files: true` is required because the directory is `.results/`.
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-results-${{ github.run_attempt }}
           path: test/e2e/.results/**
@@ -165,7 +165,7 @@ jobs:
 
       - name: 📤 Upload emulator logs artifact
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-emulator-logs-${{ github.run_attempt }}
           path: emulator-logs

--- a/.github/workflows/nosql-language-service.yml
+++ b/.github/workflows/nosql-language-service.yml
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -140,7 +140,7 @@ jobs:
         # most useful for triage. `if-no-files-found: warn` keeps the run green if vitest
         # crashed before writing the file (very rare).
         if: ${{ !cancelled() && steps.nosql-tests.outcome != 'skipped' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nosql-junit-report-${{ github.run_attempt }}
           path: packages/nosql-language-service/junit.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,10 +57,10 @@ jobs:
        !startsWith(github.head_ref, 'dev/'))
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 📦 Using Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -80,7 +80,7 @@ jobs:
           ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' &&
           (github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: actions/upload-code-coverage@v1
+        uses: actions/upload-code-coverage@82c7aee3fb2ad768e00b00a0a8d749c5815085b6 # v1
         with:
           file: coverage/cobertura-coverage.xml
           language: TypeScript
@@ -90,7 +90,7 @@ jobs:
         id: upload-coverage
         # Upload the HTML coverage report so it's downloadable from the run. Skip when unit tests never ran.
         if: ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage/


### PR DESCRIPTION
Re-applies the changes from #3199 onto a branch in this repository so CI runs with the proper permissions (the original PR came from a fork).

Pins all GitHub Actions to full-length commit SHAs and adds a Dependabot config to keep them updated weekly.

Cherry-picked from #3199 (original author: @OssSecurityBot).