### PR TITLE
Fix CI status reporting when pull requests open

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
-    # A push to a branch with an open PR fires both `push` and `pull_request` events. Cancelling one of them
-    # would leave a failed/cancelled required check on the PR head and block merge, so instead we SKIP the
-    # `pull_request` run for same-repo PRs whose head branch is already covered by this workflow's
-    # `push.branches` filters (only those branches get a `push` run in this repo). Fork PRs and same-repo PRs
-    # from other head branches (e.g. feature/*) still run on `pull_request`.
+    # A push to a covered same-repo branch with an open PR triggers both push and pull_request synchronize events.
+    # Skip that duplicate PR run, but keep opened/reopened runs so branches pushed before PR creation can report status.
     if: >-
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,11 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    # Same push+pull_request dedupe trick as build.yml: cancelling either run on the same SHA leaves a failed
-    # required check on the PR head. Skip the pull_request run only for same-repo PRs whose head branch already
-    # triggers a push run.
+    # Same push+pull_request synchronize dedupe trick as build.yml. PR opened/reopened events still run so they
+    # can create a status comment when the branch's earlier push had no PR.
     if: >-
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&

--- a/.github/workflows/nosql-language-service.yml
+++ b/.github/workflows/nosql-language-service.yml
@@ -56,11 +56,11 @@ jobs:
     name: NoSQL language-service integration
     runs-on: ubuntu-latest
 
-    # Same push+pull_request dedupe trick as build.yml: a same-repo branch covered by `push.branches` fires
-    # both events on one commit. Skip the pull_request run for those (the push run provides the checks); fork
-    # PRs and other head branches still run on pull_request.
+    # Same push+pull_request synchronize dedupe trick as build.yml. PR opened/reopened events still run so they
+    # can create a status comment when the branch's earlier push had no PR; fork PRs and other head branches run
+    # normally.
     if: >-
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,9 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
 
-    # Same push+pull_request dedupe trick as build.yml — see the comment there.
+    # Skip duplicate synchronize runs for covered same-repo branches, but run opened/reopened events to post status.
     if: >-
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&


### PR DESCRIPTION
## Summary

Ensure CI workflows publish their status comments when a pull request is opened after its branch was already pushed.

## Problem

The Build, Tests, E2E, and NoSQL language-service workflows run for both pushes to covered same-repository branches (`main`, `rel/*`, and `dev/**`) and pull request events. Their job-level deduplication previously skipped every same-repository pull request run for those branches.

When a branch was pushed before its pull request existed, the push run correctly found no PR and could not post a status comment. Opening the PR then triggered a pull request run, but the deduplication guard skipped that job as well, leaving no run capable of creating the initial status comment.

## Changes

- Skip only duplicate `pull_request` `synchronize` jobs for covered same-repository branches.
- Allow `opened` and `reopened` pull request jobs to run so they can create the initial status comment.
- Preserve push-run coverage for `main`, `rel/*`, and `dev/**` branches.
- Preserve pull request runs for forks and branches not covered by the push trigger.
- Apply the same behavior consistently to Build, Tests, E2E, and NoSQL language-service workflows.
- Update workflow comments to document the deduplication behavior.

## Resulting behavior

- Push to a covered branch without a PR: the push workflow runs and safely skips PR commenting.
- Open or reopen a PR: the pull request workflow runs and creates or updates its status comment.
- Push another commit to an open same-repository PR on a covered branch: the push workflow runs; the duplicate `synchronize` job is skipped.
- Fork PR or PR from an uncovered branch: the pull request workflow continues to run normally.

## Validation

- `npm run prettier`
- `npm run lint`
- GitHub Actions workflow diagnostics for all four modified workflow files