### PR TITLE
[rel/0.36] Handle cancelled Cosmos DB Shell tool operations

### DIFF
--- a/src/cosmosDBShell/install/installPrompts.test.ts
+++ b/src/cosmosDBShell/install/installPrompts.test.ts
@@ -16,6 +16,10 @@ vi.mock('child_process', () => ({
     spawn: vi.fn(),
 }));
 
+vi.mock('@vscode/l10n', () => ({
+    t: vi.fn((message: string) => message),
+}));
+
 vi.mock('@microsoft/vscode-azext-utils', () => ({
     callWithTelemetryAndErrorHandling: vi.fn(
         async (_eventName: string, callback: (context: unknown) => Promise<unknown>) =>
@@ -52,7 +56,7 @@ vi.mock('./dotNetSdk', () => ({
     tryInstallDotNetSdkViaExtension: vi.fn(),
 }));
 
-function mockCancelledDotNetTool(): { kill: Mock } {
+function mockCancelledDotNetTool(exitCode: number | null = null): { kill: Mock } {
     const process = new EventEmitter() as EventEmitter & {
         kill: Mock;
         stdout: EventEmitter;
@@ -61,7 +65,7 @@ function mockCancelledDotNetTool(): { kill: Mock } {
     process.stdout = new EventEmitter();
     process.stderr = new EventEmitter();
     process.kill = vi.fn(() => {
-        queueMicrotask(() => process.emit('close', null));
+        queueMicrotask(() => process.emit('close', exitCode));
         return true;
     });
     (child.spawn as Mock).mockReturnValue(process);
@@ -84,7 +88,7 @@ function mockCancelledDotNetTool(): { kill: Mock } {
     return process;
 }
 
-describe('updateCosmosDBShell', () => {
+describe('Cosmos DB Shell tool operations', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
@@ -99,6 +103,17 @@ describe('updateCosmosDBShell', () => {
         expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
         expect(invalidateCosmosDBShellSupportCache).not.toHaveBeenCalled();
         expect(ext.outputChannel.show).toHaveBeenCalledOnce();
+    });
+
+    it('reports success when the process exits successfully after cancellation is requested', async () => {
+        const process = mockCancelledDotNetTool(0);
+
+        await updateCosmosDBShell();
+
+        expect(process.kill).toHaveBeenCalledOnce();
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Cosmos DB Shell update completed.');
+        expect(invalidateCosmosDBShellSupportCache).toHaveBeenCalledOnce();
     });
 
     it('does not report a failure or launch the shell when installation is cancelled', async () => {

--- a/src/cosmosDBShell/install/installPrompts.test.ts
+++ b/src/cosmosDBShell/install/installPrompts.test.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as child from 'child_process';
+import { EventEmitter } from 'events';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import * as vscode from 'vscode';
+import { ext } from '../../extensionVariables';
+import { invalidateCosmosDBShellSupportCache } from '../shellSupportCache';
+import { hasRequiredDotNetSdk } from './dotNetSdk';
+import { promptToResolveMissingCosmosDBShell, updateCosmosDBShell } from './installPrompts';
+
+vi.mock('child_process', () => ({
+    spawn: vi.fn(),
+}));
+
+vi.mock('@microsoft/vscode-azext-utils', () => ({
+    callWithTelemetryAndErrorHandling: vi.fn(
+        async (_eventName: string, callback: (context: unknown) => Promise<unknown>) =>
+            callback({
+                errorHandling: {},
+                telemetry: { properties: {}, measurements: {} },
+                valuesToMask: [],
+            }),
+    ),
+}));
+
+vi.mock('../../extensionVariables', () => ({
+    ext: {
+        outputChannel: {
+            append: vi.fn(),
+            appendLine: vi.fn(),
+            show: vi.fn(),
+        },
+    },
+}));
+
+vi.mock('../shellSupportCache', () => ({
+    invalidateCosmosDBShellSupportCache: vi.fn(),
+    isCosmosDBShellInstalled: vi.fn(),
+}));
+
+vi.mock('../shellCommand', () => ({
+    isCosmosDBShellPathFound: vi.fn(),
+}));
+
+vi.mock('./dotNetSdk', () => ({
+    hasRequiredDotNetSdk: vi.fn(),
+    MIN_DOTNET_SDK_VERSION: '10.0.100',
+    tryInstallDotNetSdkViaExtension: vi.fn(),
+}));
+
+function mockCancelledDotNetTool(): { kill: Mock } {
+    const process = new EventEmitter() as EventEmitter & {
+        kill: Mock;
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+    };
+    process.stdout = new EventEmitter();
+    process.stderr = new EventEmitter();
+    process.kill = vi.fn(() => {
+        queueMicrotask(() => process.emit('close', null));
+        return true;
+    });
+    (child.spawn as Mock).mockReturnValue(process);
+    (vscode.window.withProgress as Mock).mockImplementation(
+        async (_options: unknown, task: (progress: unknown, token: unknown) => Promise<unknown>) => {
+            let cancel: (() => void) | undefined;
+            const result = task(
+                {},
+                {
+                    onCancellationRequested: (listener: () => void) => {
+                        cancel = listener;
+                        return { dispose: vi.fn() };
+                    },
+                },
+            );
+            cancel?.();
+            return result;
+        },
+    );
+    return process;
+}
+
+describe('updateCosmosDBShell', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not report a failure when the update is cancelled', async () => {
+        const process = mockCancelledDotNetTool();
+
+        await updateCosmosDBShell();
+
+        expect(process.kill).toHaveBeenCalledOnce();
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+        expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+        expect(invalidateCosmosDBShellSupportCache).not.toHaveBeenCalled();
+        expect(ext.outputChannel.show).toHaveBeenCalledOnce();
+    });
+
+    it('does not report a failure or launch the shell when installation is cancelled', async () => {
+        const launchShell = vi.fn();
+        const process = mockCancelledDotNetTool();
+        (hasRequiredDotNetSdk as Mock).mockReturnValue(true);
+        (vscode.window.showInformationMessage as Mock).mockResolvedValue('Install');
+
+        await promptToResolveMissingCosmosDBShell({} as never, undefined, launchShell);
+
+        expect(process.kill).toHaveBeenCalledOnce();
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+        expect(launchShell).not.toHaveBeenCalled();
+        expect(invalidateCosmosDBShellSupportCache).not.toHaveBeenCalled();
+    });
+});

--- a/src/cosmosDBShell/install/installPrompts.ts
+++ b/src/cosmosDBShell/install/installPrompts.ts
@@ -97,16 +97,17 @@ async function runCosmosDBShellDotNetTool(
                     });
                 },
             );
+            const cancelled = outcome.cancelled && !outcome.success;
             telemetryContext.telemetry.measurements.durationMs = Date.now() - startedAt;
             telemetryContext.telemetry.properties.exitCode =
                 outcome.exitCode === null ? 'null' : String(outcome.exitCode);
-            telemetryContext.telemetry.properties.cancelled = String(outcome.cancelled);
-            telemetryContext.telemetry.properties.outcome = outcome.cancelled
+            telemetryContext.telemetry.properties.cancelled = String(cancelled);
+            telemetryContext.telemetry.properties.outcome = cancelled
                 ? 'cancelled'
                 : outcome.success
                   ? 'success'
                   : 'failure';
-            return { success: outcome.success, cancelled: outcome.cancelled };
+            return { success: outcome.success, cancelled };
         },
     );
     return result ?? { success: false, cancelled: false };

--- a/src/cosmosDBShell/install/installPrompts.ts
+++ b/src/cosmosDBShell/install/installPrompts.ts
@@ -27,12 +27,19 @@ import { hasRequiredDotNetSdk, MIN_DOTNET_SDK_VERSION, tryInstallDotNetSdkViaExt
 /** Callback signature used by the install flow to resume the original launch action after install. */
 export type LaunchShellFn = (context: IActionContext, node: CosmosDBShellLaunchNode | undefined) => Promise<void>;
 
+interface DotNetToolResult {
+    success: boolean;
+    cancelled: boolean;
+}
+
 /**
  * Runs `dotnet tool install|update --global CosmosDBShell --prerelease` with a progress
- * notification, streaming output to the extension output channel. Returns true
- * when the process exits with code 0.
+ * notification, streaming output to the extension output channel.
  */
-async function runCosmosDBShellDotNetTool(operation: 'install' | 'update', dotnetPath?: string): Promise<boolean> {
+async function runCosmosDBShellDotNetTool(
+    operation: 'install' | 'update',
+    dotnetPath?: string,
+): Promise<DotNetToolResult> {
     const result = await callWithTelemetryAndErrorHandling(
         'cosmosDB.cosmosDBShell.install.tool',
         async (telemetryContext: IActionContext) => {
@@ -99,15 +106,18 @@ async function runCosmosDBShellDotNetTool(operation: 'install' | 'update', dotne
                 : outcome.success
                   ? 'success'
                   : 'failure';
-            return outcome.success;
+            return { success: outcome.success, cancelled: outcome.cancelled };
         },
     );
-    return result ?? false;
+    return result ?? { success: false, cancelled: false };
 }
 
 export async function updateCosmosDBShell(): Promise<void> {
-    const success = await runCosmosDBShellDotNetTool('update');
-    if (!success) {
+    const result = await runCosmosDBShellDotNetTool('update');
+    if (result.cancelled) {
+        return;
+    }
+    if (!result.success) {
         const showOutput = l10n.t('Show Output');
         const selection = await vscode.window.showErrorMessage(
             l10n.t('Failed to update Cosmos DB Shell. See the output for details.'),
@@ -200,8 +210,11 @@ async function installAndLaunchCosmosDBShell(
     launchShell: LaunchShellFn,
     dotnetPath?: string,
 ): Promise<void> {
-    const success = await runCosmosDBShellDotNetTool('install', dotnetPath);
-    if (!success) {
+    const result = await runCosmosDBShellDotNetTool('install', dotnetPath);
+    if (result.cancelled) {
+        return;
+    }
+    if (!result.success) {
         const showOutput = l10n.t('Show Output');
         const failureSelection = await vscode.window.showErrorMessage(
             l10n.t('Failed to install Cosmos DB Shell. See the output for details.'),


### PR DESCRIPTION
Backport of #3321

## Summary

- Preserve the `cancelled` outcome from Cosmos DB Shell `dotnet tool install|update` operations instead of collapsing it into a generic failure.
- Return silently when the user cancels an install or update, avoiding a misleading failure notification.
- Add regression coverage for both cancelled update and cancelled install flows.

## Validation

- 87 Cosmos DB Shell tests pass
- `npm run prettier-fix`
- `npm run lint`
- `npm run build`
- `npm run l10n` (run last as requested)
- `git diff --check`