### PR TITLE
Disable dev branch push builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ on:
     branches:
       - main
       - rel/*
-      - dev/**
 
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,6 @@ on:
     branches:
       - main
       - rel/*
-      - dev/**
     paths:
       - 'src/**'
       - 'test/e2e/**'

--- a/.github/workflows/nosql-language-service.yml
+++ b/.github/workflows/nosql-language-service.yml
@@ -26,7 +26,6 @@ on:
     branches:
       - main
       - rel/*
-      - dev/**
     paths:
       - 'packages/**'
       - 'scripts/import-seed.mjs'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ on:
     branches:
       - main
       - rel/*
-      - dev/**
 
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
## Summary

Stop running push-triggered CI workflows for `dev/**` branches so pull request updates produce only the authoritative PR checks.

Push and pull request runs for the same commit previously shared concurrency keys. When a PR run cancelled its overlapping push run, GitHub retained the cancelled required checks and blocked merging even after the PR checks succeeded.

- Remove `dev/**` from the push triggers for Build, Tests, E2E, and NoSQL language-service integration.
- Continue running push builds for `main` and `rel/*`.
- Continue running all four workflows for opened, reopened, and synchronized pull requests.
- Preserve the existing E2E and NoSQL path filters.