### PR TITLE
[rel/0.36] Fix coverage uploads for non-default branch pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,12 +74,13 @@ jobs:
         run: npm run vitest:coverage
 
       - name: 📊 Upload Code Coverage
-        # Skip on fork PRs (no token to upload) and when unit tests never ran. `!cancelled()` so coverage from
-        # a passing unit run is still uploaded even though later steps (build/integration) continue.
+        # The coverage service accepts uploads only for the default branch or a PR. Skip release/dev branch
+        # pushes, fork PRs (no token to upload), and runs where unit tests never started.
         if: >-
           ${{ !cancelled() && steps.unit-tests.outcome != 'skipped' &&
-          (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository) }}
+          (github.ref_name == github.event.repository.default_branch ||
+          (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository)) }}
         uses: actions/upload-code-coverage@f8bb4848421d758cb893e8e371d261678618a754
         with:
           file: coverage/cobertura-coverage.xml


### PR DESCRIPTION
Backport of #3252

## Summary

- upload code coverage to GitHub only for the default branch or internal pull requests
- skip the service upload for release and development branch pushes
- continue publishing the HTML coverage artifact for all runs where unit tests execute

## Problem

The Tests workflow fails on pushes to `rel/*` branches even though unit tests, the extension build, and integration tests all pass. `actions/upload-code-coverage` returns HTTP 400 because branch coverage uploads without a pull request number are supported only for the repository's default branch.

The previous condition allowed every non-PR event, so release and development branch pushes attempted an unsupported upload and marked the otherwise successful job as failed.

## Validation

- verified the condition for release pushes, development pushes, default-branch pushes, internal PRs, and fork PRs
- `npm run build`
- `npm run l10n`
- `npm run prettier-fix`
- `npm run lint`
- workflow diagnostics report no errors

## Follow-up

This applies the fix directly to `rel/0.36`.
