### PR TITLE
Escape control characters in Cosmos DB Shell quoteArg (defense-in-depth)

### DIFF
--- a/src/cosmosDBShell/shellCommand.test.ts
+++ b/src/cosmosDBShell/shellCommand.test.ts
@@ -63,6 +63,16 @@ describe('shellCommand.quoteArg', () => {
         expect(quoteArg('C:\\Users\\test')).toBe('"C:\\\\Users\\\\test"');
         expect(quoteArg('C:\\path with space\\file.txt')).toBe('"C:\\\\path with space\\\\file.txt"');
     });
+
+    it('wraps and escapes embedded control characters so they cannot be split into a separate terminal line', () => {
+        // An un-escaped raw newline/CR/tab written via `terminal.sendText` would be interpreted
+        // by the shell's line-based reader as ending the current input, letting the remainder
+        // of the value be parsed as separate shell input.
+        expect(quoteArg('foo\nbar')).toBe('"foo\\nbar"');
+        expect(quoteArg('foo\rbar')).toBe('"foo\\rbar"');
+        expect(quoteArg('foo\tbar')).toBe('"foo\\tbar"');
+        expect(quoteArg('a"; echo "injected\ndone')).toBe('"a\\"; echo \\"injected\\ndone"');
+    });
 });
 
 describe('shellCommand.isCosmosDBShellPathFound', () => {

--- a/src/cosmosDBShell/shellCommand.ts
+++ b/src/cosmosDBShell/shellCommand.ts
@@ -77,13 +77,23 @@ export function watchForEarlyExit(terminal: vscode.Terminal): void {
 /**
  * Quotes a value for use as a single argument inside an interactive Cosmos DB Shell
  * command (sent via `terminal.sendText`). Wraps values containing whitespace, quotes, or
- * backslashes in double quotes and applies C-style escapes (`\\` and `\"`) so the
- * argument is preserved verbatim when parsed by the shell.
+ * backslashes in double quotes and applies C-style escapes (`\\`, `\"`, `\r`, `\n`, `\t`) so
+ * the argument is preserved verbatim when parsed by the shell.
  *
  * Backslashes are escaped before quotes so the substitutions don't compound (e.g. a
  * literal `\"` in the input becomes `\\\"` in the output, not `\\"` which would be
- * parsed as `\` followed by an argument-terminating quote).
+ * parsed as `\` followed by an argument-terminating quote). Control characters (`\r`,
+ * `\n`, `\t`) are escaped too so a value containing one can't be split into a separate
+ * line once written to the terminal's PTY, which would otherwise let it be interpreted
+ * as additional shell input.
  */
 export function quoteArg(value: string): string {
-    return /[\s"'\\]/.test(value) ? `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : value;
+    return /[\s"'\\]/.test(value)
+        ? `"${value
+              .replace(/\\/g, '\\\\')
+              .replace(/"/g, '\\"')
+              .replace(/\r/g, '\\r')
+              .replace(/\n/g, '\\n')
+              .replace(/\t/g, '\\t')}"`
+        : value;
 }


### PR DESCRIPTION
## Follow-up to #3313

While reviewing the Cosmos DB Shell area for other instances of the same command-injection class fixed in #3313, found that `quoteArg()` in `shellCommand.ts` — used by `buildInteractiveConnectCommand()` to build the interactive `connect` command sent via `terminal.sendText` when reusing an existing shell terminal — has the same gap: it wraps whitespace-containing values in double quotes and escapes backslashes/quotes, but does not escape raw control characters (`\r`, `\n`, `\t`).

A value containing an unescaped control character would be written verbatim to the terminal's PTY, where a raw newline/carriage-return can be read by the shell's line-based input handling as ending the current input line before the closing quote is reached, potentially letting the remainder be interpreted as separate shell input.

## Scope / risk

Current callers of `quoteArg` are the account endpoint URL, the Entra ID tenant ID, and the managed identity client ID — all values that originate from Azure resource metadata rather than free-form, easily attacker-controlled strings (unlike database/container IDs in #3313). So this is materially lower risk than the original finding, not a live exploit path with today's callers. Fixing it anyway for defense-in-depth and to keep `quoteArg`'s escaping consistent with the `escapeCosmosDBShellStringLiteral()` helper added in #3313, since `quoteArg` is a shared utility that could be reused for higher-risk values in the future.

## Fix

- `quoteArg()` now also escapes `\r`, `\n`, `\t` (matching the escapes CosmosDBShell documents for double-quoted strings), alongside the existing `\\`/`\"` escaping.
- Updated doc comment to reflect the full escape set.
- Added test cases in `shellCommand.test.ts` covering embedded `\n`, `\r`, `\t`, and a combined quote+control-character payload.

## Validation

- `npm run lint` — exit 0
- `npm run build` — exit 0
- Unit tests (`shellCommand.test.ts`, `terminalReuse.test.ts`) — 36/36 passing
