### PR TITLE
Fix command injection in Cosmos DB Shell container navigation

### DIFF
--- a/src/cosmosDBShell/CosmosDBShellExtension.ts
+++ b/src/cosmosDBShell/CosmosDBShellExtension.ts
@@ -9,7 +9,6 @@
  * and {@link connectCosmosDBShell}). Heavier subsystems (install flow, MCP provider,
  * language server, terminal reuse, version cache) live in sibling modules.
  */
-import { type ContainerDefinition, type DatabaseDefinition } from '@azure/cosmos';
 import {
     callWithTelemetryAndErrorHandling,
     registerCommandWithTreeNodeUnwrapping,
@@ -28,6 +27,7 @@ import {
     SETTING_MCP_PORT,
     SETTING_SHELL_PATH,
 } from './constants';
+import { getGoToContainerCommand } from './goToContainerCommand';
 import { promptToResolveMissingCosmosDBShell } from './install/installPrompts';
 import {
     getCosmosDBShellCredential,
@@ -250,15 +250,6 @@ export async function launchCosmosDBShell(context: IActionContext, node?: NoSqlC
     // Record how this process was launched so future reuse decisions know which env vars
     // (e.g. COSMOSDB_SHELL_ACCOUNT_KEY / COSMOSDB_SHELL_TOKEN) are baked in.
     terminalStates.set(terminal, buildTerminalStateForNode(node));
-}
-
-function getGoToContainerCommand(database: DatabaseDefinition, container: ContainerDefinition): string | undefined {
-    if (container) {
-        return `cd "/${database.id}/${container.id}"`;
-    } else if (database) {
-        return `cd "/${database.id}"`;
-    }
-    return undefined;
 }
 
 export async function connectCosmosDBShell(context: IActionContext, node?: NoSqlContainerResourceItem) {

--- a/src/cosmosDBShell/goToContainerCommand.test.ts
+++ b/src/cosmosDBShell/goToContainerCommand.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type ContainerDefinition, type DatabaseDefinition } from '@azure/cosmos';
+import { describe, expect, it } from 'vitest';
+import { escapeCosmosDBShellStringLiteral, getGoToContainerCommand } from './goToContainerCommand';
+
+function db(id: string): DatabaseDefinition {
+    return { id } as DatabaseDefinition;
+}
+
+function container(id: string): ContainerDefinition {
+    return { id } as ContainerDefinition;
+}
+
+describe('escapeCosmosDBShellStringLiteral', () => {
+    it('escapes quotes, backslashes, and control characters', () => {
+        expect(escapeCosmosDBShellStringLiteral('plain')).toBe('plain');
+        expect(escapeCosmosDBShellStringLiteral('a"b')).toBe('a\\"b');
+        expect(escapeCosmosDBShellStringLiteral('a\\b')).toBe('a\\\\b');
+        expect(escapeCosmosDBShellStringLiteral('a\nb')).toBe('a\\nb');
+        expect(escapeCosmosDBShellStringLiteral('a\rb')).toBe('a\\rb');
+        expect(escapeCosmosDBShellStringLiteral('a\tb')).toBe('a\\tb');
+    });
+});
+
+describe('getGoToContainerCommand', () => {
+    it('builds a plain path for database + container', () => {
+        expect(getGoToContainerCommand(db('mydb'), container('mycon'))).toBe('cd "/mydb/mycon"');
+    });
+
+    it('builds a plain path for database only', () => {
+        expect(getGoToContainerCommand(db('mydb'), undefined as unknown as ContainerDefinition)).toBe('cd "/mydb"');
+    });
+
+    it('returns undefined when there is no database', () => {
+        expect(
+            getGoToContainerCommand(
+                undefined as unknown as DatabaseDefinition,
+                undefined as unknown as ContainerDefinition,
+            ),
+        ).toBeUndefined();
+    });
+
+    it('neutralizes a container id attempting to inject a second statement via `;`', () => {
+        const malicious = 'example"; echo "injected';
+        const command = getGoToContainerCommand(db('mydb'), container(malicious));
+        expect(command).toBe('cd "/mydb/example\\"; echo \\"injected"');
+    });
+
+    it('neutralizes a database id attempting to inject a second statement via a newline', () => {
+        const malicious = 'mydb"\necho "injected';
+        const command = getGoToContainerCommand(db(malicious), container('mycon'));
+        expect(command).toBe('cd "/mydb\\"\\necho \\"injected/mycon"');
+    });
+});

--- a/src/cosmosDBShell/goToContainerCommand.ts
+++ b/src/cosmosDBShell/goToContainerCommand.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type ContainerDefinition, type DatabaseDefinition } from '@azure/cosmos';
+
+// Escapes a value for embedding inside a Cosmos DB Shell double-quoted string literal, so
+// database/container IDs containing quotes, backslashes, or statement separators (`;`, newlines)
+// can't break out of the string and inject additional shell commands.
+export function escapeCosmosDBShellStringLiteral(value: string | undefined): string {
+    return (value ?? '')
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\r/g, '\\r')
+        .replace(/\n/g, '\\n')
+        .replace(/\t/g, '\\t');
+}
+
+export function getGoToContainerCommand(
+    database: DatabaseDefinition,
+    container: ContainerDefinition,
+): string | undefined {
+    if (container) {
+        return `cd "/${escapeCosmosDBShellStringLiteral(database.id)}/${escapeCosmosDBShellStringLiteral(container.id)}"`;
+    } else if (database) {
+        return `cd "/${escapeCosmosDBShellStringLiteral(database.id)}"`;
+    }
+    return undefined;
+}


### PR DESCRIPTION
## Problem

`getGoToContainerCommand` built the Cosmos DB Shell navigation command by interpolating raw
database/container IDs into a double-quoted string:

```ts
return `cd "/${database.id}/${container.id}"`;
```

Cosmos DB allows shell-significant characters (`"`, `;`, newlines, etc.) in database/container
names. A crafted name could break out of the quoted string and inject additional statements,
which execute automatically:

- at shell launch, via the `-k` startup argument
- when reusing an existing shell terminal, via `terminal.sendText(...)`

Verified against the real `cosmosdbshell` binary that a payload such as

```
example"; echo "injected
```

produces `cd "/mydb/example"; echo "injected"`, and that `;`/newline-separated statements
execute sequentially regardless of whether the preceding statement succeeds or fails — so the
injected command runs under the operator's Cosmos credentials.

Note: It's a real issue beside the command injection because " is a valid char in the name and needs to be escaped.

## Fix

- Added `src/cosmosDBShell/goToContainerCommand.ts` with `escapeCosmosDBShellStringLiteral()`,
  which escapes backslashes, double quotes, and control characters (`\r`, `\n`, `\t`) before a
  database/container ID is embedded in a shell string literal.
- `getGoToContainerCommand()` now uses the escaped IDs, neutralizing injection attempts.
- `CosmosDBShellExtension.ts` imports the helpers from the new module instead of defining them
  inline (keeps the logic testable without mocking `vscode`).
- Added `goToContainerCommand.test.ts` covering normal paths plus injection attempts via `;` and
  newline.

## Validation

- `npm run lint` — exit 0
- `npm run build` — exit 0
- Unit tests for the new module — 6/6 passing
