### PR TITLE
fix(migration): improve screen reader and keyboard accessibility

### DIFF
--- a/.github/skills/accessibility-aria-expert/SKILL.md
+++ b/.github/skills/accessibility-aria-expert/SKILL.md
@@ -33,6 +33,32 @@ Tooltips require `aria-label` + `aria-hidden` to avoid double announcements:
 - `aria-hidden="true"`: Wraps visible text to prevent duplication
 - Screen reader hears: "Badge text. Detailed explanation"
 
+## Required Accessible-Name Audit
+
+For every interactive element with visible text, compare the rendered text with its computed accessible name. Check all
+sources that can override descendant text, including `aria-label`, `aria-labelledby`, `title`, and Fluent UI tooltips with
+`relationship="label"`.
+
+- The computed accessible name must contain the exact localized visible text. Additional context may follow or precede it.
+- Prefer visible descendant text as the native accessible name. For a simple flat-text description, use `aria-description` so
+  the visible label remains the name without adding hidden DOM content. Use `aria-describedby` when the description already
+  exists in the DOM, is shared by multiple controls, contains meaningful structure, or compatibility requirements demand it.
+  Add `aria-label` only when the accessible name itself needs clarification, and include the exact visible label when doing so.
+- When adding context, derive both strings from the same localized visible-label variable. Do not translate the visible and
+  accessible labels independently because translations can drift.
+- Remember that `aria-label` overrides descendant text. Seeing the visible label inside the component does not mean it is
+  included in the accessibility tree.
+- Review existing accessible-name attributes when modifying a control, even when the change does not add or alter ARIA.
+
+For user-facing controls covered by Playwright, assert both the rendered label and computed accessible name:
+
+```tsx
+const moreLabel = page.getByRole('button', { name: /^More/ });
+await expect(moreLabel).toHaveText('More…');
+await expect(moreLabel).toHaveAccessibleName(/^More…/);
+await expect(moreLabel).toHaveAccessibleDescription('Show full description');
+```
+
 ## Detection Rules
 
 ### 1. Tooltip Without aria-label Context
@@ -305,7 +331,7 @@ import { Announcer } from '../../api/webview-client/accessibility';
 - [ ] Tooltip content included in `aria-label`
 - [ ] Visible text wrapped in `aria-hidden="true"` when aria-label duplicates it
 - [ ] Redundant aria-labels removed (identical to visible text)
-- [ ] Visible button labels match accessible name exactly (for voice control)
+- [ ] Accessible names contain the exact localized visible label (for voice control)
 - [ ] Decorative elements have `aria-hidden={true}`
 - [ ] Badges with tooltips use `focusableBadge` class + `tabIndex={0}`
 - [ ] Status updates use `Announcer` component

--- a/.github/skills/accessibility-aria-expert/SKILL.md
+++ b/.github/skills/accessibility-aria-expert/SKILL.md
@@ -59,6 +59,41 @@ await expect(moreLabel).toHaveAccessibleName(/^More…/);
 await expect(moreLabel).toHaveAccessibleDescription('Show full description');
 ```
 
+## Avoid Hidden-Text Scroll Regressions
+
+Do not add an absolutely positioned screen-reader-only element just to name a nearby semantic element, especially inside a
+scrollable table, grid, list, or panel. VoiceOver may move the virtual cursor to the hidden element's layout box and scroll the
+visible content out of view.
+
+Prefer setting the accessible name or description on a rendered element with useful on-screen bounds. For text controls, this is
+usually the semantic element itself. For an icon or symbol inside a table cell, use a visible inline wrapper as the named
+accessibility node and keep the visual-only child hidden from assistive technology:
+
+```tsx
+// ❌ VoiceOver may scroll to the hidden span when navigating the cell.
+<td>
+  <span className={styles.srOnly}>{l10n.t('Yes')}</span>
+  <CheckmarkCircleFilled />
+</td>
+
+// ❌ The value is announced, but VoiceOver's visual focus indicator may disappear from the rendered symbol.
+<td aria-label={l10n.t('Yes')}>
+  <CheckmarkCircleFilled aria-hidden={true} />
+</td>
+
+// ✅ The accessibility node uses the visible symbol's bounds; there is no off-screen layout box to reveal.
+<td>
+  <span role="img" aria-label={l10n.t('Yes')} style={{ display: 'inline-flex' }}>
+    <CheckmarkCircleFilled aria-hidden={true} />
+  </span>
+</td>
+```
+
+Use hidden DOM text only when the semantic relationship cannot be expressed directly. When it is necessary, use an established
+shared utility, anchor it to an appropriate containing block, and manually navigate the control with VoiceOver or NVDA to verify
+that focus and the virtual cursor do not scroll the visible content away or lose the visual focus indicator. Playwright
+accessible-name assertions do not detect these screen-reader-driven visual regressions.
+
 ## Detection Rules
 
 ### 1. Tooltip Without aria-label Context
@@ -332,6 +367,7 @@ import { Announcer } from '../../api/webview-client/accessibility';
 - [ ] Visible text wrapped in `aria-hidden="true"` when aria-label duplicates it
 - [ ] Redundant aria-labels removed (identical to visible text)
 - [ ] Accessible names contain the exact localized visible label (for voice control)
+- [ ] VoiceOver/NVDA navigation neither scrolls visible content away nor loses its visual focus indicator
 - [ ] Decorative elements have `aria-hidden={true}`
 - [ ] Badges with tooltips use `focusableBadge` class + `tabIndex={0}`
 - [ ] Status updates use `Announcer` component

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -300,6 +300,7 @@
   "Database name is missing in artifact connection info": "Database name is missing in artifact connection info",
   "Database name is required.": "Database name is required.",
   "Database schema files help": "Database schema files help",
+  "Database Schema Files, required": "Database Schema Files, required",
   "Database Schema Files:": "Database Schema Files:",
   "Database:": "Database:",
   "Databases": "Databases",

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -57,7 +57,7 @@ import {
     WarningRegular,
 } from '@fluentui/react-icons';
 import * as l10n from '@vscode/l10n';
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react';
 import { type MigrationAppRouter } from '../../../panels/trpc/appRouter';
 import { sanitizeCosmosDBAccountName, validateCosmosDBAccountName } from '../../../utils/cosmosDBAccountName';
 import { formatTokenCount, partitionModelsByCapability } from '../../../utils/modelUtils';
@@ -658,6 +658,7 @@ function ReferencedInCodeStatus({ isMapped }: { isMapped: boolean }): React.Reac
 
 function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
     const styles = useStyles();
+    const analysisLabelId = useId();
     const state = useMigrationState();
     const dispatch = useMigrationDispatch();
 
@@ -1094,13 +1095,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                     <Text size={200}>{state.workspacePath}</Text>
                 </Field>
 
-                <Field
-                    label={
-                        <>
-                            {l10n.t('Project Name')} <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
-                        </>
-                    }
-                >
+                <Field required label={l10n.t('Project Name')}>
                     <Input
                         value={state.projectName}
                         onChange={(_e, data) => handleProjectNameChange(data.value)}
@@ -1135,7 +1130,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                 )}
 
                 {state.availableModels.length > 0 && (
-                    <Field label={l10n.t('AI Model')}>
+                    <Field required label={l10n.t('AI Model')}>
                         <Dropdown
                             data-testid="migration-model-dropdown"
                             onOptionSelect={handleModelChange}
@@ -1252,10 +1247,20 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 styles={styles}
                             />
                         </Text>
-                        <Button appearance="secondary" size="small" onClick={handleSelectSchemaFiles}>
+                        <Button
+                            appearance="secondary"
+                            size="small"
+                            aria-description={l10n.t('Database Schema Files, required')}
+                            onClick={handleSelectSchemaFiles}
+                        >
                             {l10n.t('Select Files…')}
                         </Button>
-                        <Button appearance="secondary" size="small" onClick={handleSelectSchemaFolder}>
+                        <Button
+                            appearance="secondary"
+                            size="small"
+                            aria-description={l10n.t('Database Schema Files, required')}
+                            onClick={handleSelectSchemaFolder}
+                        >
                             {l10n.t('Select Folder…')}
                         </Button>
                         <Tooltip
@@ -1267,6 +1272,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 appearance="primary"
                                 size="small"
                                 icon={<SparkleRegular />}
+                                aria-description={l10n.t('Database Schema Files, required')}
                                 onClick={handleAnalyzeDatabaseSchema}
                             />
                         </Tooltip>
@@ -1423,7 +1429,8 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                     <div className={styles.analysisPanel}>
                         <div className={styles.analysisResult}>
                             <Text weight="semibold" size={200}>
-                                {l10n.t('Project:')} <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
+                                <span id={`${analysisLabelId}-project`}>{l10n.t('Project:')}</span>{' '}
+                                <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
                                 <InfoTooltipIcon
                                     content={l10n.t(
                                         'The name of your application or service. Examples: OrderService, InventoryAPI, CustomerPortal',
@@ -1441,6 +1448,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                             >
                                 <Input
                                     data-testid="migration-project-name"
+                                    aria-labelledby={`${analysisLabelId}-project`}
                                     size="small"
                                     value={state.analysisResult?.projectName ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('projectName', data.value)}
@@ -1448,7 +1456,8 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 />
                             </Field>
                             <Text weight="semibold" size={200}>
-                                {l10n.t('Type:')} <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
+                                <span id={`${analysisLabelId}-type`}>{l10n.t('Type:')}</span>{' '}
+                                <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
                                 <InfoTooltipIcon
                                     content={l10n.t(
                                         'The architecture or deployment style of your application. Examples: Web API, Microservice, Monolithic MVC',
@@ -1466,6 +1475,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                             >
                                 <Input
                                     data-testid="migration-project-type"
+                                    aria-labelledby={`${analysisLabelId}-type`}
                                     size="small"
                                     value={state.analysisResult?.projectType ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('projectType', data.value)}
@@ -1473,7 +1483,8 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 />
                             </Field>
                             <Text weight="semibold" size={200}>
-                                {l10n.t('Language:')} <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
+                                <span id={`${analysisLabelId}-language`}>{l10n.t('Language:')}</span>{' '}
+                                <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
                                 <InfoTooltipIcon
                                     content={l10n.t(
                                         'The primary programming language of your application. Examples: C#, Java, Python',
@@ -1491,6 +1502,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                             >
                                 <Input
                                     data-testid="migration-language"
+                                    aria-labelledby={`${analysisLabelId}-language`}
                                     size="small"
                                     value={state.analysisResult?.language ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('language', data.value)}
@@ -1498,7 +1510,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 />
                             </Field>
                             <Text weight="semibold" size={200}>
-                                {l10n.t('Frameworks:')}{' '}
+                                <span id={`${analysisLabelId}-frameworks`}>{l10n.t('Frameworks:')}</span>{' '}
                                 <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
                                 <InfoTooltipIcon
                                     content={l10n.t(
@@ -1517,6 +1529,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                             >
                                 <Input
                                     data-testid="migration-frameworks"
+                                    aria-labelledby={`${analysisLabelId}-frameworks`}
                                     size="small"
                                     value={state.analysisResult?.frameworks?.join(', ') ?? ''}
                                     onChange={(_e, data) => handleFrameworksChange(data.value)}
@@ -1524,7 +1537,8 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 />
                             </Field>
                             <Text weight="semibold" size={200}>
-                                {l10n.t('Database:')} <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
+                                <span id={`${analysisLabelId}-database`}>{l10n.t('Database:')}</span>{' '}
+                                <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
                                 <InfoTooltipIcon
                                     content={l10n.t(
                                         'The source relational database system you are migrating from. Examples: PostgreSQL, SQL Server, Oracle',
@@ -1542,6 +1556,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                             >
                                 <Input
                                     data-testid="migration-database"
+                                    aria-labelledby={`${analysisLabelId}-database`}
                                     size="small"
                                     value={state.analysisResult?.databaseType ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('databaseType', data.value)}
@@ -1549,7 +1564,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                 />
                             </Field>
                             <Text weight="semibold" size={200}>
-                                {l10n.t('Access Method:')}{' '}
+                                <span id={`${analysisLabelId}-access`}>{l10n.t('Access Method:')}</span>{' '}
                                 <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
                                 <InfoTooltipIcon
                                     content={l10n.t(
@@ -1568,6 +1583,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                             >
                                 <Input
                                     data-testid="migration-access"
+                                    aria-labelledby={`${analysisLabelId}-access`}
                                     size="small"
                                     value={state.analysisResult?.databaseAccess ?? ''}
                                     onChange={(_e, data) => handleAnalysisFieldChange('databaseAccess', data.value)}
@@ -2268,14 +2284,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                         {l10n.t('Select your target Cosmos DB environment and verify the connection.')}
                                     </Text>
 
-                                    <Field
-                                        label={
-                                            <>
-                                                {l10n.t('Target Environment')}{' '}
-                                                <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
-                                            </>
-                                        }
-                                    >
+                                    <Field required label={l10n.t('Target Environment')}>
                                         <RadioGroup
                                             value={state.targetType ?? ''}
                                             onChange={handleTargetTypeChange}

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -25,6 +25,9 @@ import {
     MenuTrigger,
     Option,
     OptionGroup,
+    Popover,
+    PopoverSurface,
+    PopoverTrigger,
     ProgressBar,
     Radio,
     RadioGroup,
@@ -264,6 +267,9 @@ const useStyles = makeStyles({
             outlineColor: 'var(--vscode-focusBorder)',
             outlineOffset: '1px',
         },
+    },
+    infoPopoverSurface: {
+        maxWidth: '360px',
     },
     analysisResult: {
         display: 'grid',
@@ -596,6 +602,29 @@ function InfoTooltipIcon({
                 <InfoRegular />
             </button>
         </Tooltip>
+    );
+}
+
+function InfoPopoverIcon({
+    content,
+    ariaLabel,
+    styles,
+}: {
+    content: ReactNode;
+    ariaLabel: string;
+    styles: ReturnType<typeof useStyles>;
+}) {
+    return (
+        <Popover withArrow>
+            <PopoverTrigger>
+                <button type="button" aria-label={ariaLabel} className={styles.infoIcon}>
+                    <InfoRegular />
+                </button>
+            </PopoverTrigger>
+            <PopoverSurface className={styles.infoPopoverSurface} aria-label={ariaLabel}>
+                {content}
+            </PopoverSurface>
+        </Popover>
     );
 }
 
@@ -1221,7 +1250,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         <Text weight="semibold" size={200}>
                             {l10n.t('Database Schema Files:')}{' '}
                             <span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>
-                            <InfoTooltipIcon
+                            <InfoPopoverIcon
                                 content={
                                     <>
                                         <p style={tooltipParagraphStyle}>
@@ -1291,7 +1320,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         {/* Volumetric Files */}
                         <Text weight="semibold" size={200}>
                             {l10n.t('Volumetrics:')}
-                            <InfoTooltipIcon
+                            <InfoPopoverIcon
                                 content={
                                     <>
                                         <p style={tooltipParagraphStyle}>
@@ -1359,7 +1388,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         {/* Access Pattern Files */}
                         <Text weight="semibold" size={200}>
                             {l10n.t('Access Patterns:')}
-                            <InfoTooltipIcon
+                            <InfoPopoverIcon
                                 content={
                                     <>
                                         <p style={tooltipParagraphStyle}>

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -1057,7 +1057,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                         {l10n.t('RDBMS → Cosmos DB NoSQL migration assistant.')}{' '}
                         <Link
                             style={{ fontSize: '12px' }}
-                            aria-label={l10n.t('Show full migration assistant description')}
+                            aria-description={l10n.t('Show full migration assistant description')}
                             onClick={() => setDescriptionExpanded(true)}
                         >
                             {l10n.t('More…')}

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -519,7 +519,12 @@ function FileListExpander({
                 aria-expanded={expanded}
                 tabIndex={0}
                 onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') setExpanded(!expanded);
+                    if (e.key === ' ') {
+                        e.preventDefault();
+                        setExpanded(!expanded);
+                    } else if (e.key === 'Enter') {
+                        setExpanded(!expanded);
+                    }
                 }}
             >
                 {expanded ? <ChevronDownRegular /> : <ChevronRightRegular />}
@@ -661,7 +666,7 @@ function getPhaseIcon(state: PhaseState) {
     );
 }
 
-function ReferencedInCodeStatus({ isMapped }: { isMapped: boolean }): React.ReactElement {
+function ReferencedInCodeStatus({ isMapped }: { isMapped: boolean }): ReactElement {
     const label = isMapped ? l10n.t('Yes') : l10n.t('No');
 
     return (

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -510,6 +510,7 @@ function FileListExpander({
                 onClick={() => setExpanded(!expanded)}
                 // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- styled <div> expander; switching to <button> would break layout
                 role="button"
+                aria-expanded={expanded}
                 tabIndex={0}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') setExpanded(!expanded);

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -668,16 +668,9 @@ function ReferencedInCodeStatus({ isMapped }: { isMapped: boolean }): React.Reac
         // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- composite ARIA img: wraps the visible status symbol which a native <img> cannot contain
         <span role="img" aria-label={label} style={{ display: 'inline-flex' }}>
             {isMapped ? (
-                <CheckmarkCircleFilled
-                    aria-hidden={true}
-                    style={{ color: 'var(--vscode-testing-iconPassed)' }}
-                />
+                <CheckmarkCircleFilled aria-hidden={true} style={{ color: 'var(--vscode-testing-iconPassed)' }} />
             ) : (
-                <Text
-                    aria-hidden={true}
-                    size={200}
-                    style={{ color: 'var(--vscode-descriptionForeground)' }}
-                >
+                <Text aria-hidden={true} size={200} style={{ color: 'var(--vscode-descriptionForeground)' }}>
                     —
                 </Text>
             )}

--- a/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
+++ b/src/webviews/cosmosdb/Migration/MigrationAssistant.tsx
@@ -631,6 +631,30 @@ function getPhaseIcon(state: PhaseState) {
     );
 }
 
+function ReferencedInCodeStatus({ isMapped }: { isMapped: boolean }): React.ReactElement {
+    const label = isMapped ? l10n.t('Yes') : l10n.t('No');
+
+    return (
+        // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- composite ARIA img: wraps the visible status symbol which a native <img> cannot contain
+        <span role="img" aria-label={label} style={{ display: 'inline-flex' }}>
+            {isMapped ? (
+                <CheckmarkCircleFilled
+                    aria-hidden={true}
+                    style={{ color: 'var(--vscode-testing-iconPassed)' }}
+                />
+            ) : (
+                <Text
+                    aria-hidden={true}
+                    size={200}
+                    style={{ color: 'var(--vscode-descriptionForeground)' }}
+                >
+                    —
+                </Text>
+            )}
+        </span>
+    );
+}
+
 function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
     const styles = useStyles();
     const state = useMigrationState();
@@ -1919,22 +1943,7 @@ function MigrationAssistantInner({ channel }: { channel: MigrationChannel }) {
                                                                 textAlign: 'center',
                                                             }}
                                                         >
-                                                            {domain.isMapped ? (
-                                                                <CheckmarkCircleFilled
-                                                                    style={{
-                                                                        color: 'var(--vscode-testing-iconPassed)',
-                                                                    }}
-                                                                />
-                                                            ) : (
-                                                                <Text
-                                                                    size={200}
-                                                                    style={{
-                                                                        color: 'var(--vscode-descriptionForeground)',
-                                                                    }}
-                                                                >
-                                                                    —
-                                                                </Text>
-                                                            )}
+                                                            <ReferencedInCodeStatus isMapped={domain.isMapped} />
                                                         </td>
                                                     </tr>
                                                 ))}

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -81,6 +81,44 @@ test.describe('Migration Assistant', () => {
         await expect(fileListExpander).toHaveAttribute('aria-expanded', 'false');
     });
 
+    test('announces required migration configuration fields', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await expect(frame.getByRole('textbox', { name: /Project Name/ })).toHaveAttribute('required', '');
+        await expect(frame.getByTestId('migration-model-dropdown')).toHaveAttribute('aria-required', 'true');
+
+        const analysisFields = [
+            ['project-name', 'Project:'],
+            ['project-type', 'Type:'],
+            ['language', 'Language:'],
+            ['frameworks', 'Frameworks:'],
+            ['database', 'Database:'],
+            ['access', 'Access Method:'],
+        ] as const;
+        for (const [field, name] of analysisFields) {
+            await expect(migration.analysisField(field)).toHaveAccessibleName(name);
+            await expect(migration.analysisField(field)).toHaveAttribute('required', '');
+        }
+
+        const schemaFilesDescription = 'Database Schema Files, required';
+        await expect(frame.getByRole('button', { name: 'Select Files…' })).toHaveAccessibleDescription(
+            schemaFilesDescription,
+        );
+        await expect(frame.getByRole('button', { name: 'Select Folder…' })).toHaveAccessibleDescription(
+            schemaFilesDescription,
+        );
+        await expect(
+            frame.getByRole('button', { name: 'Generate schema files from workspace code using AI' }),
+        ).toHaveAccessibleDescription(schemaFilesDescription);
+
+        await frame.getByRole('button', { name: /Phase 4: Target Cosmos DB Environment/ }).click();
+        await expect(frame.getByRole('radiogroup', { name: /Target Environment/ })).toHaveAttribute(
+            'aria-required',
+            'true',
+        );
+    });
+
     test('exclude-from-VCS checkbox toggles the .gitignore entry', async ({ vscodeWindow }) => {
         const frame = await openMigrationSeeded(vscodeWindow);
         const migration = new MigrationPage(frame);

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -75,9 +75,12 @@ test.describe('Migration Assistant', () => {
         const fileListExpander = frame.getByRole('button', { name: /file\(s\) selected/ }).first();
 
         await expect(fileListExpander).toHaveAttribute('aria-expanded', 'false');
-        await fileListExpander.click();
+        await fileListExpander.focus();
+        const scrollPosition = await frame.locator('html').evaluate((element) => element.scrollTop);
+        await fileListExpander.press('Space');
         await expect(fileListExpander).toHaveAttribute('aria-expanded', 'true');
-        await fileListExpander.click();
+        await expect(frame.locator('html')).toHaveJSProperty('scrollTop', scrollPosition);
+        await fileListExpander.press('Enter');
         await expect(fileListExpander).toHaveAttribute('aria-expanded', 'false');
     });
 

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -61,6 +61,15 @@ test.describe('Migration Assistant', () => {
         await expect(migration.modelDropdown).toBeVisible();
     });
 
+    test('More button has its visible label as its name and describes its purpose', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const moreButton = frame.getByRole('button', { name: /^More…/ });
+
+        await expect(moreButton).toHaveText('More…');
+        await expect(moreButton).toHaveAccessibleName('More…');
+        await expect(moreButton).toHaveAccessibleDescription('Show full migration assistant description');
+    });
+
     test('exclude-from-VCS checkbox toggles the .gitignore entry', async ({ vscodeWindow }) => {
         const frame = await openMigrationSeeded(vscodeWindow);
         const migration = new MigrationPage(frame);

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -231,6 +231,19 @@ test.describe('Migration Assistant', () => {
         await expect(migration.openedTab(/summary\.md/)).toBeVisible({ timeout: 15_000 });
     });
 
+    test('Phase 2 announces whether a domain is referenced in code', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const migration = new MigrationPage(frame);
+
+        await migration.runDiscovery();
+        await migration.runAssessment();
+
+        const salesDomainRow = migration.phase2DomainTable.getByRole('row').filter({ hasText: 'SalesDomain' });
+        const referencedCell = salesDomainRow.getByRole('cell', { name: 'Yes', exact: true });
+        await expect(referencedCell).toBeVisible();
+        await expect(referencedCell.getByRole('img', { name: 'Yes', exact: true })).toBeVisible();
+    });
+
     test('surfaces domain, summary, and schema-model artifacts with links', async ({ vscodeWindow }) => {
         const frame = await openMigrationSeeded(vscodeWindow);
         const migration = new MigrationPage(frame);

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -61,15 +61,6 @@ test.describe('Migration Assistant', () => {
         await expect(migration.modelDropdown).toBeVisible();
     });
 
-    test('More button has its visible label as its name and describes its purpose', async ({ vscodeWindow }) => {
-        const frame = await openMigrationSeeded(vscodeWindow);
-        const moreButton = frame.getByRole('button', { name: /^More…/ });
-
-        await expect(moreButton).toHaveText('More…');
-        await expect(moreButton).toHaveAccessibleName('More…');
-        await expect(moreButton).toHaveAccessibleDescription('Show full migration assistant description');
-    });
-
     test('file list discloses its expanded state', async ({ vscodeWindow }) => {
         const frame = await openMigrationSeeded(vscodeWindow);
         const fileListExpander = frame.getByRole('button', { name: /file\(s\) selected/ }).first();
@@ -105,12 +96,12 @@ test.describe('Migration Assistant', () => {
         }
 
         const schemaFilesDescription = 'Database Schema Files, required';
-        await expect(frame.getByRole('button', { name: 'Select Files…' })).toHaveAccessibleDescription(
-            schemaFilesDescription,
-        );
-        await expect(frame.getByRole('button', { name: 'Select Folder…' })).toHaveAccessibleDescription(
-            schemaFilesDescription,
-        );
+        await expect(
+            frame.getByRole('button', { name: 'Select Files…', description: schemaFilesDescription }),
+        ).toHaveAccessibleDescription(schemaFilesDescription);
+        await expect(
+            frame.getByRole('button', { name: 'Select Folder…', description: schemaFilesDescription }),
+        ).toHaveAccessibleDescription(schemaFilesDescription);
         await expect(
             frame.getByRole('button', { name: 'Generate schema files from workspace code using AI' }),
         ).toHaveAccessibleDescription(schemaFilesDescription);
@@ -135,7 +126,7 @@ test.describe('Migration Assistant', () => {
             await trigger.focus();
             await trigger.press('Enter');
 
-            const link = frame.getByRole('link', { name: linkLabel, exact: true });
+            const link = frame.getByRole('button', { name: linkLabel, exact: true });
             await expect(link).toBeFocused();
             await link.press('Escape');
             await expect(link).toBeHidden();
@@ -257,6 +248,11 @@ test.describe('Migration Assistant', () => {
         await expect(migration.progressBar).toBeVisible();
         await expect(migration.cancelButton).toBeVisible();
         await expect(migration.phaseCompleteBadge('phase1')).toBeVisible({ timeout: 30_000 });
+
+        const moreButton = frame.getByRole('button', { name: 'More…', exact: true });
+        await expect(moreButton).toHaveText('More…');
+        await expect(moreButton).toHaveAccessibleName('More…');
+        await expect(moreButton).toHaveAccessibleDescription('Show full migration assistant description');
     });
 
     test('Cancel aborts Discovery without completing', async ({ vscodeWindow }) => {

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -70,6 +70,17 @@ test.describe('Migration Assistant', () => {
         await expect(moreButton).toHaveAccessibleDescription('Show full migration assistant description');
     });
 
+    test('file list discloses its expanded state', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const fileListExpander = frame.getByRole('button', { name: /file\(s\) selected/ }).first();
+
+        await expect(fileListExpander).toHaveAttribute('aria-expanded', 'false');
+        await fileListExpander.click();
+        await expect(fileListExpander).toHaveAttribute('aria-expanded', 'true');
+        await fileListExpander.click();
+        await expect(fileListExpander).toHaveAttribute('aria-expanded', 'false');
+    });
+
     test('exclude-from-VCS checkbox toggles the .gitignore entry', async ({ vscodeWindow }) => {
         const frame = await openMigrationSeeded(vscodeWindow);
         const migration = new MigrationPage(frame);

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -119,6 +119,27 @@ test.describe('Migration Assistant', () => {
         );
     });
 
+    test('interactive help links are keyboard accessible', async ({ vscodeWindow }) => {
+        const frame = await openMigrationSeeded(vscodeWindow);
+        const helpLinks = [
+            ['Database schema files help', 'schema-ddl/'],
+            ['Volumetrics help', 'volumetrics/'],
+            ['Access patterns help', 'access-patterns/'],
+        ] as const;
+
+        for (const [helpLabel, linkLabel] of helpLinks) {
+            const trigger = frame.getByRole('button', { name: helpLabel, exact: true });
+            await trigger.focus();
+            await trigger.press('Enter');
+
+            const link = frame.getByRole('link', { name: linkLabel, exact: true });
+            await expect(link).toBeFocused();
+            await link.press('Escape');
+            await expect(link).toBeHidden();
+            await expect(trigger).toBeFocused();
+        }
+    });
+
     test('exclude-from-VCS checkbox toggles the .gitignore entry', async ({ vscodeWindow }) => {
         const frame = await openMigrationSeeded(vscodeWindow);
         const migration = new MigrationPage(frame);


### PR DESCRIPTION
## Summary

Improves the Migration Assistant's screen reader and keyboard accessibility across configuration, analysis, and results workflows. The changes preserve visible labels as accessible names, expose control state and required semantics programmatically, and make interactive help content reachable without a pointer.

## Changes

- Keeps the visible `More…` label as the button's accessible name while exposing its expanded purpose through `aria-description`.
- Announces referenced-in-code results as visible `Yes` or `No` accessibility targets without introducing hidden elements that can disrupt VoiceOver scrolling or focus bounds.
- Exposes file-list disclosure state through `aria-expanded` so assistive technologies announce collapsed and expanded transitions.
- Marks migration configuration controls as required and associates Application Details inputs with their visible labels.
- Adds accessible descriptions to required schema-file actions.
- Replaces the three tooltips containing folder links with non-modal Fluent UI popovers, allowing keyboard users to open the help, focus its link, dismiss it with Escape, and return focus to the trigger.
- Adds Playwright regressions for accessible names and descriptions, status announcements, disclosure state, required fields, label associations, keyboard focus entry, Escape dismissal, and focus restoration.
- Expands the accessibility skill guidance with lessons from manual VoiceOver verification, including visible accessibility targets and avoiding off-screen hidden content in scrollable views.

## Validation

- Focused Playwright E2E accessibility tests
- `npm run l10n`
- `npm run prettier-fix`
- `npm run lint`
- `npm run build`
- Manual VoiceOver verification for focus visibility and viewport stability

Fixes #3232
Fixes #3231
Fixes #3230
Fixes #3229
Fixes #3228