### PR TITLE
feat: strip unnecessary schema information passed to the LLM in NL2Query

### DIFF
--- a/src/chat/CosmosDbOperationsService.test.ts
+++ b/src/chat/CosmosDbOperationsService.test.ts
@@ -6,6 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import { type SerializedQueryResult } from '../cosmosdb/types/queryResult';
+import { findConfidentialStatKeys } from '../services/schemaStatisticsTestUtils';
 import { CosmosDbOperationsService } from './CosmosDbOperationsService';
 
 // ─── Shared string constants (used in both mock setup and assertions) ────────
@@ -239,6 +240,34 @@ describe('CosmosDbOperationsService', () => {
             const result = service.getQueryHistoryContext(mockEditor);
 
             expect(result).toBeUndefined();
+        });
+    });
+
+    describe('confidentiality (no raw document values in stored schema)', () => {
+        it('stores a schema stripped of value-derived statistics', () => {
+            service.recordQueryExecution(
+                'acc1',
+                'db1',
+                'c1',
+                makeResult({
+                    query: QUERY_SELECT_ALL,
+                    documents: [
+                        { id: '1', salary: 987654, nationalId: 'AB-123456789', active: true },
+                        { id: '2', salary: 42, nationalId: 'CD-9', active: false },
+                    ],
+                }),
+            );
+
+            const history = service.getQueryHistoryForContainer('acc1', 'db1', 'c1');
+            const entry = history!.executions[0];
+
+            expect(entry.schema).toBeDefined();
+            expect(findConfidentialStatKeys(entry.schema)).toEqual([]);
+            // The actual sensitive numeric value must not survive anywhere in the stored schema.
+            expect(JSON.stringify(entry.schema)).not.toContain('987654');
+            // Structure is still retained so the schema remains useful to the model.
+            const props = (entry.schema as any).properties as Record<string, unknown>;
+            expect(Object.keys(props)).toEqual(expect.arrayContaining(['salary', 'nationalId', 'active']));
         });
     });
 });

--- a/src/chat/CosmosDbOperationsService.ts
+++ b/src/chat/CosmosDbOperationsService.ts
@@ -7,6 +7,7 @@ import { type JSONSchema } from '@cosmosdb/schema-analyzer';
 import { getSchemaFromDocument, updateSchemaWithDocument, type NoSQLDocument } from '@cosmosdb/schema-analyzer/json';
 import { type SerializedQueryResult } from '../cosmosdb/types/queryResult';
 import { type QueryEditorTab } from '../panels/QueryEditorTab';
+import { stripSchemaStatistics } from '../services/schemaStatistics';
 import { getConnectionFromQueryTab } from './chatUtils';
 
 /**
@@ -89,7 +90,9 @@ export class CosmosDbOperationsService {
             for (const document of documents.slice(1)) {
                 updateSchemaWithDocument(schema, document as NoSQLDocument);
             }
-            return schema;
+            // Strip value-derived statistics (x-minValue/x-maxValue, string lengths, boolean counts)
+            // before the schema is stored and later surfaced to the language model.
+            return stripSchemaStatistics(schema);
         } catch (error) {
             console.warn('Failed to extract schema from results:', error);
             return undefined;

--- a/src/chat/executeCurrentQueryTool.test.ts
+++ b/src/chat/executeCurrentQueryTool.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { findConfidentialStatKeys } from '../services/schemaStatisticsTestUtils';
+import { registerExecuteCurrentQueryTool } from './executeCurrentQueryTool';
+import { invokeRegisteredTool } from './queryEditorToolTestUtils';
+
+// Drive the telemetry wrapper synchronously so the tool body runs end-to-end and we can inspect
+// the LanguageModelToolResult it returns.
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+    callWithTelemetryAndErrorHandling: vi.fn(async (_event: string, callback: (ctx: unknown) => unknown) => {
+        const ctx = {
+            telemetry: { properties: {} as Record<string, string>, measurements: {} as Record<string, number> },
+            errorHandling: { suppressDisplay: false },
+            valuesToMask: [] as string[],
+        };
+        return callback(ctx);
+    }),
+    parseError: (error: unknown) => ({ message: error instanceof Error ? error.message : String(error) }),
+}));
+
+vi.mock('../extensionVariables', () => ({
+    ext: { outputChannel: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+
+// `getActiveTab` requires a non-empty `openTabs`; the actual tab is resolved via
+// `getActiveQueryEditor`, which we stub below.
+vi.mock('../panels/QueryEditorTab', () => ({
+    QueryEditorTab: { openTabs: new Set([{}]) },
+}));
+
+vi.mock('./chatUtils', () => ({
+    getActiveQueryEditor: vi.fn(),
+    getConnectionFromQueryTab: vi.fn(),
+}));
+
+describe('cosmosdb_executeCurrentQuery — confidentiality', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('never sends value-derived statistics or raw values to the model', async () => {
+        const { getActiveQueryEditor, getConnectionFromQueryTab } = await import('./chatUtils');
+
+        const tab = {
+            getSelectedQuery: vi.fn(() => undefined),
+            getCurrentQuery: vi.fn(() => 'SELECT * FROM c'),
+            runActiveQueryInEditor: vi.fn(async () => 'exec-1'),
+            getCurrentQueryResults: vi.fn(() => ({
+                query: 'SELECT * FROM c',
+                documents: [
+                    { id: '1', salary: 987654, nationalId: 'AB-123456789', active: true },
+                    { id: '2', salary: 42, nationalId: 'CD-9', active: false },
+                ],
+                requestCharge: 3.14,
+                roundTrips: 1,
+                hasMoreResults: false,
+            })),
+        };
+        vi.mocked(getActiveQueryEditor).mockReturnValue(tab as never);
+        vi.mocked(getConnectionFromQueryTab).mockReturnValue({
+            endpoint: 'https://example.documents.azure.com/',
+            databaseId: 'db1',
+            containerId: 'c1',
+        } as never);
+
+        const { text } = await invokeRegisteredTool(registerExecuteCurrentQueryTool);
+        const payload = JSON.parse(text);
+
+        // The tool still returns useful metadata + an inferred schema.
+        expect(payload.documentCount).toBe(2);
+        expect(payload.schema).toBeDefined();
+
+        // No value-derived statistic keys anywhere in the payload.
+        expect(findConfidentialStatKeys(payload)).toEqual([]);
+        // The actual sensitive numeric value must not appear anywhere in the serialized result.
+        expect(text).not.toContain('987654');
+
+        // Structural information is preserved so the schema remains useful to the model.
+        const props = payload.schema.properties as Record<string, unknown>;
+        expect(Object.keys(props)).toEqual(expect.arrayContaining(['salary', 'nationalId', 'active']));
+    });
+});

--- a/src/chat/executeCurrentQueryTool.ts
+++ b/src/chat/executeCurrentQueryTool.ts
@@ -9,6 +9,7 @@ import * as l10n from '@vscode/l10n';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
 import { QueryEditorTab } from '../panels/QueryEditorTab';
+import { stripSchemaStatistics } from '../services/schemaStatistics';
 import { getActiveQueryEditor, getConnectionFromQueryTab } from './chatUtils';
 
 /**
@@ -171,7 +172,9 @@ export function registerExecuteCurrentQueryTool(context: vscode.ExtensionContext
                         }
 
                         const documents = queryResult.documents ?? [];
-                        // Result metadata only — never include raw document values.
+                        // Result metadata only — never include raw document values. The inferred
+                        // schema is stripped of value-derived statistics (x-minValue/x-maxValue,
+                        // x-min/maxLength, boolean counts) so no actual document values reach the model.
                         const metadata = {
                             databaseId: connection.databaseId,
                             containerId: connection.containerId,
@@ -181,7 +184,9 @@ export function registerExecuteCurrentQueryTool(context: vscode.ExtensionContext
                             hasMoreResults: queryResult.hasMoreResults,
                             schema:
                                 documents.length > 0
-                                    ? (getSchemaFromDocuments(documents as NoSQLDocument[]) as Record<string, unknown>)
+                                    ? (stripSchemaStatistics(
+                                          getSchemaFromDocuments(documents as NoSQLDocument[]),
+                                      ) as Record<string, unknown>)
                                     : undefined,
                         };
 

--- a/src/chat/getQueryEditorContextTool.test.ts
+++ b/src/chat/getQueryEditorContextTool.test.ts
@@ -5,12 +5,21 @@
 
 /// <reference types="vitest/globals" />
 
-import { resolveEditorQueries } from './getQueryEditorContextTool';
+import { findConfidentialStatKeys } from '../services/schemaStatisticsTestUtils';
+import { registerGetQueryEditorContextTool, resolveEditorQueries } from './getQueryEditorContextTool';
+import { invokeRegisteredTool } from './queryEditorToolTestUtils';
 
 // `resolveEditorQueries` is pure. Mock the heavy sibling modules the tool file imports (but that this
 // function never touches) so the unit under test loads without the panel / service / vscode graph.
 vi.mock('@microsoft/vscode-azext-utils', () => ({
-    callWithTelemetryAndErrorHandling: vi.fn(),
+    callWithTelemetryAndErrorHandling: vi.fn(async (_event: string, callback: (ctx: unknown) => unknown) => {
+        const ctx = {
+            telemetry: { properties: {} as Record<string, string>, measurements: {} as Record<string, number> },
+            errorHandling: { suppressDisplay: false },
+            valuesToMask: [] as string[],
+        };
+        return callback(ctx);
+    }),
     parseError: (error: unknown) => ({ message: error instanceof Error ? error.message : String(error) }),
 }));
 
@@ -20,7 +29,7 @@ vi.mock('../extensionVariables', () => ({
 
 vi.mock('../panels/QueryEditorTab', () => ({
     QueryEditorTab: class {
-        static openTabs = new Set();
+        static openTabs = new Set([{}]);
     },
 }));
 
@@ -78,5 +87,49 @@ describe('resolveEditorQueries', () => {
 
         expect(result.selectedQuery).toBe('  SELECT 1  ');
         expect(result.activeQuery).toBe('  SELECT 1  ');
+    });
+});
+
+describe('cosmosdb_getQueryEditorContext — confidentiality', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns a current-result schema stripped of value-derived statistics', async () => {
+        const { getActiveQueryEditor, getConnectionFromQueryTab } = await import('./chatUtils');
+
+        const tab = {
+            getCurrentQuery: vi.fn(() => 'SELECT * FROM c'),
+            getSelectedQuery: vi.fn(() => undefined),
+            getCurrentQueryResults: vi.fn(() => ({
+                query: 'SELECT * FROM c',
+                documents: [
+                    { id: '1', salary: 987654, nationalId: 'AB-123456789', active: true },
+                    { id: '2', salary: 42, nationalId: 'CD-9', active: false },
+                ],
+                requestCharge: 2.5,
+                roundTrips: 1,
+                hasMoreResults: false,
+            })),
+        };
+        vi.mocked(getActiveQueryEditor).mockReturnValue(tab as never);
+        vi.mocked(getConnectionFromQueryTab).mockReturnValue({
+            databaseId: 'db1',
+            containerId: 'c1',
+        } as never);
+
+        const { text } = await invokeRegisteredTool(registerGetQueryEditorContextTool);
+        const context = JSON.parse(text);
+
+        expect(context.currentResult).toBeDefined();
+        expect(context.currentResult.schema).toBeDefined();
+
+        expect(findConfidentialStatKeys(context)).toEqual([]);
+        // The actual sensitive numeric value must not appear anywhere in the serialized context.
+        expect(text).not.toContain('987654');
+
+        // Structural information is preserved so the schema remains useful to the model.
+        const props = context.currentResult.schema.properties as Record<string, unknown>;
+        expect(Object.keys(props)).toEqual(expect.arrayContaining(['salary', 'nationalId', 'active']));
     });
 });

--- a/src/chat/getQueryEditorContextTool.ts
+++ b/src/chat/getQueryEditorContextTool.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
 import { QueryEditorTab } from '../panels/QueryEditorTab';
 import { SchemaService } from '../services/SchemaService';
+import { stripSchemaStatistics } from '../services/schemaStatistics';
 import { getActiveQueryEditor, getConnectionFromQueryTab } from './chatUtils';
 import { CosmosDbOperationsService } from './CosmosDbOperationsService';
 
@@ -210,13 +211,13 @@ export function registerGetQueryEditorContextTool(context: vscode.ExtensionConte
                                 requestCharge: currentResult.requestCharge,
                                 roundTrips: currentResult.roundTrips,
                                 hasMoreResults: currentResult.hasMoreResults,
-                                // Structure only — getSchemaFromDocuments never carries raw values.
+                                // Structure only — stripped of value-derived statistics so no actual
+                                // document values (numeric min/max, string lengths) reach the model.
                                 schema:
                                     documents.length > 0
-                                        ? (getSchemaFromDocuments(documents as NoSQLDocument[]) as Record<
-                                              string,
-                                              unknown
-                                          >)
+                                        ? (stripSchemaStatistics(
+                                              getSchemaFromDocuments(documents as NoSQLDocument[]),
+                                          ) as Record<string, unknown>)
                                         : undefined,
                             };
                         }

--- a/src/chat/queryEditorToolTestUtils.ts
+++ b/src/chat/queryEditorToolTestUtils.ts
@@ -22,19 +22,34 @@ interface InvokableTool {
 export async function invokeRegisteredTool(
     register: (context: vscode.ExtensionContext) => void,
 ): Promise<{ result: vscode.LanguageModelToolResult; text: string }> {
+    const lmRecord = vscode.lm as unknown as Record<string, unknown>;
+    const originalRegisterTool = lmRecord.registerTool;
+
     let captured: InvokableTool | undefined;
-    (vscode.lm as unknown as { registerTool: unknown }).registerTool = (_name: string, tool: unknown) => {
+    lmRecord.registerTool = (_name: string, tool: unknown) => {
         captured = tool as InvokableTool;
         return { dispose: () => {} };
     };
 
-    register({ subscriptions: { push: () => {} } } as unknown as vscode.ExtensionContext);
+    try {
+        register({ subscriptions: { push: () => {} } } as unknown as vscode.ExtensionContext);
 
-    if (!captured) {
-        throw new Error('register did not call vscode.lm.registerTool');
+        if (!captured) {
+            throw new Error('register did not call vscode.lm.registerTool');
+        }
+
+        const cts = new vscode.CancellationTokenSource();
+        try {
+            const result = await captured.invoke({ input: {} }, cts.token);
+            const text = (result.content as Array<{ value?: string }>).map((part) => part.value ?? '').join('');
+            return { result, text };
+        } finally {
+            cts.dispose();
+        }
+    } finally {
+        if (originalRegisterTool !== undefined) {
+            lmRecord.registerTool = originalRegisterTool;
+        } else {
+            delete lmRecord.registerTool;
+        }
     }
-
-    const result = await captured.invoke({ input: {} }, { isCancellationRequested: false });
-    const text = (result.content as Array<{ value?: string }>).map((part) => part.value ?? '').join('');
-    return { result, text };
-}

--- a/src/chat/queryEditorToolTestUtils.ts
+++ b/src/chat/queryEditorToolTestUtils.ts
@@ -53,3 +53,4 @@ export async function invokeRegisteredTool(
             delete lmRecord.registerTool;
         }
     }
+}

--- a/src/chat/queryEditorToolTestUtils.ts
+++ b/src/chat/queryEditorToolTestUtils.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/** The minimal shape a language-model tool exposes for invocation. */
+interface InvokableTool {
+    invoke: (options: unknown, token: unknown) => Promise<vscode.LanguageModelToolResult>;
+}
+
+/**
+ * Registers a query-editor language-model tool, captures the tool object it hands to
+ * `vscode.lm.registerTool`, invokes it once, and returns both the raw result and the concatenated
+ * text of its parts.
+ *
+ * Centralizes the registration-capture + invoke + serialize dance shared by the tool tests so each
+ * test only has to arrange its tab/connection stubs and assert on the returned `text`. Uses plain
+ * function stubs (no test-framework globals) so it stays a dependency-light helper.
+ */
+export async function invokeRegisteredTool(
+    register: (context: vscode.ExtensionContext) => void,
+): Promise<{ result: vscode.LanguageModelToolResult; text: string }> {
+    let captured: InvokableTool | undefined;
+    (vscode.lm as unknown as { registerTool: unknown }).registerTool = (_name: string, tool: unknown) => {
+        captured = tool as InvokableTool;
+        return { dispose: () => {} };
+    };
+
+    register({ subscriptions: { push: () => {} } } as unknown as vscode.ExtensionContext);
+
+    if (!captured) {
+        throw new Error('register did not call vscode.lm.registerTool');
+    }
+
+    const result = await captured.invoke({ input: {} }, { isCancellationRequested: false });
+    const text = (result.content as Array<{ value?: string }>).map((part) => part.value ?? '').join('');
+    return { result, text };
+}

--- a/src/services/SchemaService.test.ts
+++ b/src/services/SchemaService.test.ts
@@ -16,6 +16,7 @@ import { type NoSqlQueryConnection } from '../cosmosdb/NoSqlQueryConnection';
 import { type SchemaMetadata } from './SchemaFileStorage';
 import type * as SchemaFileStorageModule from './SchemaFileStorage';
 import { type SchemaWriteOptions } from './SchemaService';
+import { collectSchemaKeys, findConfidentialStatKeys } from './schemaStatisticsTestUtils';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -105,6 +106,7 @@ vi.mock('./SchemaFileStorage', async () => {
 const {
     SchemaService,
     aggressivelySimplify,
+    stripSchemaStatistics,
     composeMetadata,
     SCHEMA_SIZE_LIMIT_BYTES,
     DEFAULT_SIMPLIFIED_TARGET_BYTES,
@@ -703,6 +705,89 @@ describe('aggressivelySimplify (pure helper)', () => {
         // The other 2 slots are filled by *some* rare fields (stable sort
         // picks them by insertion order — `rare_000` and `rare_001`).
         expect(kept.filter((k) => k.startsWith('rare_'))).toEqual(['rare_000', 'rare_001']);
+    });
+});
+
+describe('stripSchemaStatistics (confidentiality boundary)', () => {
+    it('removes every value-derived statistic that getSchemaFromDocuments records', () => {
+        // Sensitive documents: a salary (numeric), a national ID (string) and a flag (boolean).
+        const documents = [
+            { id: '1', salary: 987654, nationalId: 'AB-123456789', active: true },
+            { id: '2', salary: 42, nationalId: 'CD-9', active: false },
+        ];
+        const raw = getSchemaFromDocuments(documents) as JSONSchema;
+
+        // Precondition: the raw schema DOES leak the value-derived extremes — this is the bug
+        // the stripping guards against, so assert it is present before stripping.
+        const rawKeys = collectSchemaKeys(raw);
+        expect(rawKeys.has('x-minValue')).toBe(true);
+        expect(rawKeys.has('x-maxValue')).toBe(true);
+        expect(JSON.stringify(raw)).toContain('987654');
+
+        const stripped = stripSchemaStatistics(raw);
+        expect(findConfidentialStatKeys(stripped)).toEqual([]);
+        // The actual sensitive numeric value must not survive anywhere in the payload.
+        expect(JSON.stringify(stripped)).not.toContain('987654');
+    });
+
+    it('preserves structural information the model needs (property names, types, popularity)', () => {
+        const schema: JSONSchema = {
+            type: 'object',
+            'x-occurrence': 5,
+            properties: {
+                salary: { type: 'number', 'x-occurrence': 5, 'x-minValue': 42, 'x-maxValue': 987654 },
+                name: { type: 'string', 'x-occurrence': 5, 'x-minLength': 1, 'x-maxLength': 40 },
+            },
+        } as unknown as JSONSchema;
+
+        const stripped = stripSchemaStatistics(schema) as unknown as Record<string, unknown>;
+        const props = stripped.properties as Record<string, Record<string, unknown>>;
+
+        expect(Object.keys(props).sort()).toEqual(['name', 'salary']);
+        expect(props.salary.type).toBe('number');
+        expect(props.name.type).toBe('string');
+        // Popularity counters are intentionally kept — they drive later simplification.
+        expect(stripped['x-occurrence']).toBe(5);
+        expect(props.salary['x-occurrence']).toBe(5);
+        // Value-derived extremes are gone.
+        expect(findConfidentialStatKeys(stripped)).toEqual([]);
+    });
+
+    it('strips statistics nested inside anyOf branches and array items', () => {
+        const schema: JSONSchema = {
+            type: 'object',
+            properties: {
+                tags: {
+                    type: 'array',
+                    items: { type: 'string', 'x-minLength': 3, 'x-maxLength': 20 },
+                    'x-minItems': 0,
+                    'x-maxItems': 9,
+                },
+                mixed: {
+                    anyOf: [
+                        { type: 'number', 'x-minValue': -5, 'x-maxValue': 100 },
+                        { type: 'string', 'x-minLength': 2, 'x-maxLength': 6 },
+                    ],
+                },
+            },
+        } as unknown as JSONSchema;
+
+        expect(findConfidentialStatKeys(stripSchemaStatistics(schema))).toEqual([]);
+    });
+
+    it('does not mutate the input schema (returns a clone)', () => {
+        const schema: JSONSchema = {
+            type: 'object',
+            properties: { salary: { type: 'number', 'x-minValue': 1, 'x-maxValue': 2 } },
+        } as unknown as JSONSchema;
+
+        const stripped = stripSchemaStatistics(schema);
+        const original = (schema.properties as Record<string, Record<string, unknown>>).salary;
+
+        expect(stripped).not.toBe(schema);
+        // Original still carries its statistics — stripping happened on the clone only.
+        expect(original['x-minValue']).toBe(1);
+        expect(original['x-maxValue']).toBe(2);
     });
 });
 

--- a/src/services/SchemaService.ts
+++ b/src/services/SchemaService.ts
@@ -18,6 +18,11 @@ import { type NoSqlQueryConnection } from '../cosmosdb/NoSqlQueryConnection';
 import { withClaimsChallengeHandling } from '../cosmosdb/withClaimsChallengeHandling';
 import { ext } from '../extensionVariables';
 import { SchemaFileStorage, type SchemaMetadata } from './SchemaFileStorage';
+import { deepCloneSchema, stripNoisyStats } from './schemaStatistics';
+
+// Re-exported so existing importers (and tests) can keep pulling the confidentiality helper from
+// `SchemaService`; the implementation now lives in the dependency-light `schemaStatistics` module.
+export { stripSchemaStatistics } from './schemaStatistics';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -66,32 +71,6 @@ export const DEFAULT_SIMPLIFIED_KEEP_TOP_N = 2;
  */
 export const DEFAULT_SIMPLIFIED_ROOT_KEEP_TOP_N = 50;
 export const DEFAULT_POPULARITY_KEY = 'x-occurrence';
-
-/**
- * `x-*` extensions that are stripped from schemas before they are handed to
- * the language model: they are dense statistics that the LLM cannot use
- * meaningfully, and they consume the majority of bytes in deep schemas.
- *
- * `x-occurrence`, `x-typeOccurrence`, `x-dataType` and `x-bsonType` are kept
- * because the popularity cut depends on them and because the schema format
- * documentation (see `packages/schema-analyzer/docs/schema-format.md`) treats
- * `x-dataType` / `x-bsonType` as part of the public type tag.
- */
-const NOISY_STAT_KEYS = new Set<string>([
-    'x-documentsInspected',
-    'x-minProperties',
-    'x-maxProperties',
-    'x-minItems',
-    'x-maxItems',
-    'x-minLength',
-    'x-maxLength',
-    'x-minValue',
-    'x-maxValue',
-    'x-minDate',
-    'x-maxDate',
-    'x-trueCount',
-    'x-falseCount',
-]);
 
 // ─── Public types ───────────────────────────────────────────────────────────
 
@@ -1156,45 +1135,8 @@ export function aggressivelySimplify(
     return { schema: clone, popularityKeyHit, wasSimplified: mutated };
 }
 
-function deepCloneSchema(schema: JSONSchema): JSONSchema {
-    // Schemas are tree-shaped JSON; structuredClone is the safest deep copy.
-    return structuredClone(schema);
-}
-
 function jsonByteSize(value: unknown): number {
     return Buffer.byteLength(JSON.stringify(value) ?? '', 'utf8');
-}
-
-function stripNoisyStats(node: JSONSchema | undefined): boolean {
-    if (!node || typeof node !== 'object') return false;
-    let mutated = false;
-
-    for (const key of Object.keys(node)) {
-        if (NOISY_STAT_KEYS.has(key)) {
-            delete (node as Record<string, unknown>)[key];
-            mutated = true;
-        }
-    }
-
-    if (node.properties) {
-        for (const child of Object.values(node.properties)) {
-            if (typeof child === 'object') {
-                mutated = stripNoisyStats(child) || mutated;
-            }
-        }
-    }
-    if (node.anyOf) {
-        for (const entry of node.anyOf) {
-            if (typeof entry === 'object') {
-                mutated = stripNoisyStats(entry) || mutated;
-            }
-        }
-    }
-    if (node.items && typeof node.items === 'object' && !Array.isArray(node.items)) {
-        mutated = stripNoisyStats(node.items) || mutated;
-    }
-
-    return mutated;
 }
 
 function hasPopularityCounter(node: JSONSchema | undefined, key: string): boolean {

--- a/src/services/schemaStatistics.ts
+++ b/src/services/schemaStatistics.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type JSONSchema } from '@cosmosdb/schema-analyzer';
+
+/**
+ * `x-*` extensions that encode value-derived statistics computed from the actual documents that
+ * were inspected. They are stripped from schemas before they are handed to the language model for
+ * two reasons: they are dense statistics the model cannot use meaningfully (they consume the
+ * majority of bytes in deep schemas), and — more importantly — several of them expose the real
+ * values observed in the data (`x-minValue` / `x-maxValue` are the actual numeric extremes;
+ * `x-minLength` / `x-maxLength` the actual string lengths; `x-trueCount` / `x-falseCount` the
+ * actual boolean distribution).  None of these may reach the model.
+ *
+ * `x-occurrence`, `x-typeOccurrence`, `x-dataType` and `x-bsonType` are intentionally NOT included
+ * here: the popularity cut depends on them and the schema format documentation (see
+ * `packages/schema-analyzer/docs/schema-format.md`) treats `x-dataType` / `x-bsonType` as part of
+ * the public type tag.
+ */
+export const NOISY_STAT_KEYS = new Set<string>([
+    'x-documentsInspected',
+    'x-minProperties',
+    'x-maxProperties',
+    'x-minItems',
+    'x-maxItems',
+    'x-minLength',
+    'x-maxLength',
+    'x-minValue',
+    'x-maxValue',
+    'x-minDate',
+    'x-maxDate',
+    'x-trueCount',
+    'x-falseCount',
+]);
+
+/**
+ * Deep-clones a schema. Schemas are tree-shaped JSON, so `structuredClone` is the safest deep copy.
+ */
+export function deepCloneSchema(schema: JSONSchema): JSONSchema {
+    return structuredClone(schema);
+}
+
+/**
+ * Removes every {@link NOISY_STAT_KEYS} entry from `node` and all of its descendants
+ * (`properties`, `anyOf` branches and array `items`), mutating in place. Returns `true` when at
+ * least one key was removed.
+ */
+export function stripNoisyStats(node: JSONSchema | undefined): boolean {
+    if (!node || typeof node !== 'object') return false;
+    let mutated = false;
+
+    for (const key of Object.keys(node)) {
+        if (NOISY_STAT_KEYS.has(key)) {
+            delete (node as Record<string, unknown>)[key];
+            mutated = true;
+        }
+    }
+
+    if (node.properties) {
+        for (const child of Object.values(node.properties)) {
+            if (typeof child === 'object') {
+                mutated = stripNoisyStats(child) || mutated;
+            }
+        }
+    }
+    if (node.anyOf) {
+        for (const entry of node.anyOf) {
+            if (typeof entry === 'object') {
+                mutated = stripNoisyStats(entry) || mutated;
+            }
+        }
+    }
+    if (node.items && typeof node.items === 'object' && !Array.isArray(node.items)) {
+        mutated = stripNoisyStats(node.items) || mutated;
+    }
+
+    return mutated;
+}
+
+/**
+ * Returns a deep-cloned copy of `schema` with all value-derived statistics ({@link NOISY_STAT_KEYS},
+ * e.g. `x-minValue` / `x-maxValue` / `x-minLength` / `x-maxLength`) removed at every level.
+ *
+ * Unlike the aggressive simplification in `SchemaService`, this performs no popularity-based
+ * property trimming or byte-budget shaping — it only strips the confidential, value-derived
+ * extremes.  It is the minimal transform that inferred *result* and *query-history* schemas must
+ * pass through before they are serialized into a language-model tool result, so that no actual
+ * document values (numeric min/max, string lengths, boolean counts) ever reach the model.  Schemas
+ * built directly from live documents via `getSchemaFromDocuments` carry these keys, so every such
+ * schema handed to the LLM must be routed through this helper first.
+ */
+export function stripSchemaStatistics(schema: JSONSchema): JSONSchema {
+    const clone = deepCloneSchema(schema);
+    stripNoisyStats(clone);
+    return clone;
+}

--- a/src/services/schemaStatistics.ts
+++ b/src/services/schemaStatistics.ts
@@ -19,7 +19,7 @@ import { type JSONSchema } from '@cosmosdb/schema-analyzer';
  * `packages/schema-analyzer/docs/schema-format.md`) treats `x-dataType` / `x-bsonType` as part of
  * the public type tag.
  */
-export const NOISY_STAT_KEYS = new Set<string>([
+export const NOISY_STAT_KEYS: ReadonlySet<string> = new Set<string>([
     'x-documentsInspected',
     'x-minProperties',
     'x-maxProperties',

--- a/src/services/schemaStatisticsTestUtils.ts
+++ b/src/services/schemaStatisticsTestUtils.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { NOISY_STAT_KEYS } from './schemaStatistics';
+
+/**
+ * The value-derived statistic keys that must never reach the language model. Derived directly from
+ * the production {@link NOISY_STAT_KEYS} set so the confidentiality tests always check exactly what
+ * production strips: adding a key to `NOISY_STAT_KEYS` automatically extends the guarantee the tests
+ * assert.
+ */
+export const CONFIDENTIAL_STAT_KEYS: readonly string[] = [...NOISY_STAT_KEYS];
+
+/**
+ * Recursively collects every property key that appears anywhere in `value` (objects and arrays are
+ * walked to arbitrary depth). Used by confidentiality tests to scan a fully serialized tool payload
+ * for forbidden keys, rather than checking only the top level.
+ */
+export function collectSchemaKeys(value: unknown, acc: Set<string> = new Set<string>()): Set<string> {
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            collectSchemaKeys(item, acc);
+        }
+    } else if (value && typeof value === 'object') {
+        for (const [key, child] of Object.entries(value)) {
+            acc.add(key);
+            collectSchemaKeys(child, acc);
+        }
+    }
+    return acc;
+}
+
+/**
+ * Returns the {@link CONFIDENTIAL_STAT_KEYS} that appear anywhere in `payload`. An empty array means
+ * the payload is free of value-derived statistics; a non-empty array names exactly what leaked,
+ * which makes test failures self-explanatory.
+ */
+export function findConfidentialStatKeys(payload: unknown): string[] {
+    const keys = collectSchemaKeys(payload);
+    return CONFIDENTIAL_STAT_KEYS.filter((key) => keys.has(key));
+}


### PR DESCRIPTION
Remove schema "noisy stats" such as min/max values or string lengths from context passed to LLM.