### PR TITLE
ci: fix #3280 — disable the correct Test step in build.yml

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -355,13 +355,23 @@ extends:
                               TargetFolder: '$(ob_outputDirectory)'
                           condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
 
-                        - task: Npm@1
-                          displayName: '🧪 Test'
-                          inputs:
-                              command: custom
-                              customCommand: test
-                              workingDir: $(Build.SourcesDirectory)
-                          condition: succeeded()
+                        # The 'Test' step (npm test -> scripts/run-integration-tests.mjs) is disabled here. It launches a real VS Code
+                        # extension host via @vscode/test-electron and installs the dependent extension
+                        # 'ms-azuretools.vscode-azureresourcegroups' from the VS Code Marketplace, which requires outbound network
+                        # access that is incompatible with this pipeline's DefaultDeny network isolation policy (see PR #3275,
+                        # reverted in #3278 after the Marketplace install was blocked with AggregateError [EACCES]).
+                        #
+                        # These integration tests (and the separate Playwright E2E suite) already run and gate every PR/push via
+                        # GitHub Actions (.github/workflows/test.yml and .github/workflows/e2e.yml), so re-running them here would
+                        # be redundant. Re-enable only if the Marketplace-dependent install is removed or moved to a
+                        # network-isolation-compatible environment (e.g. CloudTest).
+                        # - task: Npm@1
+                        #   displayName: '🧪 Test'
+                        #   inputs:
+                        #       command: custom
+                        #       customCommand: test
+                        #       workingDir: $(Build.SourcesDirectory)
+                        #   condition: succeeded()
 
                         - task: PowerShell@2
                           displayName: '⚖️ Validate Version / Preview Alignment'

--- a/.azure-pipelines/common/test.yml
+++ b/.azure-pipelines/common/test.yml
@@ -7,26 +7,16 @@ steps:
   displayName: 'Start X Virtual Frame Buffer'
   condition: eq(variables['Agent.OS'], 'Linux')
 
-# The 'Test' step (npm test -> scripts/run-integration-tests.mjs) is disabled here. It launches a real VS Code
-# extension host via @vscode/test-electron and installs the dependent extension
-# 'ms-azuretools.vscode-azureresourcegroups' from the VS Code Marketplace, which requires outbound network access
-# that is incompatible with this pipeline's DefaultDeny network isolation policy (see PR #3275, reverted in #3278
-# after the Marketplace install was blocked with AggregateError [EACCES]).
-#
-# These integration tests (and the separate Playwright E2E suite) already run and gate every PR/push via GitHub
-# Actions (.github/workflows/test.yml and .github/workflows/e2e.yml), so re-running them here would be redundant.
-# Re-enable only if the Marketplace-dependent install is removed or moved to a network-isolation-compatible
-# environment (e.g. CloudTest).
-# - task: Npm@1
-#   displayName: 'Test'
-#   inputs:
-#     command: custom
-#     customCommand: test
-#   env:
-#     SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
-#     SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
-#     SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
-#     DISPLAY: :10 # Only necessary for linux test
+- task: Npm@1
+  displayName: 'Test'
+  inputs:
+    command: custom
+    customCommand: test
+  env:
+    SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
+    SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
+    SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
+    DISPLAY: :10 # Only necessary for linux test
 
 - task: Npm@1
   displayName: 'Unit Test'


### PR DESCRIPTION
PR #3280 disabled the wrong `Test` step: it commented out `Npm@1 'Test'` in `.azure-pipelines/common/test.yml`, which is used by `main.yml`'s multi-OS CI matrix (Windows/Linux/macOS), not the release pipeline with the `DefaultDeny` network isolation policy. The step that is actually redundant with GH Actions and conflicts with `DefaultDeny` (Marketplace access needed) is the separate `🧪 Test` step in `build.yml` itself.

- Restored the `Test` step in `.azure-pipelines/common/test.yml`.
- Commented out the `🧪 Test` step in `.azure-pipelines/build.yml` instead, with the same rationale comment.

No behavior change to `DefaultDeny` policy (already re-applied in #3280).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>