### PR TITLE
Preserve all main and release branch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,17 @@ on:
       - dev/**
 
 # Workflow-level concurrency dedupes runs for the SAME branch across DIFFERENT commits (e.g. rapid pushes
-# during a rebase). For pull_request events the group is scoped by PR number + head repo so two forks pushing
-# branches with the same name don't cancel each other.
+# during a rebase), except on main and rel/* where every run gets a unique group and is always built. For
+# pull_request events the group is scoped by PR number + head repo so two forks pushing branches with the same
+# name don't cancel each other.
 concurrency:
   group: >-
     build-${{ github.workflow }}-${{
-    github.event_name == 'pull_request' &&
-    format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
-    github.ref_name }}
+    github.ref == 'refs/heads/main' && github.run_id ||
+    startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
+        github.event_name == 'pull_request' &&
+        format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
+        github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,11 +75,13 @@ jobs:
        !startsWith(github.head_ref, 'rel/') &&
        !startsWith(github.head_ref, 'dev/'))
 
-    # Scope concurrency by PR (or by branch on push) so two forks pushing branches with the same name don't cancel
-    # each other.
+    # Scope concurrency by PR (or by branch on push) so two forks pushing branches with the same name don't
+    # cancel each other. Main and rel/* runs get unique groups so every commit is tested.
     concurrency:
       group: >-
         e2e-${{ github.workflow }}-${{
+        github.ref == 'refs/heads/main' && github.run_id ||
+        startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
         github.event_name == 'pull_request' &&
         format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
         github.ref_name }}

--- a/.github/workflows/nosql-language-service.yml
+++ b/.github/workflows/nosql-language-service.yml
@@ -41,11 +41,14 @@ on:
       - 'scripts/import-seed.mjs'
       - '.github/workflows/nosql-language-service.yml'
 
-# Workflow-level concurrency dedupes rapid pushes on the same branch; PR runs are scoped by PR number + head
-# repo so two forks pushing branches with the same name don't cancel each other.
+# Workflow-level concurrency dedupes rapid pushes on the same branch, except on main and rel/* where every run
+# gets a unique group. PR runs are scoped by PR number + head repo so two forks pushing branches with the same
+# name don't cancel each other.
 concurrency:
   group: >-
     nosql-${{ github.workflow }}-${{
+    github.ref == 'refs/heads/main' && github.run_id ||
+    startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
     github.event_name == 'pull_request' &&
     format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
     github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ on:
 concurrency:
   group: >-
     test-${{ github.workflow }}-${{
+    github.ref == 'refs/heads/main' && github.run_id ||
+    startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
     github.event_name == 'pull_request' &&
     format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
     github.ref_name }}


### PR DESCRIPTION
## Summary

- Assign each `main` workflow run a unique concurrency group using `github.run_id`.
- Apply the same per-run isolation to all `rel/*` branch workflows.
- Preserve the existing branch and pull request deduplication behavior for every other ref.

## Why

The shared branch concurrency group allowed rapid pushes to cancel an in-progress build or replace a pending build. That behavior is useful for development branches, but it can leave commits on `main` and release branches without a completed build.

Using a unique group for protected branch runs ensures every commit is built while retaining `cancel-in-progress: true` and the existing deduplication behavior elsewhere.

## Validation

- `npm run prettier-fix`
- `npm run lint`
- `git diff --check -- .github/workflows/build.yml`