### PR TITLE
[rel/0.36] Fix throughput bucket availability in the Query Editor

### DIFF
--- a/src/commands/refreshTreeElement/refreshTreeElement.ts
+++ b/src/commands/refreshTreeElement/refreshTreeElement.ts
@@ -5,7 +5,10 @@
 
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
+import { QueryEditorTab } from '../../panels/QueryEditorTab';
+import { CosmosDBAccountResourceItemBase } from '../../tree/azure-resources-view/cosmosdb/CosmosDBAccountResourceItemBase';
 import { BaseCachedBranchDataProvider } from '../../tree/BaseCachedBranchDataProvider';
+import { CosmosDBContainerResourceItem } from '../../tree/cosmosdb/CosmosDBContainerResourceItem';
 import { type TreeElement } from '../../tree/TreeElement';
 
 export async function refreshTreeElement(context: IActionContext, node?: TreeElement): Promise<void> {
@@ -15,14 +18,30 @@ export async function refreshTreeElement(context: IActionContext, node?: TreeEle
 
     if (node && 'refresh' in node && typeof node.refresh === 'function') {
         await node.refresh.call(node, context);
+        notifyThroughputBucketRefresh(node);
         return;
     }
 
     if (node.dataProvider && node.dataProvider instanceof BaseCachedBranchDataProvider) {
-        return node.dataProvider.refresh(node);
+        node.dataProvider.refresh(node);
+        notifyThroughputBucketRefresh(node);
+        return;
     }
 
     if (node && 'id' in node && typeof node.id === 'string') {
-        return ext.state.notifyChildrenChanged(node.id);
+        ext.state.notifyChildrenChanged(node.id);
+        notifyThroughputBucketRefresh(node);
+    }
+}
+
+function notifyThroughputBucketRefresh(node: TreeElement): void {
+    if (node instanceof CosmosDBContainerResourceItem) {
+        QueryEditorTab.refreshThroughputBucketsForContainer(
+            node.model.accountInfo.id,
+            node.model.database.id,
+            node.model.container.id,
+        );
+    } else if (node instanceof CosmosDBAccountResourceItemBase) {
+        QueryEditorTab.refreshThroughputBucketsForContainer(node.id);
     }
 }

--- a/src/cosmosdb/throughputBuckets.test.ts
+++ b/src/cosmosdb/throughputBuckets.test.ts
@@ -14,7 +14,7 @@ describe('isThroughputBucketsFeatureRegistered', () => {
     it('returns true for the registered Throughput Buckets feature', () => {
         expect(
             isThroughputBucketsFeatureRegistered({
-                name: 'Microsoft.DocumentDB/ThroughputBuckets',
+                name: 'Microsoft.DocumentDB/ThroughputBucketing',
                 properties: { state: 'Registered' },
             }),
         ).toBe(true);
@@ -23,7 +23,7 @@ describe('isThroughputBucketsFeatureRegistered', () => {
     it('matches the feature name and state case-insensitively', () => {
         expect(
             isThroughputBucketsFeatureRegistered({
-                name: 'microsoft.documentdb/throughputbuckets',
+                name: 'microsoft.documentdb/throughputbucketing',
                 properties: { state: 'REGISTERED' },
             }),
         ).toBe(true);
@@ -34,7 +34,7 @@ describe('isThroughputBucketsFeatureRegistered', () => {
         (state) => {
             expect(
                 isThroughputBucketsFeatureRegistered({
-                    name: 'Microsoft.DocumentDB/ThroughputBuckets',
+                    name: 'Microsoft.DocumentDB/ThroughputBucketing',
                     properties: { state },
                 }),
             ).toBe(false);

--- a/src/cosmosdb/throughputBuckets.ts
+++ b/src/cosmosdb/throughputBuckets.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type CosmosDBManagementClient } from '@azure/arm-cosmosdb';
-import { createPipelineRequest } from '@azure/core-rest-pipeline';
+import { createHttpHeaders, createPipelineRequest } from '@azure/core-rest-pipeline';
 import { type IActionContext } from '@microsoft/vscode-azext-utils';
-import { COSMOSDB_ARM_API_VERSION, createFeatureClient } from '../utils/azureClients';
+import { createFeatureClient, PRESERVE_API_VERSION_HEADER } from '../utils/azureClients';
 import { type AzureResourceMetadata } from './AzureResourceMetadata';
 import { type NoSqlQueryConnection } from './NoSqlQueryConnection';
 import {
@@ -16,7 +16,8 @@ import {
 } from './throughputBucketsFeature';
 
 const DOCUMENT_DB_PROVIDER = 'Microsoft.DocumentDB';
-const THROUGHPUT_BUCKETS_FEATURE = 'ThroughputBuckets';
+const THROUGHPUT_BUCKETS_FEATURE = 'ThroughputBucketing';
+const THROUGHPUT_BUCKETS_API_VERSION = '2025-05-01-preview';
 const MANAGEMENT_ENDPOINT_FALLBACK = 'https://management.azure.com';
 
 /**
@@ -102,7 +103,7 @@ async function readEnabledThroughputBuckets(
         `${host}/subscriptions/${metadata.subscription.subscriptionId}` +
         `/resourceGroups/${metadata.resourceGroup}` +
         `/providers/Microsoft.DocumentDB/databaseAccounts/${metadata.accountName}`;
-    const query = `?api-version=${COSMOSDB_ARM_API_VERSION}`;
+    const query = `?api-version=${THROUGHPUT_BUCKETS_API_VERSION}`;
 
     // Prefer the container's dedicated throughput settings. A 404 means the
     // container inherits throughput (and any buckets) from a shared-throughput
@@ -126,7 +127,15 @@ async function readEnabledThroughputBuckets(
  * throughput) and throws for any other non-success status.
  */
 async function getThroughputSettings(client: CosmosDBManagementClient, url: string): Promise<unknown> {
-    const response = await client.sendRequest(createPipelineRequest({ url, method: 'GET' }));
+    // `throughputBuckets` is preview-only, so this request must keep
+    // `THROUGHPUT_BUCKETS_API_VERSION` instead of the client's pinned GA api-version.
+    const response = await client.sendRequest(
+        createPipelineRequest({
+            url,
+            method: 'GET',
+            headers: createHttpHeaders({ [PRESERVE_API_VERSION_HEADER]: 'true' }),
+        }),
+    );
 
     if (response.status === 404) {
         return undefined;

--- a/src/cosmosdb/throughputBuckets.ts
+++ b/src/cosmosdb/throughputBuckets.ts
@@ -59,7 +59,7 @@ export async function supportsThroughputBuckets(
  * configured on the container (or its shared-throughput database).
  *
  * The Cosmos DB ARM SDK does not yet model `throughputBuckets`, so the value is
- * read directly from the pinned-api-version REST response. If the buckets
+ * read directly from the preview REST response. If the buckets
  * cannot be read, all five are reported as enabled to preserve the selector's
  * previous always-available behaviour.
  */

--- a/src/cosmosdb/throughputBucketsFeature.ts
+++ b/src/cosmosdb/throughputBucketsFeature.ts
@@ -5,7 +5,7 @@
 
 import { type FeatureResult } from '@azure/arm-features';
 
-const THROUGHPUT_BUCKETS_FEATURE = 'ThroughputBuckets';
+const THROUGHPUT_BUCKETS_FEATURE = 'ThroughputBucketing';
 
 /** Cosmos DB supports at most five throughput buckets per container. */
 export const MAX_THROUGHPUT_BUCKETS = 5;

--- a/src/panels/QueryEditorTab.ts
+++ b/src/panels/QueryEditorTab.ts
@@ -241,6 +241,23 @@ export class QueryEditorTab extends BaseTab {
         }
     }
 
+    public static refreshThroughputBucketsForContainer(
+        accountId: string,
+        databaseId?: string,
+        containerId?: string,
+    ): void {
+        for (const tab of QueryEditorTab.openTabs) {
+            const connection = tab.state.connection;
+            if (
+                connection?.azureMetadata?.accountId === accountId &&
+                (!databaseId || connection.databaseId === databaseId) &&
+                (!containerId || connection.containerId === containerId)
+            ) {
+                tab.eventSink.emit({ type: 'throughputBucketsRefreshRequested' });
+            }
+        }
+    }
+
     public updateQuery(query: string): void {
         this.state.query = query;
         this.state.isLastQueryAIGenerated = true;

--- a/src/panels/trpc/routers/queryEditorEventsRouter.ts
+++ b/src/panels/trpc/routers/queryEditorEventsRouter.ts
@@ -34,6 +34,9 @@ export const QueryEditorEventSchema = z.discriminatedUnion('type', [
         containerSchema: z.record(z.string(), z.unknown()).nullable(),
     }),
     z.object({
+        type: z.literal('throughputBucketsRefreshRequested'),
+    }),
+    z.object({
         type: z.literal('runActiveQueryRequested'),
         query: z.string(),
     }),

--- a/src/panels/trpc/routers/queryEditorRouter.ts
+++ b/src/panels/trpc/routers/queryEditorRouter.ts
@@ -453,6 +453,10 @@ export const queryEditorRouterDef = queryEditorRouter({
         return undefined;
     }),
 
+    refreshThroughputBuckets: queryEditorProcedure.mutation(async ({ ctx }) => {
+        return getEnabledThroughputBuckets(ctx.state.connection, ctx.actionContext);
+    }),
+
     disconnectFromDatabase: queryEditorProcedure.mutation(({ ctx }) => {
         ctx.state.connection = undefined;
         ctx.panel.title = QueryEditorTab.title;

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -36,13 +36,31 @@ import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
 export const COSMOSDB_ARM_API_VERSION = '2025-10-15';
 const DOCUMENT_DB_PROVIDER_PATH = '/providers/microsoft.documentdb/';
 
+/**
+ * Opt-out marker for {@link COSMOSDB_ARM_API_VERSION} pinning. A caller that must reach a
+ * preview-only resource property (e.g. `throughputBuckets`, which the pinned GA api-version omits)
+ * sets this header so its own `api-version` survives the pipeline.
+ * The header is stripped before the request leaves the pipeline, so ARM never sees it.
+ */
+export const PRESERVE_API_VERSION_HEADER = 'x-vscode-cosmosdb-preserve-api-version';
+
+type PinnablePipelineRequest = {
+    url: string;
+    headers: { has(name: string): boolean; delete(name: string): void };
+};
+
 function pinCosmosDBApiVersion(client: CosmosDBManagementClient): CosmosDBManagementClient {
     const clientWithPipeline = client as unknown as {
         pipeline: { addPolicy: (policy: unknown) => void };
     };
     clientWithPipeline.pipeline.addPolicy({
         name: 'PinCosmosDBApiVersionPolicy',
-        async sendRequest(request: { url: string }, next: (req: { url: string }) => Promise<unknown>) {
+        async sendRequest(request: PinnablePipelineRequest, next: (req: PinnablePipelineRequest) => Promise<unknown>) {
+            if (request.headers.has(PRESERVE_API_VERSION_HEADER)) {
+                request.headers.delete(PRESERVE_API_VERSION_HEADER);
+                return next(request);
+            }
+
             const [path, query] = request.url.split('?');
             if (query && path.toLowerCase().includes(DOCUMENT_DB_PROVIDER_PATH)) {
                 const rewritten = query

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
@@ -468,10 +468,20 @@ export class QueryEditorContextProvider extends BaseContextProvider<QueryEditorA
                     containerSchema: event.containerSchema as JSONSchema | null,
                 });
                 break;
+            case 'throughputBucketsRefreshRequested':
+                void this.refreshThroughputBuckets();
+                break;
             case 'runActiveQueryRequested':
                 void this.runActiveQueryFromTool(event.query);
                 break;
         }
+    }
+
+    private async refreshThroughputBuckets(): Promise<void> {
+        const throughputBuckets = await this.safeMutate(() =>
+            this.trpcClient.queryEditor.refreshThroughputBuckets.mutate(),
+        );
+        this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets });
     }
 
     private handleQueryExecutionResult(result?: QueryExecutionResponse): void {

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
@@ -478,10 +478,12 @@ export class QueryEditorContextProvider extends BaseContextProvider<QueryEditorA
     }
 
     private async refreshThroughputBuckets(): Promise<void> {
-        const throughputBuckets = await this.safeMutate(() =>
-            this.trpcClient.queryEditor.refreshThroughputBuckets.mutate(),
-        );
-        this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets });
+        try {
+            const throughputBuckets = await this.trpcClient.queryEditor.refreshThroughputBuckets.mutate();
+            this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets });
+        } catch {
+            // Error notification is handled by the tRPC errorLink middleware. Keep the last known availability.
+        }
     }
 
     private handleQueryExecutionResult(result?: QueryExecutionResponse): void {

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.test.ts
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { defaultState, dispatch } from './QueryEditorState';
+
+describe('QueryEditorState', () => {
+    describe('updateThroughputBuckets', () => {
+        it('clears a selected bucket that is no longer enabled', () => {
+            const state = { ...defaultState, selectedThroughputBucket: 2 };
+
+            const result = dispatch(state, {
+                type: 'updateThroughputBuckets',
+                throughputBuckets: [true, false, true, true, true],
+            });
+
+            expect(result.selectedThroughputBucket).toBeUndefined();
+        });
+
+        it('preserves a selected bucket that remains enabled', () => {
+            const state = { ...defaultState, selectedThroughputBucket: 2 };
+
+            const result = dispatch(state, {
+                type: 'updateThroughputBuckets',
+                throughputBuckets: [false, true, false, false, false],
+            });
+
+            expect(result.selectedThroughputBucket).toBe(2);
+        });
+
+        it('clears the selection when throughput buckets become unavailable', () => {
+            const state = { ...defaultState, selectedThroughputBucket: 2 };
+
+            const result = dispatch(state, {
+                type: 'updateThroughputBuckets',
+                throughputBuckets: undefined,
+            });
+
+            expect(result.selectedThroughputBucket).toBeUndefined();
+        });
+    });
+});

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.tsx
@@ -244,7 +244,15 @@ export function dispatch(state: QueryEditorState, action: DispatchAction): Query
         case 'selectBucket':
             return { ...state, selectedThroughputBucket: action.throughputBucket };
         case 'updateThroughputBuckets':
-            return { ...state, throughputBuckets: action.throughputBuckets };
+            return {
+                ...state,
+                throughputBuckets: action.throughputBuckets,
+                selectedThroughputBucket:
+                    state.selectedThroughputBucket !== undefined &&
+                    action.throughputBuckets?.[state.selectedThroughputBucket - 1]
+                        ? state.selectedThroughputBucket
+                        : undefined,
+            };
         case 'setConnectionList':
             return { ...state, connectionList: action.connectionList };
         case 'setSchemaBasedOnQueries':


### PR DESCRIPTION
Backport of #3257.

## Summary

Fixes the Query Editor's **Throughput Bucket** menu so it shows the buckets that are actually enabled for a container.

The issue had three parts:

- Feature detection used the wrong AFEC name. The registered feature is `ThroughputBucketing`, not `ThroughputBuckets`.
- Bucket settings are only returned by the `2025-05-01-preview` API. The client previously rewrote that request to the pinned GA version, which omitted the bucket data.
- Bucket state was only loaded when the editor opened. Refreshing an account or container now also refreshes matching Query Editor tabs.

The API-version override is limited to the throughput-settings request; all other Cosmos DB management calls keep the pinned GA version.

## Validation

- 17 throughput bucket tests passed
- `npm run l10n` passed
- `npm run prettier-fix` passed
- `npm run lint` passed
- `npm run build` passed
- Backport patch ID matches the merged #3257 patch

No conflicts were encountered.