### PR TITLE
fix(sampleDataTool): strip value-derived statistics from inferred schema

### DIFF
--- a/src/chat/sampleDataTool.test.ts
+++ b/src/chat/sampleDataTool.test.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import * as vscode from 'vscode';
+import { type NoSqlQueryConnection } from '../cosmosdb/NoSqlQueryConnection';
+import { findConfidentialStatKeys } from '../services/schemaStatisticsTestUtils';
+import { sampleAndPersistContainerSchema } from './sampleDataTool';
+
+// `sampleAndPersistContainerSchema` exercises the real `getSchemaFromDocuments` /
+// `stripSchemaStatistics` helpers. Mock only the heavy siblings (Cosmos client, schema analyzer
+// service) so the confidentiality boundary can be asserted deterministically.
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+    callWithTelemetryAndErrorHandling: vi.fn(),
+    parseError: (error: unknown) => ({ message: error instanceof Error ? error.message : String(error) }),
+}));
+
+vi.mock('@vscode/l10n', () => ({ t: (message: string) => message }));
+
+vi.mock('../extensionVariables', () => ({
+    ext: { outputChannel: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+
+vi.mock('../panels/QueryEditorTab', () => ({
+    QueryEditorTab: class {
+        static openTabs = new Set();
+    },
+}));
+
+vi.mock('./chatUtils', () => ({
+    getActiveQueryEditor: vi.fn(),
+    getConnectionFromQueryTab: vi.fn(),
+}));
+
+const mergeDocumentsIntoSchema = vi.fn();
+const getSimplifiedSchema = vi.fn();
+
+vi.mock('../services/SchemaService', () => ({
+    SchemaService: {
+        getInstance: () => ({ mergeDocumentsIntoSchema, getSimplifiedSchema }),
+    },
+}));
+
+const fetchAll = vi.fn();
+
+vi.mock('../cosmosdb/getCosmosClient', () => ({
+    getCosmosClient: () => ({
+        database: () => ({
+            container: () => ({
+                items: { query: () => ({ fetchAll }) },
+            }),
+        }),
+    }),
+}));
+
+const connection = { databaseId: 'db1', containerId: 'c1' } as NoSqlQueryConnection;
+
+// Documents with confidential values (numeric extremes, string lengths) that `getSchemaFromDocuments`
+// records as `x-minValue` / `x-maxValue` / `x-minLength` / `x-maxLength` statistics.
+const sampleDocuments = [
+    { id: '1', salary: 987654, nationalId: 'AB-123456789', active: true },
+    { id: '2', salary: 42, nationalId: 'CD-9', active: false },
+];
+
+describe('sampleAndPersistContainerSchema — confidentiality boundary', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        fetchAll.mockResolvedValue({ resources: sampleDocuments, requestCharge: 1.23 });
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+            get: () => false,
+        } as never);
+    });
+
+    it('strips value-derived statistics from the fallback schema when persistence fails', async () => {
+        mergeDocumentsIntoSchema.mockRejectedValue(new Error('disk full'));
+
+        const result = await sampleAndPersistContainerSchema(connection);
+
+        expect(mergeDocumentsIntoSchema).toHaveBeenCalledOnce();
+        // Persistence failed, so the raw inferred schema is the one serialized to the model.
+        expect(findConfidentialStatKeys(result.schema)).toEqual([]);
+        expect(JSON.stringify(result)).not.toContain('987654');
+
+        // Structural information is preserved so the schema stays useful to the model.
+        const props = (result.schema as { properties?: Record<string, unknown> }).properties ?? {};
+        expect(Object.keys(props)).toEqual(expect.arrayContaining(['salary', 'nationalId', 'active']));
+    });
+
+    it('strips value-derived statistics from the fallback schema when getSimplifiedSchema returns nothing', async () => {
+        mergeDocumentsIntoSchema.mockResolvedValue(undefined);
+        getSimplifiedSchema.mockResolvedValue(undefined);
+
+        const result = await sampleAndPersistContainerSchema(connection);
+
+        expect(getSimplifiedSchema).toHaveBeenCalledOnce();
+        expect(findConfidentialStatKeys(result.schema)).toEqual([]);
+        expect(JSON.stringify(result)).not.toContain('987654');
+    });
+});

--- a/src/chat/sampleDataTool.ts
+++ b/src/chat/sampleDataTool.ts
@@ -12,6 +12,7 @@ import { type NoSqlQueryConnection } from '../cosmosdb/NoSqlQueryConnection';
 import { ext } from '../extensionVariables';
 import { QueryEditorTab } from '../panels/QueryEditorTab';
 import { SchemaService } from '../services/SchemaService';
+import { stripSchemaStatistics } from '../services/schemaStatistics';
 import { getActiveQueryEditor, getConnectionFromQueryTab } from './chatUtils';
 
 /**
@@ -127,7 +128,10 @@ export async function sampleAndPersistContainerSchema(connection: NoSqlQueryConn
         .getConfiguration('cosmosDB.queryEditor')
         .get<boolean>('generateSchemaBasedOnQueries', false);
 
-    result.schema = getSchemaFromDocuments(documents) as Record<string, unknown>;
+    // Structure only — stripped of value-derived statistics (`x-minValue`/`x-maxValue`, string
+    // lengths, etc.) so no actual document values reach the model on the persistence-failure fallback
+    // path below, where this raw inferred schema is serialized directly instead of the simplified one.
+    result.schema = stripSchemaStatistics(getSchemaFromDocuments(documents)) as Record<string, unknown>;
 
     // Always persist the sampled schema into the schema analyzer (`SchemaService`) — even when the
     // "generate schema based on queries" setting is off — so later query generation can read it back


### PR DESCRIPTION
This pull request adds comprehensive tests for the confidentiality boundary of the `sampleAndPersistContainerSchema` function and updates the implementation to ensure value-derived statistics are stripped from schemas on persistence fallback. These changes improve the security and reliability of schema handling, especially in failure scenarios.

**Testing improvements:**

* Added a new test file `src/chat/sampleDataTool.test.ts` that verifies `sampleAndPersistContainerSchema` does not leak confidential value-derived statistics (such as `x-minValue`, `x-maxValue`, etc.) into the serialized schema when persistence fails or when schema simplification returns nothing. The tests also confirm that structural schema information is preserved.

**Confidentiality and schema handling:**

* Updated `src/chat/sampleDataTool.ts` to import and use `stripSchemaStatistics` so that, on fallback paths, the raw inferred schema is stripped of value-derived statistics before being serialized, ensuring no actual document values reach the model. [[1]](diffhunk://#diff-e5a54c963f68cf3d148846f480e7ee12082bfc0f46d16cc5ef74d483b7283878R15) [[2]](diffhunk://#diff-e5a54c963f68cf3d148846f480e7ee12082bfc0f46d16cc5ef74d483b7283878L130-R134)