### PR TITLE
ci: disable AzDO integration test step, reapply DefaultDeny netiso

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -81,6 +81,8 @@ extends:
             linuxEsrpSigning: true
             WindowsHostVersion:
                 Version: 2022
+            networkisolation:
+                policy: DefaultDeny
         git:
             # Use the OAuth token in the Git config for localized file check-in
             persistCredentials: true

--- a/.azure-pipelines/common/test.yml
+++ b/.azure-pipelines/common/test.yml
@@ -7,16 +7,26 @@ steps:
   displayName: 'Start X Virtual Frame Buffer'
   condition: eq(variables['Agent.OS'], 'Linux')
 
-- task: Npm@1
-  displayName: 'Test'
-  inputs:
-    command: custom
-    customCommand: test
-  env:
-    SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
-    SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
-    SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
-    DISPLAY: :10 # Only necessary for linux test
+# The 'Test' step (npm test -> scripts/run-integration-tests.mjs) is disabled here. It launches a real VS Code
+# extension host via @vscode/test-electron and installs the dependent extension
+# 'ms-azuretools.vscode-azureresourcegroups' from the VS Code Marketplace, which requires outbound network access
+# that is incompatible with this pipeline's DefaultDeny network isolation policy (see PR #3275, reverted in #3278
+# after the Marketplace install was blocked with AggregateError [EACCES]).
+#
+# These integration tests (and the separate Playwright E2E suite) already run and gate every PR/push via GitHub
+# Actions (.github/workflows/test.yml and .github/workflows/e2e.yml), so re-running them here would be redundant.
+# Re-enable only if the Marketplace-dependent install is removed or moved to a network-isolation-compatible
+# environment (e.g. CloudTest).
+# - task: Npm@1
+#   displayName: 'Test'
+#   inputs:
+#     command: custom
+#     customCommand: test
+#   env:
+#     SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
+#     SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
+#     SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
+#     DISPLAY: :10 # Only necessary for linux test
 
 - task: Npm@1
   displayName: 'Unit Test'


### PR DESCRIPTION
## Summary
Disables the redundant AzDO integration `Test` step and reapplies the `DefaultDeny` network isolation policy that was reverted in #3278.

## Background
PR #3275 enforced `DefaultDeny` network isolation on this pipeline (S360 SFI-ES-4.2.4). It broke the AzDO `Test` step (`npm test` → `scripts/run-integration-tests.mjs`), which launches a real VS Code extension host via `@vscode/test-electron` and installs the dependent extension `ms-azuretools.vscode-azureresourcegroups` from the VS Code Marketplace — blocked under `DefaultDeny` with `AggregateError [EACCES]`. #3278 reverted the policy to unblock builds.

## Change
Instead of requesting a netiso exception for the Marketplace/CDN endpoints (which the netiso team is unlikely to grant per their [Wave 10 guidance](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-defaultdeny-s360-items) — endpoint vetting is denied when the use could be avoided, e.g. by moving tests elsewhere):

- **`.azure-pipelines/common/test.yml`** — comment out the AzDO `Test` step, with an explanation. This step is redundant: the same integration tests, plus the separate Playwright E2E suite, already run and gate every PR/push via GitHub Actions (`.github/workflows/test.yml`, `.github/workflows/e2e.yml`).
- **`.azure-pipelines/build.yml`** — reapply `networkisolation: policy: DefaultDeny`.

## Validation plan
This branch's pipeline run will be triggered to confirm the build succeeds under `DefaultDeny` without the disabled step.

### 🔗 Related
- Reverts the fix from microsoft/vscode-cosmosdb#3278
- Reintroduces microsoft/vscode-cosmosdb#3275's policy change
