### PR TITLE
Revert "chore(deps): bump brace-expansion from 5.0.8 to 5.0.9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6400,9 +6400,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
brace-expansion 5.0.9 is not yet available to Azure Pipelines and we can't release anything.

Reverts microsoft/vscode-cosmosdb#3237

Similar to microsoft/vscode-cosmosdb#3242