### PR TITLE
Fix CI workflow trigger deduplication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,7 @@ on:
       - dev/**
 
   pull_request:
-    branches:
-      - main
-      - rel/*
-      - dev/**
+    types: [opened, reopened, synchronize]
 
 # Workflow-level concurrency dedupes runs for the SAME branch across DIFFERENT commits (e.g. rapid pushes
 # during a rebase), except on main and rel/* where every run gets a unique group and is always built. For
@@ -52,16 +49,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-
-    # Covered same-repo branches already run on push, so skip their duplicate pull_request jobs. GitHub associates
-    # the push checks with the PR by commit SHA. Fork PRs and branches not covered by push still run here.
-
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository ||
-      (github.head_ref != 'main' &&
-       !startsWith(github.head_ref, 'rel/') &&
-       !startsWith(github.head_ref, 'dev/'))
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -244,7 +231,7 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
         run: |
@@ -340,19 +327,6 @@ jobs:
           package_icon=$(result_icon "$PACKAGE_RESULT")
           build_artifacts=$(list_run_artifacts "${GITHUB_RUN_ID}")
 
-          # Resolve PR number for comment posting: prefer the pull_request event payload, otherwise use
-          # `gh pr view` by branch name (works for push events too).
-          if [ -z "${PR_NUMBER:-}" ] && [ -n "${BRANCH_NAME:-}" ]; then
-              pr_info=$(gh pr view "${BRANCH_NAME}" --repo "${REPO}" \
-                  --json number 2>/dev/null) || true
-              if [ -n "$pr_info" ]; then
-                  PR_NUMBER=$(echo "$pr_info" | jq -r '.number // empty')
-                  echo "ℹ️ Found PR #${PR_NUMBER}"
-              else
-                  echo "ℹ️ No open PR found for branch '${BRANCH_NAME}'"
-              fi
-          fi
-
           # Overall status — green only when every gating step succeeded or was skipped. verify-skills is
           # warning-only and excluded from pass/fail. Drives the title icon (no separate status section).
           all_green=true
@@ -400,6 +374,6 @@ jobs:
 
           echo "✅ Job summary written to: ${GITHUB_STEP_SUMMARY}"
 
-          if [ -n "${PR_NUMBER:-}" ]; then
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
               post_or_update_comment "${PR_NUMBER}" "${MARKER}" "${GITHUB_STEP_SUMMARY}" "${comment_meaningful}"
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,19 +31,14 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-# Workflow-level concurrency dedupes runs for the SAME branch across DIFFERENT commits (e.g. rapid pushes
-# during a rebase), except on main and rel/* where every run gets a unique group and is always built. For
-# pull_request events the group is scoped by PR number + head repo so two forks pushing branches with the same
-# name don't cancel each other.
+# Push and PR runs for the same head repository and branch share a concurrency group, so a scheduled PR run
+# cancels an overlapping push build. Push runs cannot cancel PR runs. Main and rel/* pushes get unique groups
+# so every release commit is built, and fork PRs remain isolated by their head repository.
 concurrency:
-  group: >-
-    build-${{ github.workflow }}-${{
-    github.ref == 'refs/heads/main' && github.run_id ||
-    startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
-        github.event_name == 'pull_request' &&
-        format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
-        github.ref_name }}
-  cancel-in-progress: true
+  {
+    cancel-in-progress: "${{ github.event_name == 'pull_request' }}",
+    group: "build-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || startsWith(github.ref, 'refs/heads/rel/') && github.run_id || github.event_name == 'pull_request' && format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.head_ref) || format('{0}-{1}', github.repository, github.ref_name) }}",
+  }
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
-    # A push to a covered same-repo branch with an open PR triggers both push and pull_request synchronize events.
-    # Skip that duplicate PR run, but keep opened/reopened runs so branches pushed before PR creation can report status.
+    # Covered same-repo branches already run on push, so skip their duplicate pull_request jobs. GitHub associates
+    # the push checks with the PR by commit SHA. Fork PRs and branches not covered by push still run here.
+
     if: >-
-      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
+      github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,10 +44,7 @@ on:
       - '.github/workflows/e2e.yml'
 
   pull_request:
-    branches:
-      - main
-      - rel/*
-      - dev/**
+    types: [opened, reopened, synchronize]
     paths:
       - 'src/**'
       - 'test/e2e/**'
@@ -64,14 +61,6 @@ jobs:
     name: 🎭 Run e2e tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    # Same push+pull_request dedupe behavior as build.yml.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository ||
-      (github.head_ref != 'main' &&
-       !startsWith(github.head_ref, 'rel/') &&
-       !startsWith(github.head_ref, 'dev/'))
 
     # Scope concurrency by PR (or by branch on push) so two forks pushing branches with the same name don't
     # cancel each other. Main and rel/* runs get unique groups so every commit is tested.
@@ -185,7 +174,7 @@ jobs:
           REPO: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           E2E_RESULT: ${{ steps.e2e-tests.outcome }}
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
         run: |
@@ -264,15 +253,6 @@ jobs:
           e2e_icon=$(result_icon "$E2E_RESULT")
           artifacts=$(list_run_artifacts "${GITHUB_RUN_ID}")
 
-          # Resolve PR number for push events (no PR payload) by branch name.
-          if [ -z "${PR_NUMBER:-}" ] && [ -n "${BRANCH_NAME:-}" ]; then
-              pr_info=$(gh pr view "${BRANCH_NAME}" --repo "${REPO}" \
-                  --json number 2>/dev/null) || true
-              if [ -n "$pr_info" ]; then
-                  PR_NUMBER=$(echo "$pr_info" | jq -r '.number // empty')
-              fi
-          fi
-
           MARKER="<!-- ci-summary:e2e -->"
           cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
           ${MARKER}
@@ -297,6 +277,6 @@ jobs:
               success|failure) comment_meaningful=true ;;
           esac
 
-          if [ -n "${PR_NUMBER:-}" ]; then
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
               post_or_update_comment "${PR_NUMBER}" "${MARKER}" "${GITHUB_STEP_SUMMARY}" "${comment_meaningful}"
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,17 +62,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    # Scope concurrency by PR (or by branch on push) so two forks pushing branches with the same name don't
-    # cancel each other. Main and rel/* runs get unique groups so every commit is tested.
+    # Push and PR runs share a head repository + branch group, so PR runs cancel overlapping push builds.
+    # Main and rel/* pushes remain unique, and fork PRs remain isolated by their head repository.
     concurrency:
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
       group: >-
         e2e-${{ github.workflow }}-${{
         github.ref == 'refs/heads/main' && github.run_id ||
         startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
         github.event_name == 'pull_request' &&
-        format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
-        github.ref_name }}
-      cancel-in-progress: true
+        format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.head_ref) ||
+        format('{0}-{1}', github.repository, github.ref_name) }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,10 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    # Same push+pull_request synchronize dedupe trick as build.yml. PR opened/reopened events still run so they
-    # can create a status comment when the branch's earlier push had no PR.
+    # Same push+pull_request dedupe behavior as build.yml.
     if: >-
-      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
+      github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&

--- a/.github/workflows/nosql-language-service.yml
+++ b/.github/workflows/nosql-language-service.yml
@@ -59,11 +59,9 @@ jobs:
     name: NoSQL language-service integration
     runs-on: ubuntu-latest
 
-    # Same push+pull_request synchronize dedupe trick as build.yml. PR opened/reopened events still run so they
-    # can create a status comment when the branch's earlier push had no PR; fork PRs and other head branches run
-    # normally.
+    # Same push+pull_request dedupe behavior as build.yml.
     if: >-
-      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
+      github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&

--- a/.github/workflows/nosql-language-service.yml
+++ b/.github/workflows/nosql-language-service.yml
@@ -31,11 +31,9 @@ on:
       - 'packages/**'
       - 'scripts/import-seed.mjs'
       - '.github/workflows/nosql-language-service.yml'
+
   pull_request:
-    branches:
-      - main
-      - rel/*
-      - dev/**
+    types: [opened, reopened, synchronize]
     paths:
       - 'packages/**'
       - 'scripts/import-seed.mjs'
@@ -58,14 +56,6 @@ jobs:
   integration:
     name: NoSQL language-service integration
     runs-on: ubuntu-latest
-
-    # Same push+pull_request dedupe behavior as build.yml.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository ||
-      (github.head_ref != 'main' &&
-       !startsWith(github.head_ref, 'rel/') &&
-       !startsWith(github.head_ref, 'dev/'))
 
     env:
       COSMOS_ENDPOINT: https://localhost:8081
@@ -165,7 +155,7 @@ jobs:
           REPO: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           NOSQL_RESULT: ${{ steps.nosql-tests.outcome }}
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
         run: |
@@ -243,14 +233,6 @@ jobs:
           nosql_icon=$(result_icon "$NOSQL_RESULT")
           artifacts=$(list_run_artifacts "${GITHUB_RUN_ID}")
 
-          if [ -z "${PR_NUMBER:-}" ] && [ -n "${BRANCH_NAME:-}" ]; then
-              pr_info=$(gh pr view "${BRANCH_NAME}" --repo "${REPO}" \
-                  --json number 2>/dev/null) || true
-              if [ -n "$pr_info" ]; then
-                  PR_NUMBER=$(echo "$pr_info" | jq -r '.number // empty')
-              fi
-          fi
-
           MARKER="<!-- ci-summary:nosql -->"
           cat >> "$GITHUB_STEP_SUMMARY" << SUMMARY_EOF
           ${MARKER}
@@ -271,6 +253,6 @@ jobs:
               success|failure) comment_meaningful=true ;;
           esac
 
-          if [ -n "${PR_NUMBER:-}" ]; then
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
               post_or_update_comment "${PR_NUMBER}" "${MARKER}" "${GITHUB_STEP_SUMMARY}" "${comment_meaningful}"
           fi

--- a/.github/workflows/nosql-language-service.yml
+++ b/.github/workflows/nosql-language-service.yml
@@ -39,18 +39,17 @@ on:
       - 'scripts/import-seed.mjs'
       - '.github/workflows/nosql-language-service.yml'
 
-# Workflow-level concurrency dedupes rapid pushes on the same branch, except on main and rel/* where every run
-# gets a unique group. PR runs are scoped by PR number + head repo so two forks pushing branches with the same
-# name don't cancel each other.
+# Push and PR runs share a head repository + branch group, so PR runs cancel overlapping push builds. Main and
+# rel/* pushes remain unique, and fork PRs remain isolated by their head repository.
 concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   group: >-
     nosql-${{ github.workflow }}-${{
     github.ref == 'refs/heads/main' && github.run_id ||
     startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
     github.event_name == 'pull_request' &&
-    format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
-    github.ref_name }}
-  cancel-in-progress: true
+    format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.head_ref) ||
+    format('{0}-{1}', github.repository, github.ref_name) }}
 
 jobs:
   integration:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,7 @@ on:
       - dev/**
 
   pull_request:
-    branches:
-      - main
-      - rel/*
-      - dev/**
+    types: [opened, reopened, synchronize]
 
 concurrency:
   group: >-
@@ -49,14 +46,6 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-
-    # Same push+pull_request dedupe behavior as build.yml.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name != github.repository ||
-      (github.head_ref != 'main' &&
-       !startsWith(github.head_ref, 'rel/') &&
-       !startsWith(github.head_ref, 'dev/'))
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -132,7 +121,7 @@ jobs:
           REPO: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           COVERAGE_URL: ${{ steps.upload-coverage.outputs.artifact-url }}
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
         run: |
@@ -187,15 +176,6 @@ jobs:
           unit_icon=$(result_icon "$UNIT_TEST_RESULT")
           int_icon=$(result_icon "$INTEGRATION_TEST_RESULT")
 
-          # Resolve PR number for push events (no PR payload) by branch name.
-          if [ -z "${PR_NUMBER:-}" ] && [ -n "${BRANCH_NAME:-}" ]; then
-              pr_info=$(gh pr view "${BRANCH_NAME}" --repo "${REPO}" \
-                  --json number 2>/dev/null) || true
-              if [ -n "$pr_info" ]; then
-                  PR_NUMBER=$(echo "$pr_info" | jq -r '.number // empty')
-              fi
-          fi
-
           coverage_section=""
           if [ -n "${COVERAGE_URL:-}" ]; then
               coverage_section="
@@ -224,6 +204,6 @@ jobs:
               esac
           done
 
-          if [ -n "${PR_NUMBER:-}" ]; then
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
               post_or_update_comment "${PR_NUMBER}" "${MARKER}" "${GITHUB_STEP_SUMMARY}" "${comment_meaningful}"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,9 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
 
-    # Skip duplicate synchronize runs for covered same-repo branches, but run opened/reopened events to post status.
+    # Same push+pull_request dedupe behavior as build.yml.
     if: >-
-      github.event_name != 'pull_request' || github.event.action != 'synchronize' ||
+      github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name != github.repository ||
       (github.head_ref != 'main' &&
        !startsWith(github.head_ref, 'rel/') &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,14 @@ on:
     types: [opened, reopened, synchronize]
 
 concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   group: >-
     test-${{ github.workflow }}-${{
     github.ref == 'refs/heads/main' && github.run_id ||
     startsWith(github.ref, 'refs/heads/rel/') && github.run_id ||
     github.event_name == 'pull_request' &&
-    format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.event.pull_request.number) ||
-    github.ref_name }}
-  cancel-in-progress: true
+    format('{0}-{1}', github.event.pull_request.head.repo.full_name, github.head_ref) ||
+    format('{0}-{1}', github.repository, github.ref_name) }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Adjust CI triggers so branches are validated before a PR exists, while only PR-triggered runs publish PR status comments.

- Run push builds for `main`, `rel/*`, and `dev/**` branches.
- Run workflows for opened, reopened, and synchronized pull requests, including pull requests from forks.
- Keep E2E and NoSQL workflows scoped by their existing path filters.
- Post or update PR summary comments only from `pull_request`-driven runs.
- Remove branch-to-PR discovery from push runs.
- Align push and PR concurrency keys by head repository and branch so a scheduled PR run can cancel an overlapping push run while fork branches remain isolated.
- Keep release branch runs independently scheduled and preserve consistent trigger formatting across workflows.