### PR TITLE
Stabilize migration plan E2E test

### DIFF
--- a/src/panels/MigrationAssistantTab.ts
+++ b/src/panels/MigrationAssistantTab.ts
@@ -40,6 +40,7 @@ import { MIGRATION_SELECTED_MODEL_KEY } from '../utils/modelUtils';
 import { pickAppResource, pickWorkspaceResource } from '../utils/pickItem/pickAppResource';
 import { BaseTab } from './BaseTab';
 import { getSelectedModel, IS_PHASE4_REQUIRED, isDebugPromptsEnabled } from './migration/helpers/aiHelpers';
+import { capturePrompt, isMigrationAiMockEnabled } from './migration/helpers/e2eMigrationAiMock';
 import { emitMigrationEvent, resetCancellationToken } from './migration/helpers/migrationHelpers';
 import { setMigrationTelemetryContext } from './migration/helpers/migrationTelemetry';
 import { buildCodeMigrationPrompt } from './migration/prompts';
@@ -1649,6 +1650,11 @@ export class MigrationAssistantTab extends BaseTab {
             } catch (error) {
                 console.warn('Failed to handle code migration prompt debug file:', error);
             }
+        }
+
+        if (isMigrationAiMockEnabled()) {
+            capturePrompt(`code-migration-${mode}`, prompt);
+            return;
         }
 
         await vscode.commands.executeCommand('workbench.action.chat.open', {

--- a/src/panels/migration/helpers/e2eMigrationAiMock.ts
+++ b/src/panels/migration/helpers/e2eMigrationAiMock.ts
@@ -367,7 +367,7 @@ function delay(ms: number, token?: vscode.CancellationToken): Promise<void> {
  * text to `capture.jsonl` in {@link CAPTURE_DIR_ENV_KEY}. Lets e2e tests assert
  * that user-entered phase instructions actually reach the model prompt.
  */
-function capturePrompt(route: string | undefined, promptText: string): void {
+export function capturePrompt(route: string | undefined, promptText: string): void {
     const dir = process.env[CAPTURE_DIR_ENV_KEY];
     if (!dir) {
         return;

--- a/test/e2e/specs/migration.spec.ts
+++ b/test/e2e/specs/migration.spec.ts
@@ -476,11 +476,13 @@ test.describe('Migration Assistant', () => {
         await expect(migration.migrationActionButton).toBeEnabled();
         await expect(migration.migrationActionButton).toContainText('Plan Migration');
 
-        // Click "Plan Migration" (opens Copilot Chat with the generated prompt —
-        // a no-op for plan creation in the mocked e2e run), then simulate Chat
-        // writing the plan to disk. The file watcher flips hasCodeMigrationPlan.
+        // Click "Plan Migration" and verify the offline mock receives the generated
+        // prompt, then simulate Chat writing the plan to disk. The file watcher
+        // flips hasCodeMigrationPlan.
         await migration.migrationActionButton.click();
-        await migration.focus();
+        await expect
+            .poll(() => readCapturedPrompts().some((p) => p.route === 'code-migration-plan'), { timeout: 15_000 })
+            .toBe(true);
         writeCodeMigrationPlan();
 
         // The plan now exists: "View Plan" appears and the primary action


### PR DESCRIPTION
## Summary

Stabilize the Migration Assistant plan-state E2E test by keeping its final migration command inside the existing offline AI mock boundary.

## Root cause

Clicking **Plan Migration** invoked the real `workbench.action.chat.open` command even when the migration AI mock was enabled. On unsigned CI profiles, Copilot could display a sign-in modal that intercepted the test attempt to refocus the Migration Assistant tab. The modal persisted across Playwright retries, causing an unrelated E2E failure observed on #3243.

## Changes

- Export the existing migration prompt capture helper for use by the final migration command.
- When both existing E2E mock flags are enabled, capture `code-migration-plan` or `code-migration-start` prompts and skip opening real Copilot Chat.
- Update the E2E test to assert that clicking **Plan Migration** reaches the extension backend before simulating creation of the migration plan file.
- Preserve production behavior unchanged outside the doubly guarded E2E environment.

## Validation

- Focused Playwright migration plan test
- `npm run prettier-fix`
- `npm run lint`