### PR TITLE
Fix refreshed throughput bucket state in Query Editor

### DIFF
--- a/src/cosmosdb/throughputBuckets.ts
+++ b/src/cosmosdb/throughputBuckets.ts
@@ -59,7 +59,7 @@ export async function supportsThroughputBuckets(
  * configured on the container (or its shared-throughput database).
  *
  * The Cosmos DB ARM SDK does not yet model `throughputBuckets`, so the value is
- * read directly from the pinned-api-version REST response. If the buckets
+ * read directly from the preview REST response. If the buckets
  * cannot be read, all five are reported as enabled to preserve the selector's
  * previous always-available behaviour.
  */

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorContextProvider.tsx
@@ -478,10 +478,12 @@ export class QueryEditorContextProvider extends BaseContextProvider<QueryEditorA
     }
 
     private async refreshThroughputBuckets(): Promise<void> {
-        const throughputBuckets = await this.safeMutate(() =>
-            this.trpcClient.queryEditor.refreshThroughputBuckets.mutate(),
-        );
-        this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets });
+        try {
+            const throughputBuckets = await this.trpcClient.queryEditor.refreshThroughputBuckets.mutate();
+            this.dispatch({ type: 'updateThroughputBuckets', throughputBuckets });
+        } catch {
+            // Error notification is handled by the tRPC errorLink middleware. Keep the last known availability.
+        }
     }
 
     private handleQueryExecutionResult(result?: QueryExecutionResponse): void {

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.test.ts
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { defaultState, dispatch } from './QueryEditorState';
+
+describe('QueryEditorState', () => {
+    describe('updateThroughputBuckets', () => {
+        it('clears a selected bucket that is no longer enabled', () => {
+            const state = { ...defaultState, selectedThroughputBucket: 2 };
+
+            const result = dispatch(state, {
+                type: 'updateThroughputBuckets',
+                throughputBuckets: [true, false, true, true, true],
+            });
+
+            expect(result.selectedThroughputBucket).toBeUndefined();
+        });
+
+        it('preserves a selected bucket that remains enabled', () => {
+            const state = { ...defaultState, selectedThroughputBucket: 2 };
+
+            const result = dispatch(state, {
+                type: 'updateThroughputBuckets',
+                throughputBuckets: [false, true, false, false, false],
+            });
+
+            expect(result.selectedThroughputBucket).toBe(2);
+        });
+
+        it('clears the selection when throughput buckets become unavailable', () => {
+            const state = { ...defaultState, selectedThroughputBucket: 2 };
+
+            const result = dispatch(state, {
+                type: 'updateThroughputBuckets',
+                throughputBuckets: undefined,
+            });
+
+            expect(result.selectedThroughputBucket).toBeUndefined();
+        });
+    });
+});

--- a/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.tsx
+++ b/src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.tsx
@@ -244,7 +244,15 @@ export function dispatch(state: QueryEditorState, action: DispatchAction): Query
         case 'selectBucket':
             return { ...state, selectedThroughputBucket: action.throughputBucket };
         case 'updateThroughputBuckets':
-            return { ...state, throughputBuckets: action.throughputBuckets };
+            return {
+                ...state,
+                throughputBuckets: action.throughputBuckets,
+                selectedThroughputBucket:
+                    state.selectedThroughputBucket !== undefined &&
+                    action.throughputBuckets?.[state.selectedThroughputBucket - 1]
+                        ? state.selectedThroughputBucket
+                        : undefined,
+            };
         case 'setConnectionList':
             return { ...state, connectionList: action.connectionList };
         case 'setSchemaBasedOnQueries':


### PR DESCRIPTION
## Summary
- clear a selected throughput bucket when refreshed availability no longer enables it
- preserve the last known availability when the refresh request fails
- cover selection reconciliation with focused reducer tests
- clarify that throughput bucket settings use the preview REST response

This carries the Copilot follow-up from #3291 to `main` without the release backport commits.

## Validation
- `npm run prettier-fix`
- `npm run lint`
- `npm run build`
- `npx vitest run src/webviews/cosmosdb/QueryEditor/state/QueryEditorState.test.ts`