### PR TITLE
[rel/0.36] Backport latest Azure DevOps pipeline changes

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -136,18 +136,24 @@ extends:
                               pwsh: true
                               targetType: 'inline'
 
-                        # Temporarily disabled: manual Component Governance detection is causing
-                        # Network Isolation blocked-connection noise in this
-                        # pipeline. This task can be re-enabled after policy/tooling alignment.
+                        # Component Governance detection and the notice@0 NOTICE-file generator are both
+                        # disabled here. notice@0 depends on CG scan data and has proven unreliable —
+                        # it intermittently fails with a generic, unactionable
+                        # "failed to call notice file generator API" error caused by outages in the
+                        # external OSPO NOTICE-generation service, unrelated to this repo or its
+                        # dependency graph. Since notice@0 is CG's only consumer in this pipeline,
+                        # running CG detection here brought Network Isolation noise (#3159) for no
+                        # benefit once NOTICE generation is disabled too. NOTICE.html is now maintained
+                        # manually in the repo instead of being regenerated at build time.
                         # - task: ComponentGovernanceComponentDetection@0
                         #   displayName: '🛡️ Component Governance - Component Detection'
 
-                        - task: notice@0
-                          displayName: '📄 Generate NOTICE file'
-                          continueOnError: true # the notice@0 task is unreliable and sometimes fails the build unexpectedly due to random outages
-                          inputs:
-                              outputfile: $(Build.SourcesDirectory)/NOTICE.html
-                              outputformat: html
+                        # - task: notice@0
+                        #   displayName: '📄 Generate NOTICE file'
+                        #   continueOnError: true # the notice@0 task is unreliable and sometimes fails the build unexpectedly due to random outages
+                        #   inputs:
+                        #       outputfile: $(Build.SourcesDirectory)/NOTICE.html
+                        #       outputformat: html
 
                         - task: PowerShell@2
                           displayName: '🔢 Read Node.js version from .nvmrc'

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -81,6 +81,8 @@ extends:
             linuxEsrpSigning: true
             WindowsHostVersion:
                 Version: 2022
+            networkisolation:
+                policy: DefaultDeny
         git:
             # Use the OAuth token in the Git config for localized file check-in
             persistCredentials: true

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -355,13 +355,23 @@ extends:
                               TargetFolder: '$(ob_outputDirectory)'
                           condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
 
-                        - task: Npm@1
-                          displayName: '🧪 Test'
-                          inputs:
-                              command: custom
-                              customCommand: test
-                              workingDir: $(Build.SourcesDirectory)
-                          condition: succeeded()
+                        # The 'Test' step (npm test -> scripts/run-integration-tests.mjs) is disabled here. It launches a real VS Code
+                        # extension host via @vscode/test-electron and installs the dependent extension
+                        # 'ms-azuretools.vscode-azureresourcegroups' from the VS Code Marketplace, which requires outbound network
+                        # access that is incompatible with this pipeline's DefaultDeny network isolation policy (see PR #3275,
+                        # reverted in #3278 after the Marketplace install was blocked with AggregateError [EACCES]).
+                        #
+                        # These integration tests (and the separate Playwright E2E suite) already run and gate every PR/push via
+                        # GitHub Actions (.github/workflows/test.yml and .github/workflows/e2e.yml), so re-running them here would
+                        # be redundant. Re-enable only if the Marketplace-dependent install is removed or moved to a
+                        # network-isolation-compatible environment (e.g. CloudTest).
+                        # - task: Npm@1
+                        #   displayName: '🧪 Test'
+                        #   inputs:
+                        #       command: custom
+                        #       customCommand: test
+                        #       workingDir: $(Build.SourcesDirectory)
+                        #   condition: succeeded()
 
                         - task: PowerShell@2
                           displayName: '⚖️ Validate Version / Preview Alignment'

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -229,10 +229,6 @@ extends:
                               customCommand: run package
                               workingDir: $(Build.SourcesDirectory)
 
-                        - pwsh: npm i -g @vscode/vsce --userconfig $(Build.SourcesDirectory)/.azure-pipelines/.npmrc
-                          displayName: '⬇️ Install vsce'
-                          condition: succeeded()
-
                         # Find the vsix and set the vsix file name variable
                         # Fails with an error if more than one .vsix file is found, or if no .vsix file is found
                         - task: PowerShell@2
@@ -264,7 +260,7 @@ extends:
 
                         ## Sign the extension using OneBranch signing task
                         ## see for VS Code specifics: https://aka.ms/vsm-ms-publisher-sign#cai-teams-sign-using-onebranch
-                        - script: vsce generate-manifest -i $(vsixFileName) -o extension.manifest
+                        - script: npx vsce generate-manifest -i $(vsixFileName) -o extension.manifest
                           displayName: '📝 Generate extension manifest for signing'
                           condition: and(succeeded(), ${{ eq(parameters.isOfficialBuild, true) }})
 
@@ -301,7 +297,7 @@ extends:
                           condition: and(succeeded(), ${{ eq(parameters.isOfficialBuild, true) }})
                           inputs:
                               script: |
-                                  $output = vsce verify-signature -i $(vsixFileName) -m extension.manifest -s extension.signature.p7s 2>&1
+                                  $output = npx vsce verify-signature -i $(vsixFileName) -m extension.manifest -s extension.signature.p7s 2>&1
                                   Write-Output $output
 
                                   # Check if the vsce command failed to execute

--- a/.azure-pipelines/common/test.yml
+++ b/.azure-pipelines/common/test.yml
@@ -7,26 +7,16 @@ steps:
   displayName: 'Start X Virtual Frame Buffer'
   condition: eq(variables['Agent.OS'], 'Linux')
 
-# The 'Test' step (npm test -> scripts/run-integration-tests.mjs) is disabled here. It launches a real VS Code
-# extension host via @vscode/test-electron and installs the dependent extension
-# 'ms-azuretools.vscode-azureresourcegroups' from the VS Code Marketplace, which requires outbound network access
-# that is incompatible with this pipeline's DefaultDeny network isolation policy (see PR #3275, reverted in #3278
-# after the Marketplace install was blocked with AggregateError [EACCES]).
-#
-# These integration tests (and the separate Playwright E2E suite) already run and gate every PR/push via GitHub
-# Actions (.github/workflows/test.yml and .github/workflows/e2e.yml), so re-running them here would be redundant.
-# Re-enable only if the Marketplace-dependent install is removed or moved to a network-isolation-compatible
-# environment (e.g. CloudTest).
-# - task: Npm@1
-#   displayName: 'Test'
-#   inputs:
-#     command: custom
-#     customCommand: test
-#   env:
-#     SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
-#     SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
-#     SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
-#     DISPLAY: :10 # Only necessary for linux test
+- task: Npm@1
+  displayName: 'Test'
+  inputs:
+    command: custom
+    customCommand: test
+  env:
+    SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
+    SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
+    SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
+    DISPLAY: :10 # Only necessary for linux test
 
 - task: Npm@1
   displayName: 'Unit Test'

--- a/.azure-pipelines/common/test.yml
+++ b/.azure-pipelines/common/test.yml
@@ -7,16 +7,26 @@ steps:
   displayName: 'Start X Virtual Frame Buffer'
   condition: eq(variables['Agent.OS'], 'Linux')
 
-- task: Npm@1
-  displayName: 'Test'
-  inputs:
-    command: custom
-    customCommand: test
-  env:
-    SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
-    SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
-    SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
-    DISPLAY: :10 # Only necessary for linux test
+# The 'Test' step (npm test -> scripts/run-integration-tests.mjs) is disabled here. It launches a real VS Code
+# extension host via @vscode/test-electron and installs the dependent extension
+# 'ms-azuretools.vscode-azureresourcegroups' from the VS Code Marketplace, which requires outbound network access
+# that is incompatible with this pipeline's DefaultDeny network isolation policy (see PR #3275, reverted in #3278
+# after the Marketplace install was blocked with AggregateError [EACCES]).
+#
+# These integration tests (and the separate Playwright E2E suite) already run and gate every PR/push via GitHub
+# Actions (.github/workflows/test.yml and .github/workflows/e2e.yml), so re-running them here would be redundant.
+# Re-enable only if the Marketplace-dependent install is removed or moved to a network-isolation-compatible
+# environment (e.g. CloudTest).
+# - task: Npm@1
+#   displayName: 'Test'
+#   inputs:
+#     command: custom
+#     customCommand: test
+#   env:
+#     SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
+#     SERVICE_PRINCIPAL_SECRET: $(SERVICE_PRINCIPAL_SECRET)
+#     SERVICE_PRINCIPAL_DOMAIN: $(SERVICE_PRINCIPAL_DOMAIN)
+#     DISPLAY: :10 # Only necessary for linux test
 
 - task: Npm@1
   displayName: 'Unit Test'


### PR DESCRIPTION
Backport of `main` (`.azure-pipelines` changes since `rel/0.36`).

## Summary

Backports the latest effective Azure DevOps pipeline changes from `main` to `rel/0.36`. The resulting `.azure-pipelines` tree matches `main` exactly.

## Reasoning

PR #3280 restored the `DefaultDeny` network isolation policy required for S360 SFI-ES-4.2.4. Under that policy, the AzDO integration test cannot install `ms-azuretools.vscode-azureresourcegroups` from the VS Code Marketplace and fails with `AggregateError [EACCES]`. Requesting a network-isolation exception is avoidable because the same integration tests, plus Playwright E2E tests, already gate every PR and push in GitHub Actions.

The follow-up in #3289 is included because it corrects #3280 by disabling the Marketplace-dependent test in `.azure-pipelines/build.yml` while restoring `.azure-pipelines/common/test.yml`. The backport also disables the unreliable NOTICE/Component Governance tasks and uses the repository-pinned local `vsce`, reducing external-service and network dependencies under `DefaultDeny`.

## Backported commits

- #3276: disable NOTICE and Component Governance detection tasks in the build pipeline
- #3280: reapply `DefaultDeny` and disable the redundant AzDO integration test
- #3286: use the pinned local `vsce` for signing
- #3289: disable the correct build test step and restore the common test template

## Validation

- `npm run l10n` passed
- `npm run prettier-fix` passed
- `npm run lint` passed
- `npm run build` passed
- `.azure-pipelines` matches `origin/main`

No conflicts were encountered.