### PR TITLE
chore: update version to 0.36 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## 0.36.0
+
+### Added
+
+- Added a **Quick Start tour** for the NoSQL Query Editor, with contextual tips for query, document, schema, connection, and results actions and commands to replay or reset the tour. (#3180)
+- Added GitHub Copilot tools and skills for opening and focusing Query Editors, inspecting editor and connection context, sampling data, applying generated queries, and executing the current query. (#3206)
+- Added support for **query-enabled throughput buckets**, gated on the account's preview feature registration. (#3198)
+
+### Fixed
+
+- Improved keyboard and screen reader accessibility throughout the Migration Assistant, including focus management, status announcements, and dialog labeling. (#3234)
+
+### Changed
+
+- Reworked **Natural Language to Query (NL2Query)** to use GitHub Copilot tools and skills instead of the previous in-editor generation experience and chat participant. (#3206)
+- Expanded end-to-end coverage for NL2Query, the Learn menu, Query Editor onboarding, and the Migration Assistant; isolated migration tests from Copilot sign-in. (#3175, #3225, #3244)
+- Updated localization.
+- Updated several dependencies to address vulnerabilities.
+
 ## 0.35.2 (Preview)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cosmosdb",
-  "version": "0.35.2",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cosmosdb",
-      "version": "0.35.2",
+      "version": "0.36.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-cosmosdb",
-  "version": "0.35.2",
-  "preview": true,
+  "version": "0.36.0",
+  "preview": false,
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "publisher": "ms-azuretools",
   "displayName": "Azure Cosmos DB",


### PR DESCRIPTION
This pull request prepares for the 0.36.0 stable release. It updates the extension version, removes the preview flag, and documents all major new features, fixes, and improvements in the changelog.

Release and documentation updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R4): Updates the extension version to `0.36.0` and sets `"preview": false` to mark this as a stable release.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R21): Adds release notes for version 0.36.0, including the new Quick Start tour for the NoSQL Query Editor, GitHub Copilot integration, query-enabled throughput buckets, accessibility improvements, NL2Query rework, expanded test coverage, localization, and dependency updates.