### PR TITLE
Revert "[s360-breeze-toolkit: SFI-ES-4.2.4] Enforce DefaultDeny network isolation for build pipeline"

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -81,8 +81,6 @@ extends:
             linuxEsrpSigning: true
             WindowsHostVersion:
                 Version: 2022
-            networkisolation:
-                policy: DefaultDeny
         git:
             # Use the OAuth token in the Git config for localized file check-in
             persistCredentials: true


### PR DESCRIPTION
The marketplace/gallery connection is blocked (AggregateError [EACCES]  → Windows Firewall deny from Network Isolation), causing  Failed Installing Extensions  →  npm test exit code 1.

We'll need to find another solution, Reverting this for now.

Reverts microsoft/vscode-cosmosdb#3275