### PR TITLE
Fix document conflict recovery state

### DIFF
--- a/src/panels/trpc/routers/documentRouter.test.ts
+++ b/src/panels/trpc/routers/documentRouter.test.ts
@@ -141,6 +141,34 @@ describe('documentRouter partition key updates', () => {
         expect(result.cleanupRequiredMessage).toBe('Stored cleanup phase');
     });
 
+    it('restores pending cleanup from the destination when the source disappeared', async () => {
+        const context = createContext();
+        context.state.pendingPartitionKeyCleanup = {
+            sourceIdentifier: oldIdentifier,
+            sourceEtag: 'loaded-etag',
+            destination: writeResult,
+            message: 'Stored cleanup phase',
+        };
+        documentSessionMocks.readDocument
+            .mockRejectedValueOnce(new Error('Item not found or request timed out'))
+            .mockResolvedValueOnce({ documentContent, partitionKey: writeResult.partitionKey });
+        documentSessionMocks.deleteDocument.mockRejectedValueOnce({ statusCode: 404 });
+        const caller = documentRouterDef.createCaller(context);
+
+        const initialState = await caller.getInitialState();
+        const cleanupResult = await caller.retryPartitionKeyCleanup();
+
+        expect(initialState).toMatchObject({
+            documentId: oldIdentifier,
+            documentContent,
+            documentPartitionKey: writeResult.partitionKey,
+            cleanupRequiredMessage: 'Stored cleanup phase',
+        });
+        expect(cleanupResult).toMatchObject({ success: true, cleanupRequired: false, documentContent });
+        expect(context.state.documentId).toEqual(newIdentifier);
+        expect(context.state.pendingPartitionKeyCleanup).toBeUndefined();
+    });
+
     it('retries cleanup without recreating the destination', async () => {
         const context = createContext();
         documentSessionMocks.deleteDocument.mockRejectedValueOnce(new Error('Service unavailable'));

--- a/src/panels/trpc/routers/documentRouter.test.ts
+++ b/src/panels/trpc/routers/documentRouter.test.ts
@@ -506,4 +506,46 @@ describe('documentRouter concurrent updates', () => {
             'server-etag',
         );
     });
+
+    it('keeps the loaded etag when a stale partition-key move is not confirmed', async () => {
+        const context = createContext();
+        context.state.documentEtag = 'loaded-etag';
+        documentSessionMocks.extractPartitionKeyFromDocument.mockResolvedValue('new');
+        documentSessionMocks.readDocument.mockResolvedValue({
+            documentContent: { ...documentContent, pk: 'old', _etag: 'server-etag' },
+            partitionKey: writeResult.partitionKey,
+        });
+        confirmationMocks.getConfirmationAsInSettings.mockResolvedValue(false);
+        vi.mocked(vscode.window.showWarningMessage).mockImplementation(async (_message, _options, ...items) =>
+            items.find((item) => item.title === 'Overwrite'),
+        );
+
+        await documentRouterDef.createCaller(context).saveDocument({ documentText: JSON.stringify(documentContent) });
+
+        expect(context.state.documentEtag).toBe('loaded-etag');
+        expect(documentSessionMocks.createDocument).not.toHaveBeenCalled();
+        expect(documentSessionMocks.deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it('keeps the loaded etag when partition-key confirmation throws', async () => {
+        const context = createContext();
+        context.state.documentEtag = 'loaded-etag';
+        documentSessionMocks.extractPartitionKeyFromDocument.mockResolvedValue('new');
+        documentSessionMocks.readDocument.mockResolvedValue({
+            documentContent: { ...documentContent, pk: 'old', _etag: 'server-etag' },
+            partitionKey: writeResult.partitionKey,
+        });
+        confirmationMocks.getConfirmationAsInSettings.mockRejectedValue(new Error('Canceled'));
+        vi.mocked(vscode.window.showWarningMessage).mockImplementation(async (_message, _options, ...items) =>
+            items.find((item) => item.title === 'Overwrite'),
+        );
+
+        await expect(
+            documentRouterDef.createCaller(context).saveDocument({ documentText: JSON.stringify(documentContent) }),
+        ).rejects.toThrow('Canceled');
+
+        expect(context.state.documentEtag).toBe('loaded-etag');
+        expect(documentSessionMocks.createDocument).not.toHaveBeenCalled();
+        expect(documentSessionMocks.deleteDocument).not.toHaveBeenCalled();
+    });
 });

--- a/src/panels/trpc/routers/documentRouter.ts
+++ b/src/panels/trpc/routers/documentRouter.ts
@@ -381,14 +381,15 @@ async function updateDocument(
     if (partitionKeyChanged) {
         if (actionContext) actionContext.telemetry.properties.partitionKeyChanged = 'true';
 
-        if (state.documentEtag) {
+        let sourceEtag = state.documentEtag;
+        if (sourceEtag) {
             const currentDocument = await readDocument(
                 connection,
                 documentId,
                 ctx.signal,
                 state.partitionKeyDefinition,
             );
-            if (currentDocument && currentDocument.documentContent._etag !== state.documentEtag) {
+            if (currentDocument && currentDocument.documentContent._etag !== sourceEtag) {
                 const resolution = await promptForDocumentConflict();
                 if (resolution === 'discard') {
                     updateLoadedDocumentState(state, currentDocument);
@@ -397,7 +398,7 @@ async function updateDocument(
                 if (resolution !== 'overwrite') {
                     return { success: false, aborted: true } as const;
                 }
-                state.documentEtag = currentDocument.documentContent._etag;
+                sourceEtag = currentDocument.documentContent._etag;
             }
         }
 
@@ -421,11 +422,11 @@ async function updateDocument(
         }
 
         try {
-            await deletePartitionKeyMoveSource(connection, documentId, state.documentEtag);
+            await deletePartitionKeyMoveSource(connection, documentId, sourceEtag);
         } catch {
             state.pendingPartitionKeyCleanup = {
                 sourceIdentifier: documentId,
-                sourceEtag: state.documentEtag,
+                sourceEtag,
                 destination: result,
             };
             return {

--- a/src/panels/trpc/routers/documentRouter.ts
+++ b/src/panels/trpc/routers/documentRouter.ts
@@ -58,11 +58,24 @@ export const documentRouterDef = documentRouter({
         let documentPartitionKey: PartitionKeyDefinition | undefined;
 
         if (state.documentId) {
-            const result = await readDocument(connection, state.documentId, ctx.signal, state.partitionKeyDefinition);
-            documentContent = result?.documentContent;
-            documentPartitionKey = result?.partitionKey;
-            if (result?.partitionKey) state.partitionKeyDefinition = result.partitionKey;
-            state.documentEtag = result?.documentContent._etag;
+            try {
+                const result = await readDocument(
+                    connection,
+                    state.documentId,
+                    ctx.signal,
+                    state.partitionKeyDefinition,
+                );
+                documentContent = result?.documentContent;
+                documentPartitionKey = result?.partitionKey;
+                if (result?.partitionKey) state.partitionKeyDefinition = result.partitionKey;
+                state.documentEtag = result?.documentContent._etag;
+            } catch (error) {
+                if (!state.pendingPartitionKeyCleanup) {
+                    throw error;
+                }
+                documentContent = state.pendingPartitionKeyCleanup.destination.documentContent;
+                documentPartitionKey = state.pendingPartitionKeyCleanup.destination.partitionKey;
+            }
         } else if (state.mode === 'add') {
             const result = await buildNewDocumentTemplate(connection, state.partitionKeyDefinition);
             documentContent = result?.documentContent;

--- a/src/webviews/cosmosdb/Document/state/DocumentState.test.ts
+++ b/src/webviews/cosmosdb/Document/state/DocumentState.test.ts
@@ -28,6 +28,7 @@ describe('DocumentState cleanup', () => {
             currentDocumentContent: '{"id":"destination","edited":true}',
             isDirty: true,
             cleanupRequiredMessage: 'Cleanup required',
+            error: 'Previous cleanup failed',
         };
 
         const result = dispatch(state, {
@@ -40,5 +41,6 @@ describe('DocumentState cleanup', () => {
         expect(result.currentDocumentContent).toBe('{"id":"destination"}');
         expect(result.isDirty).toBe(false);
         expect(result.cleanupRequiredMessage).toBeUndefined();
+        expect(result.error).toBeUndefined();
     });
 });

--- a/src/webviews/cosmosdb/Document/state/DocumentState.tsx
+++ b/src/webviews/cosmosdb/Document/state/DocumentState.tsx
@@ -157,6 +157,7 @@ export function dispatch(state: DocumentState, action: DispatchAction): Document
                 partitionKey: action.partitionKey,
                 isDirty: false,
                 cleanupRequiredMessage: undefined,
+                error: undefined,
             };
         case 'setError':
             return { ...state, error: action.error };


### PR DESCRIPTION
## Summary

Addresses three valid GitHub Copilot findings from the `rel/0.36` backport PR #3293 on `main` first.

- Keep a refreshed source ETag local until a partition-key move is confirmed and proceeds. Declining confirmation or throwing during confirmation now leaves the editor's trusted loaded ETag unchanged, so a later save cannot silently overwrite the newer server version.
- Clear a prior cleanup error when partition-key cleanup completes successfully, preventing a stale failure from remaining visible after recovery.
- Restore pending cleanup when a partition-key source document is already missing after reload. Initialization falls back to the stored destination snapshot while preserving the source identity and cleanup state, allowing Retry to treat a source 404 as successful idempotent cleanup and refresh the destination.
- Add regression coverage for declined and thrown move confirmations, cleanup success after a prior error, and the missing-source reload-to-retry flow.

After this merges, the commits can be backported to the existing `rel/0.36` targeting PR.

## Validation

- Focused document router and reducer tests passed
- `npm run prettier-fix` passed
- `npm run lint` passed
- `npm run build` passed